### PR TITLE
Added kernel flags to configure statement 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,11 @@ configure: check-vars check-config
 	cd $(STDLIBHOME) && \
 	rm -rf build && \
 	mkdir -p build/circle-newlib && \
-	./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS; \
+	if [ "$(RASPPI)" = "4" ]; then \
+		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ -o REALTIME; \
+	else \
+		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ; \
+	fi
 
 # Build Circle stdlib
 circle-stdlib: configure

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,7 @@ configure: check-vars check-config
 	cd $(STDLIBHOME) && \
 	rm -rf build && \
 	mkdir -p build/circle-newlib && \
-	if [ "$(RASPPI)" = "4" ]; then \
-		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ; \
-	else \
-		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ; \
-	fi
+	./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS; \
 
 # Build Circle stdlib
 circle-stdlib: configure

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ configure: check-vars check-config
 	rm -rf build && \
 	mkdir -p build/circle-newlib && \
 	if [ "$(RASPPI)" = "4" ]; then \
-		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ -o REALTIME; \
+		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ; \
 	else \
 		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ configure: check-vars check-config
 	rm -rf build && \
 	mkdir -p build/circle-newlib && \
 	if [ "$(RASPPI)" = "4" ]; then \
-		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ -o REALTIME; \
+		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ ; \
 	else \
 		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ configure: check-vars check-config
 	if [ "$(RASPPI)" = "4" ]; then \
 		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ -o REALTIME; \
 	else \
-		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o USE_USB_FIQ -o REALTIME; \
+		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ; \
 	fi
 
 # Build Circle stdlib

--- a/Makefile
+++ b/Makefile
@@ -116,12 +116,11 @@ configure: check-vars check-config
 	cd $(STDLIBHOME) && \
 	rm -rf build && \
 	mkdir -p build/circle-newlib && \
-	./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS)
-    # Add global C++ flags to Circle's Config.mk
-	@echo "DEFINE += -DKERNEL_MAX_SIZE=0x400000" >> $(CIRCLEHOME)/Config.mk
-	@echo "DEFINE += -DSCREEN_HEADLESS" >> $(CIRCLEHOME)/Config.mk
-	@echo "DEFINE += -DUSE_USB_FIQ" >> $(CIRCLEHOME)/Config.mk
-	@echo "DEFINE += -DREALTIME" >> $(CIRCLEHOME)/Config.mk	
+	if [ "$(RASPPI)" = "4" ]; then \
+		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o SCREEN_HEADLESS -o USE_USB_FIQ -o REALTIME; \
+	else \
+		./configure -r $(RASPPI) --prefix "$(CURRENT_PREFIX)" $(DEBUG_CONFIGURE_FLAGS) -o KERNEL_MAX_SIZE=0x400000 -o USE_USB_FIQ -o REALTIME; \
+	fi
 
 # Build Circle stdlib
 circle-stdlib: configure

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,15 @@ CURRENT_SUPPORTED = $(if $(filter 64,$(ARCH_MODE)),$(SUPPORTED_RASPPI_64),$(SUPP
 CURRENT_DIST_DIR = $(if $(filter 64,$(ARCH_MODE)),$(DIST_DIR)64,$(DIST_DIR))
 CURRENT_ZIP_NAME = $(if $(filter 64,$(ARCH_MODE)),usbode-$(BUILD_VERSION)-$(BRANCH)-$(COMMIT)-64bit.zip,$(ZIP_NAME))
 
+# Global C++ flags for Circle configuration
+GLOBAL_CPPFLAGS = -DKERNEL_MAX_SIZE=0x400000 \
+                  -DSCREEN_HEADLESS \
+                  -DUSE_USB_FIQ \
+                  -DREALTIME
+
+# Export for submodules
+export EXTRA_CPPFLAGS += $(GLOBAL_CPPFLAGS)
+
 RASPPI ?= $(if $(CURRENT_SUPPORTED),$(word 1,$(CURRENT_SUPPORTED)),1)
 # Fallback if empty
 ifeq ($(SUPPORTED_RASPPI),)


### PR DESCRIPTION
Following flags are enabled:

- Added headless support (for pi4 support)
- Enabled USE_USB_FIQ
- Set KERNEL_MAX_SIZE to 0x400000 (4mb) since 64 bit builds for the pi4 were exceeding 2MB.