### PR TITLE
Fix USB CD-ROM hang on old UHCI hosts + read-ahead cache for USB 1.1 performance

### DIFF
--- a/addon/discimage/cuebinfile.cpp
+++ b/addon/discimage/cuebinfile.cpp
@@ -51,13 +51,19 @@ CCueBinFileDevice::CCueBinFileDevice(FIL *pFile, char *cue_str, MEDIA_TYPE media
     // NEW: Use shared Fast Seek helper
     if (m_pFile) {
         FatFsOptimizer::EnableFastSeek(m_pFile, &m_pCLMT, 256, "BIN/ISO: ");
+        m_nLogicalPos = f_tell(m_pFile);
     }
+
+    m_pCacheBuffer = new u8[CacheSize];
 }
 
 CCueBinFileDevice::~CCueBinFileDevice(void) {
     // NEW: Use shared Fast Seek helper
     FatFsOptimizer::DisableFastSeek(&m_pCLMT);
-    
+
+    delete[] m_pCacheBuffer;
+    m_pCacheBuffer = nullptr;
+
     if (m_pFile) {
         f_close(m_pFile);
         delete m_pFile;
@@ -76,13 +82,56 @@ int CCueBinFileDevice::Read(void *pBuffer, size_t nSize) {
         return -1;
     }
 
-    UINT nBytesRead = 0;
-    FRESULT result = f_read(m_pFile, pBuffer, nSize, &nBytesRead);
+    // Cache hit: entirely served from RAM, no SD card access.
+    if (m_pCacheBuffer && nSize <= m_nCacheLen &&
+        m_nLogicalPos >= m_nCacheStart &&
+        m_nLogicalPos + nSize <= m_nCacheStart + m_nCacheLen) {
+        memcpy(pBuffer, m_pCacheBuffer + (m_nLogicalPos - m_nCacheStart), nSize);
+        m_nLogicalPos += nSize;
+        return nSize;
+    }
+
+    // Requests larger than the cache go straight through and don't disturb it.
+    if (!m_pCacheBuffer || nSize > CacheSize) {
+        FRESULT result = f_lseek(m_pFile, m_nLogicalPos);
+        if (result != FR_OK) {
+            LOGERR("Seek to offset %llu failed, err %d", m_nLogicalPos, result);
+            return -1;
+        }
+
+        UINT nBytesRead = 0;
+        result = f_read(m_pFile, pBuffer, nSize, &nBytesRead);
+        if (result != FR_OK) {
+            LOGERR("Failed to read %d bytes into memory, err %d", nSize, result);
+            return -1;
+        }
+        m_nLogicalPos += nBytesRead;
+        return nBytesRead;
+    }
+
+    // Cache miss: read a larger window than requested, so the next
+    // sequential read (the common case) is served from the cache.
+    FRESULT result = f_lseek(m_pFile, m_nLogicalPos);
     if (result != FR_OK) {
-        LOGERR("Failed to read %d bytes into memory, err %d", nSize, result);
+        LOGERR("Seek to offset %llu failed, err %d", m_nLogicalPos, result);
         return -1;
     }
-    return nBytesRead;
+
+    UINT nBytesRead = 0;
+    result = f_read(m_pFile, m_pCacheBuffer, CacheSize, &nBytesRead);
+    if (result != FR_OK) {
+        LOGERR("Failed to read %d bytes into memory, err %d", (int)CacheSize, result);
+        m_nCacheLen = 0;
+        return -1;
+    }
+
+    m_nCacheStart = m_nLogicalPos;
+    m_nCacheLen = nBytesRead;
+
+    size_t nServe = ((size_t)nBytesRead < nSize) ? (size_t)nBytesRead : nSize;
+    memcpy(pBuffer, m_pCacheBuffer, nServe);
+    m_nLogicalPos += nServe;
+    return nServe;
 }
 
 int CCueBinFileDevice::Write(const void *pBuffer, size_t nSize) {
@@ -96,7 +145,7 @@ u64 CCueBinFileDevice::Tell() const {
         return static_cast<u64>(-1);
     }
 
-    return f_tell(m_pFile);
+    return m_nLogicalPos;
 }
 
 u64 CCueBinFileDevice::Seek(u64 nOffset) {
@@ -105,15 +154,10 @@ u64 CCueBinFileDevice::Seek(u64 nOffset) {
         return static_cast<u64>(-1);
     }
 
-    // Don't seek if we're already there
-    if (Tell() == nOffset)
-	    return nOffset;
-
-    FRESULT result = f_lseek(m_pFile, nOffset);
-    if (result != FR_OK) {
-        LOGERR("Seek to offset %llu is not ok, err %d", nOffset, result);
-        return 0;
-    }
+    // Just record the position; Read() lazily seeks the underlying file
+    // only on a cache miss, so a Seek() into an already-cached region
+    // costs nothing.
+    m_nLogicalPos = nOffset;
     return nOffset;
 }
 

--- a/addon/discimage/cuebinfile.h
+++ b/addon/discimage/cuebinfile.h
@@ -64,8 +64,22 @@ class CCueBinFileDevice : public ICueDevice {
     mutable bool m_tracksParsed = false;
     mutable int m_numTracks = 0;
     // TODO: Add track structure storage
-    
+
     void ParseCueSheet() const;
+
+    // Read-ahead cache: Seek() only records the logical position (host
+    // reads always Seek() then Read(), so the underlying FIL cursor doesn't
+    // need to track it). Read() serves from the cache when possible, and on
+    // a miss reads a larger window than requested so that the immediately
+    // following sequential read (the common case for game/OS data and
+    // Redbook streaming) becomes a cache hit instead of another SD card
+    // access - this avoids the additional read latency showing up as
+    // stutter on the low-bandwidth USB 1.1 link.
+    static constexpr size_t CacheSize = 128 * 1024;
+    u8* m_pCacheBuffer = nullptr;
+    u64 m_nCacheStart = 0;
+    size_t m_nCacheLen = 0;
+    u64 m_nLogicalPos = 0;
     
     static constexpr const char* default_cue_sheet =
         "FILE \"image.iso\" BINARY\n"

--- a/patches/circle/usb-gadget-suspend-resume.patch
+++ b/patches/circle/usb-gadget-suspend-resume.patch
@@ -1,0 +1,172 @@
+--- a/include/circle/usb/gadget/dwusbgadget.h
++++ b/include/circle/usb/gadget/dwusbgadget.h
+@@ -97,6 +97,7 @@
+ 	void FlushRxFIFO (void);
+ 
+ 	void HandleUSBSuspend (void);
++	void HandleUSBResume (void);
+ 	void HandleUSBReset (void);
+ 	void HandleEnumerationDone (void);
+ 	void HandleInEPInterrupt (void);
+@@ -133,6 +134,7 @@
+ 	};
+ 
+ 	TState m_State;
++	TState m_StateBeforeSuspend;
+ 
+ 	enum TPnPEvent
+ 	{
+--- a/lib/usb/gadget/dwusbgadget.cpp
++++ b/lib/usb/gadget/dwusbgadget.cpp
+@@ -43,6 +43,7 @@
+ :	m_pInterruptSystem (pInterruptSystem),
+ 	m_DeviceSpeed (DeviceSpeed),
+ 	m_State (StatePowered),
++	m_StateBeforeSuspend (StatePowered),
+ 	m_bPnPEvent {FALSE, FALSE}
+ {
+ 	for (unsigned i = 0; i <= NumberOfEPs; i++)
+@@ -437,6 +438,7 @@
+ 
+ 	// Enable interrupts
+ 	IntMask.Or (DWHCI_CORE_INT_MASK_USB_SUSPEND);
++	IntMask.Or (DWHCI_CORE_INT_MASK_WKUP_INTR);
+ 	IntMask.Or (DWHCI_CORE_INT_MASK_USB_RESET_INTR);
+ 	IntMask.Or (DWHCI_CORE_INT_MASK_ENUM_DONE);
+ 	IntMask.Or (DWHCI_CORE_INT_MASK_IN_EP_INTR);
+@@ -529,13 +531,34 @@
+ 			}
+ 		}
+ 
++		m_StateBeforeSuspend = m_State;
+ 		m_State = StateSuspended;
+ 	}
+ 
+ 	CDWHCIRegister IntStatus (DWHCI_CORE_INT_STAT, DWHCI_CORE_INT_MASK_USB_SUSPEND);
+ 	IntStatus.Write ();
+ }
++
++void CDWUSBGadget::HandleUSBResume (void)
++{
++	// Trace: always log resume with current state (diagnosis for issue #591)
++	LOGNOTE ("USB resume (state %u)", (unsigned) m_State);
++
++	if (m_State == StateSuspended)
++	{
++		// The host resumed the bus without a reset. Old UHCI hosts (e.g.
++		// Intel PIIX4 driven by DOS USBASPI.SYS) stop the schedule between
++		// enumeration steps: >3 ms without SOFs looks like a suspend to the
++		// DWC2 core, but the host continues transactions afterwards without
++		// resetting. Restore the pre-suspend state, so those transactions
++		// are processed instead of being dropped.
++		m_State = m_StateBeforeSuspend;
++	}
+ 
++	CDWHCIRegister IntStatus (DWHCI_CORE_INT_STAT, DWHCI_CORE_INT_MASK_WKUP_INTR);
++	IntStatus.Write ();
++}
++
+ void CDWUSBGadget::HandleUSBReset (void)
+ {
+ #ifdef USB_GADGET_DEBUG
+@@ -692,9 +715,20 @@
+ #endif
+ 
+ 	assert (   m_State == StateSuspended
++		|| m_State == StateResetDone
+ 		|| m_State == StateEnumDone
+ 		|| m_State == StateConfigured);
+ 
++	if (m_State == StateSuspended)
++	{
++		// EP activity while suspended means the host resumed the bus
++		// without a reset (see HandleUSBResume()). Restore the state and
++		// process the interrupt instead of dropping it.
++		LOGNOTE ("Implicit USB resume on IN EP activity (state %u)",
++			 (unsigned) m_StateBeforeSuspend);
++		m_State = m_StateBeforeSuspend;
++	}
++
+ 	CDWHCIRegister AllEPsIntStat (DWHCI_DEV_ALL_EPS_INT_STAT);
+ 	CDWHCIRegister AllEPsIntMask (DWHCI_DEV_ALL_EPS_INT_MASK);
+ 	u32 nInEPStat = (AllEPsIntStat.Read () & AllEPsIntMask.Read ()) & 0xFFFF;
+@@ -703,19 +737,9 @@
+ 	{
+ 		if (nInEPStat & 1)
+ 		{
+-			if (m_State != StateSuspended)
+-			{
+-				assert (nEP <= NumberOfEPs);
+-				assert (m_pEP[nEP]);
+-				m_pEP[nEP]->HandleInInterrupt ();
+-			}
+-			else
+-			{
+-				// Suspended: acknowledge without processing (a transfer,
+-				// which completed while suspend was being handled)
+-				CDWHCIRegister InEPIntAck (DWHCI_DEV_IN_EP_INT (nEP), ~0U);
+-				InEPIntAck.Write ();
+-			}
++			assert (nEP <= NumberOfEPs);
++			assert (m_pEP[nEP]);
++			m_pEP[nEP]->HandleInInterrupt ();
+ 		}
+ 	}
+ }
+@@ -727,9 +751,21 @@
+ #endif
+ 
+ 	assert (   m_State == StateSuspended
++		|| m_State == StateResetDone
+ 		|| m_State == StateEnumDone
+ 		|| m_State == StateConfigured);
+ 
++	if (m_State == StateSuspended)
++	{
++		// EP activity while suspended means the host resumed the bus
++		// without a reset (see HandleUSBResume()). Restore the state and
++		// process the interrupt (e.g. a SETUP from an old UHCI host)
++		// instead of acknowledging and dropping it.
++		LOGNOTE ("Implicit USB resume on OUT EP activity (state %u)",
++			 (unsigned) m_StateBeforeSuspend);
++		m_State = m_StateBeforeSuspend;
++	}
++
+ 	CDWHCIRegister AllEPsIntStat (DWHCI_DEV_ALL_EPS_INT_STAT);
+ 	CDWHCIRegister AllEPsIntMask (DWHCI_DEV_ALL_EPS_INT_MASK);
+ 	u32 nOutEPStat = (AllEPsIntStat.Read () & AllEPsIntMask.Read ()) >> 16;
+@@ -738,19 +774,9 @@
+ 	{
+ 		if (nOutEPStat & 1)
+ 		{
+-			if (m_State != StateSuspended)
+-			{
+-				assert (nEP <= NumberOfEPs);
+-				assert (m_pEP[nEP]);
+-				m_pEP[nEP]->HandleOutInterrupt ();
+-			}
+-			else
+-			{
+-				CDWHCIRegister OutEPIntAck (DWHCI_DEV_OUT_EP_INT (nEP));
+-				OutEPIntAck.Set (  DWHCI_DEV_OUT_EP_INT_SETUP_DONE
+-						 | DWHCI_DEV_OUT_EP_INT_XFER_COMPLETE);
+-				OutEPIntAck.Write ();
+-			}
++			assert (nEP <= NumberOfEPs);
++			assert (m_pEP[nEP]);
++			m_pEP[nEP]->HandleOutInterrupt ();
+ 		}
+ 	}
+ }
+@@ -774,6 +800,11 @@
+ 		nIntStatus = 0;
+ 	}
+ 
++	if (nIntStatus & DWHCI_CORE_INT_MASK_WKUP_INTR)
++	{
++		HandleUSBResume ();
++	}
++
+ 	if (nIntStatus & DWHCI_CORE_INT_MASK_USB_RESET_INTR)
+ 	{
+ 		HandleUSBReset ();


### PR DESCRIPTION
## Summary

  Two complementary fixes for USB 1.1 compatibility and performance:

  1. **Fix USB CD-ROM enumeration hang on old UHCI hosts** — DOS USBASPI on Intel PIIX4 (e.g. Gateway 440LX) pauses the
  bus schedule between enumeration steps. The DWC2 gadget core reported suspend, but Circle's gadget driver had no
  resume path: every EP interrupt while suspended was dropped, making USBASPI wait forever at "Scanning USB
  Devices...". Now handles the wakeup interrupt and restores state on implicit resume (no reset), so USBASPI's resumed
  traffic is processed instead of dropped.
  
  2. **Add read-ahead cache to CUE/BIN image reader** — Reduces SD card latency on USB 1.1's low-bandwidth link. Seek()
  records position lazily; Read() checks a 128KB cache first and reads a larger window on miss, so sequential reads
  (game data, Redbook audio) become cache hits instead of fresh SD card accesses. Improves perceived smoothness without
  changing the ~1MB/s throughput ceiling.

  Tested on Gateway G6-233 (440LX/PIIX4) with USBASPI 2.27 + USBCD + MSCDEX.

## Test plan

  - [ ] Boot USBODE on old Intel UHCI hardware with DOS USBASPI driver
  - [ ] Verify CD-ROM is detected (no hang at "Scanning USB Devices...")
  - [ ] Load files from CD and verify audio playback feels smooth, not jerky
  - [ ] Verify no regressions on newer USB 2.0 hosts or Windows 98
