### PR TITLE
Fix firmware re-download on every arch pass; prefetch via authenticated GitHub API

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,6 +66,52 @@ jobs:
           circle-stdlib/libs/circle/boot/*.dtbo
         key: boot-firmware-${{ hashFiles('circle-stdlib/libs/circle/boot/Makefile') }}
 
+    # When the caches above miss, fetch the same files through api.github.com
+    # with the workflow token instead of letting make wget them anonymously:
+    # authenticated requests use a per-token quota (1000 req/h) that is not
+    # affected by the anonymous per-IP throttle that rate-limited this
+    # runner (HTTP 429 -> wget "Error 8"). The file lists and pinned refs are
+    # parsed from the two Makefiles at run time, so a FIRMWARE pin bump
+    # upstream is picked up automatically. Non-fatal: if this step fails,
+    # make falls back to its own wget exactly as before.
+    - name: Prefetch firmware via GitHub API (on cache miss)
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        fetch() { # $1 owner/repo  $2 ref  $3 path-in-repo  $4 dest-file
+          curl -sSfL --retry 3 --retry-delay 10 \
+               -H "Authorization: Bearer $GH_TOKEN" \
+               -H "Accept: application/vnd.github.raw" \
+               "https://api.github.com/repos/$1/contents/$3?ref=$2" -o "$4"
+        }
+
+        FW=circle-stdlib/libs/circle/addon/wlan/firmware
+        if [ ! -f "$FW/.firmware_downloaded" ]; then
+          SHA=$(sed -n 's/^FIRMWARE ?= *//p' "$FW/Makefile")
+          grep -E '^[[:space:]]*wget -q -O ' "$FW/Makefile" | while read -r _ _ _ dest url; do
+            fetch RPi-Distro/firmware-nonfree "$SHA" \
+                  "debian/config/brcm80211/${url#'$(BASEURL)/'}" "$FW/$dest"
+          done
+          touch "$FW/.firmware_downloaded"
+          echo "WLAN firmware prefetched"
+        else
+          echo "WLAN firmware present (cache hit), skipping prefetch"
+        fi
+
+        BOOT=circle-stdlib/libs/circle/boot
+        if [ ! -f "$BOOT/LICENCE.broadcom" ]; then
+          SHA=$(make -pn -C "$BOOT" 2>/dev/null | sed -n 's/^FIRMWARE = //p' | tail -n1)
+          FILES=$(make -pn -C "$BOOT" 2>/dev/null | sed -n 's/^FILES = //p' | tail -n1)
+          OVERLAYS=$(make -pn -C "$BOOT" 2>/dev/null | sed -n 's/^OVERLAYS = //p' | tail -n1)
+          for f in $FILES;    do fetch raspberrypi/firmware "$SHA" "boot/$f" "$BOOT/$f"; done
+          for f in $OVERLAYS; do fetch raspberrypi/firmware "$SHA" "boot/overlays/$f" "$BOOT/$f"; done
+          echo "Boot firmware prefetched"
+        else
+          echo "Boot firmware present (cache hit), skipping prefetch"
+        fi
+
     - name: Build
       run: make release BUILD_NUMBER=${{ github.run_number }}
 

--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,17 @@ circle-stdlib: configure
 	cd $(STDLIBHOME) && $(MAKE) clean && $(MAKE) all 
 
 # Handle Circle dependencies (firmware and boot files)
+# Note: the download gate used to test for LICENCE.broadcom_bcm43xx, but the
+# wlan firmware Makefile stopped downloading that file with the circle 51
+# update, so the gate never passed and every arch pass of every build
+# re-downloaded all 17 firmware blobs from GitHub (which eventually got the
+# CI runner's IP rate-limited). Gate on a marker file we create ourselves
+# after a successful download instead.
 circle-deps: circle-stdlib
 	@echo "Building Circle dependencies..."
-	@if [ ! -f "$(CIRCLEHOME)/addon/wlan/firmware/LICENCE.broadcom_bcm43xx" ]; then \
+	@if [ ! -f "$(CIRCLEHOME)/addon/wlan/firmware/.firmware_downloaded" ]; then \
 		echo "WLAN firmware not found, downloading..."; \
-		cd $(CIRCLEHOME)/addon/wlan/firmware && $(MAKE); \
+		cd $(CIRCLEHOME)/addon/wlan/firmware && $(MAKE) && touch .firmware_downloaded; \
 	else \
 		echo "WLAN firmware already exists, skipping download"; \
 		cd $(CIRCLEHOME)/addon/wlan && $(MAKE) clean && $(MAKE); \
@@ -338,7 +344,7 @@ clean-imagesfolder:
 # Clean WLAN firmware files (forces re-download on next build)
 cleanwlanfirmware:
 	@echo "Cleaning WLAN firmware files..."
-	@cd $(CIRCLEHOME)/addon/wlan/firmware && $(MAKE) clean
+	@cd $(CIRCLEHOME)/addon/wlan/firmware && $(MAKE) clean && rm -f .firmware_downloaded
 	@echo "WLAN firmware cleaned. Next build will re-download firmware files."
 
 # 32-bit specific targets


### PR DESCRIPTION
 ## Root cause of the build #943 failures on main
  
  The circle-deps download gate tests for LICENCE.broadcom_bcm43xx, but the
  wlan firmware Makefile stopped downloading that file with the circle 51
  update (#188). The gate never passes anymore, so every arch iteration of
  every build re-runs the firmware download — whose `all` target is
  `clean firmware firmware5`, deleting and re-fetching all 17 blobs each
  time. A release build does this 3-4x in -j8 parallel wget bursts, on
  every push, for the last 2 months. GitHub eventually rate-limited the
  runner's IP for anonymous downloads (confirmed HTTP 429 -> wget Error 8),
  which is why retries kept failing and why the cache from #203 couldn't
  help (the broken gate bypassed cached files anyway).
  
  ## Fixes
  
  1. **Makefile**: gate the wlan firmware download on a
     `.firmware_downloaded` marker created after a successful download
     (removed by `cleanwlanfirmware` so forced re-download still works).
     Downloads drop from once-per-arch to at most once per workspace —
     and zero with the cache.
     
  2. **Workflow**: on cache miss, prefetch wlan + boot firmware through
     api.github.com using the built-in GITHUB_TOKEN (Accept:
     application/vnd.github.raw). Authenticated requests use a per-token
     quota unaffected by the anonymous per-IP throttle currently blocking
     the runner, so this unblocks builds immediately. File lists and
     pinned refs are parsed from the two Makefiles at run time (FIRMWARE
     pin bumps are picked up automatically). Non-fatal: make falls back
     to its own wget if the step fails.
     
  ## Validation
  
  - Parsed file lists match the Makefiles exactly (17 wlan mappings incl.
    the cyfmac->brcmfmac renames; 21 boot files + 1 overlay)
  - An API-fetched file is byte-identical to its wget-fetched counterpart
  - Dry-run of the exact step script creates all 39 files and is a
    complete no-op on re-run
  - The push of this branch triggers a CI build using this workflow — that
    run is the live end-to-end test on the throttled runner