### PR TITLE
CI: cache downloaded WLAN/boot firmware to fix rate-limit build failures

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,6 +34,38 @@ jobs:
       with:
         submodules:  recursive
         clean: true
+
+    # circle-deps / boot re-download these from GitHub on every build once
+    # "Clean workspace" + submodule deinit wipe them out. On a self-hosted
+    # runner building frequently, unauthenticated raw-file fetches to
+    # RPi-Distro/firmware-nonfree can hit GitHub's rate limit (HTTP 429) and
+    # fail the whole build. Cache them across runs; the key is derived from
+    # the pinned firmware commit hash in each Makefile, so bumping either
+    # FIRMWARE variable upstream automatically invalidates the cache instead
+    # of silently keeping stale blobs.
+    - name: Cache WLAN firmware
+      uses: actions/cache@v4
+      with:
+        path: circle-stdlib/libs/circle/addon/wlan/firmware
+        key: wlan-firmware-${{ hashFiles('circle-stdlib/libs/circle/addon/wlan/firmware/Makefile') }}
+
+    - name: Cache boot firmware
+      uses: actions/cache@v4
+      with:
+        # Only the files boot/Makefile downloads, never the tracked
+        # sources (Makefile, armstub/*, config*.txt) that ship in the
+        # circle submodule itself, so a cache restore can never shadow a
+        # newer tracked file with a stale cached one.
+        path: |
+          circle-stdlib/libs/circle/boot/LICENCE.broadcom
+          circle-stdlib/libs/circle/boot/COPYING.linux
+          circle-stdlib/libs/circle/boot/bootcode.bin
+          circle-stdlib/libs/circle/boot/start*.elf
+          circle-stdlib/libs/circle/boot/fixup*.dat
+          circle-stdlib/libs/circle/boot/*.dtb
+          circle-stdlib/libs/circle/boot/*.dtbo
+        key: boot-firmware-${{ hashFiles('circle-stdlib/libs/circle/boot/Makefile') }}
+
     - name: Build
       run: make release BUILD_NUMBER=${{ github.run_number }}
 


### PR DESCRIPTION
## Problem
  Build #943 (merge of #202) failed twice with:
  
      make[4]: *** [Makefile:29: firmware5] Error 8
      
  Root cause: circle-deps and boot/Makefile download WLAN and boot firmware
  blobs from RPi-Distro/firmware-nonfree on GitHub, but only when those
  files aren't already present. The workflow's "Clean workspace" step
  (git clean -ffdx + submodule deinit --force) wipes them every single
  run regardless — so a self-hosted runner building frequently
  re-downloads the same files over and over. Today that tripped GitHub's
  rate limit (confirmed HTTP 429 on the firmware URLs), failing the build
  with no code involved at all.
  
  ## Fix
  Cache both firmware directories with actions/cache, keyed off each
  Makefile's contents:
  - WLAN firmware dir is cached whole (only tracked files there are
    Makefile/.gitignore, neither of which the download touches).
  - boot/ cache is scoped to only the specific downloaded files
    (LICENCE.broadcom, bootcode.bin, start*.elf, fixup*.dat, *.dtb,
    *.dtbo, etc.) rather than the whole directory, since boot/ also has
    tracked sources (Makefile, armstub/*, config32.txt, config64.txt)
    that a whole-directory cache restore could shadow with stale content.
    
  Keying on Makefile hash means if either FIRMWARE commit pin is bumped
  upstream, the cache key changes and it re-downloads automatically —
  no staleness risk.
  
  ## Risk
  Low — CI-only change, no product code touched. Since .github/** is in
  the workflow's own paths-ignore list, this change doesn't even trigger
  a build on push; it'll only take effect on the next real code push.