### PR TITLE
CI: never ship empty boot firmware (real cause of Zero 2 W dead-on-boot in 3.0.6)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,8 +66,98 @@ jobs:
           circle-stdlib/libs/circle/boot/*.dtbo
         key: boot-firmware-${{ hashFiles('circle-stdlib/libs/circle/boot/Makefile') }}
 
+    # A restored cache or an earlier failed download can contain 0-byte
+    # firmware files: wget -O creates the destination before the transfer
+    # starts, and the circle boot Makefile's download loop ignores per-file
+    # wget failures. Build-947 "succeeded" that way while shipping 0-byte
+    # bootcode.bin/fixup.dat — which bricks Pi Zero (2) W cards — and the
+    # poisoned files were then saved into the cache. Delete any empty files
+    # so the prefetch step / make re-download them instead.
+    - name: Purge empty firmware files (cache poison guard)
+      run: |
+        find circle-stdlib/libs/circle/addon/wlan/firmware \
+             circle-stdlib/libs/circle/boot \
+             -maxdepth 1 -type f -size 0 -print -delete
+
+    # When the caches above miss, fetch the same files through api.github.com
+    # with the workflow token instead of letting make wget them anonymously:
+    # authenticated requests use a per-token quota (1000 req/h) that is not
+    # affected by the anonymous per-IP throttle that rate-limited this runner
+    # (HTTP 429 -> wget "Error 8" -> silent 0-byte files, see above). The file
+    # lists and pinned refs are parsed from the two Makefiles at run time, so
+    # a FIRMWARE pin bump upstream is picked up automatically. Non-fatal: if
+    # this step fails, make falls back to its own wget exactly as before.
+    #
+    # Each file is fetched only if missing or empty, and every download goes
+    # to a temp file that is moved into place only when non-empty, so a failed
+    # transfer can never leave a 0-byte file for make to treat as done.
+    - name: Prefetch firmware via GitHub API (on cache miss)
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -uo pipefail
+        fetch() { # $1 owner/repo  $2 ref  $3 path-in-repo  $4 dest-file
+          local tmp="$4.fetch-tmp"
+          if curl -sSfL --retry 3 --retry-delay 10 \
+               -H "Authorization: Bearer $GH_TOKEN" \
+               -H "Accept: application/vnd.github.raw" \
+               "https://api.github.com/repos/$1/contents/$3?ref=$2" -o "$tmp" \
+             && [ -s "$tmp" ]; then
+            mv "$tmp" "$4"
+          else
+            rm -f "$tmp"
+            echo "prefetch FAILED for $3"
+            return 1
+          fi
+        }
+
+        rc=0
+
+        FW=circle-stdlib/libs/circle/addon/wlan/firmware
+        SHA=$(sed -n 's/^FIRMWARE ?= *//p' "$FW/Makefile")
+        while read -r _ _ _ dest url; do
+          [ -s "$FW/$dest" ] && continue
+          fetch RPi-Distro/firmware-nonfree "$SHA" \
+                "debian/config/brcm80211/${url#'$(BASEURL)/'}" "$FW/$dest" || rc=1
+        done < <(grep -E '^[[:space:]]*wget -q -O ' "$FW/Makefile")
+
+        BOOT=circle-stdlib/libs/circle/boot
+        SHA=$(make -pn -C "$BOOT" 2>/dev/null | sed -n 's/^FIRMWARE = //p' | tail -n1)
+        FILES=$(make -pn -C "$BOOT" 2>/dev/null | sed -n 's/^FILES = //p' | tail -n1)
+        OVERLAYS=$(make -pn -C "$BOOT" 2>/dev/null | sed -n 's/^OVERLAYS = //p' | tail -n1)
+        for f in $FILES; do
+          [ -s "$BOOT/$f" ] || fetch raspberrypi/firmware "$SHA" "boot/$f" "$BOOT/$f" || rc=1
+        done
+        for f in $OVERLAYS; do
+          [ -s "$BOOT/$f" ] || fetch raspberrypi/firmware "$SHA" "boot/overlays/$f" "$BOOT/$f" || rc=1
+        done
+
+        exit $rc
+
     - name: Build
       run: make release BUILD_NUMBER=${{ github.run_number }}
+
+    # Refuse to ship a build containing empty files. A verified-good build
+    # has none (checked against a local clean build), and empty boot firmware
+    # looks like a successful build while bricking every Pi Zero (2) W card
+    # it is flashed or sysupgraded onto (build-947, build-950).
+    - name: Verify no empty files in distribution
+      run: |
+        bad=$(find dist dist64 -type f -size 0)
+        if [ -n "$bad" ]; then
+          echo "ERROR: empty files in distribution:"
+          echo "$bad"
+          exit 1
+        fi
+        for f in dist/bootcode.bin dist/fixup.dat dist/start.elf \
+                 dist64/bootcode.bin dist64/fixup.dat dist64/start.elf; do
+          if [ ! -s "$f" ]; then
+            echo "ERROR: missing or empty critical boot file: $f"
+            exit 1
+          fi
+        done
+        echo "All distribution files verified non-empty"
 
     - name: Get filename
       id: get-filename


### PR DESCRIPTION
## Summary
Root cause of the 3.0.6 "Pi appears completely dead" reports on Zero 2 W — and it was never the phy-linestate patch. Both published 3.0.6 image sets (build-947 and build-950) ship a **0-byte `bootcode.bin` and 0-byte `fixup.dat`**. The Zero (2) W boot ROM loads `bootcode.bin` from the card first, so the Pi shows no LED, no display, nothing. The sysupgrade tars contain the same empty files and overwrite a working card's boot files, bricking it. Pi 4 was unaffected (EEPROM boot + intact `start4.elf`/`fixup4.dat`), which is why only Zero 2 W users hit this.

**How it happened:** circle's `boot/Makefile` download loop ignores per-file wget failures (`wget -q -O` creates the file before the transfer; the for-loop discards exit codes). When GitHub rate-limited the runner (429), build-947 "succeeded" with empty files, and `actions/cache` (added in #203) then preserved the poison for every later build — including build-950, which contained the #205 revert but still bricked.

The poisoned caches have already been deleted from the repo's Actions cache storage, and the v3.0.6 release is flagged with a warning until fixed assets are up.

## Changes (all in the workflow)
1. **Purge step** after cache restore: delete any 0-byte file in the two firmware dirs, so a poisoned cache self-heals.
2. **Prefetch step** on cache miss: fetch firmware via `api.github.com` with the workflow token (per-token quota, immune to the anonymous per-IP throttle). Downloads go to a temp file moved into place only when non-empty — this step cannot create poison. Non-fatal; make's wget remains the fallback.
3. **Verify step** after build: fail loudly if `dist/`/`dist64/` contain any empty file or lack `bootcode.bin`/`fixup.dat`/`start.elf`. A clean build has zero empty files (verified against a local build), so any hit is a real defect.

## Verification
- Parsing of both firmware Makefiles (refs, file lists, cypress/brcm path mapping) validated locally against the pinned submodule
- `fetch()` live-tested: success path downloads the real 52,624-byte `bootcode.bin`; failure path (404) leaves no file behind and returns nonzero
- YAML validated
- A clean local build has no empty files in `dist`/`dist64`, so the verify step is safe against false positives

## Note on #205
The phy-linestate revert (#205) turned out not to be the Zero 2 W culprit, but hardware testing (440LX/DOS, AM4/Win11) confirmed everything works without the patch, and its own commit message required Zero 2 W regression gating before restoring — so the revert stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)