### PR TITLE
Bug fixes: disc-swap races, Zero-family PWM/WLAN crash, ST7789 backlight, FTP sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ it back to a bin/cue. Example command lines:
 
 `chdman createcd -i MultiBin.cue -o MultiBin.chd` 
 Note CHD files are compatible with USBODE, but performance isn't perfect yet. So to convert back to .bin/cue use:
-`chdman extractct -i MultiBin.chd -o SingleBin.cue -ob SingleBin.bin`
+`chdman extractcd -i MultiBin.chd -o SingleBin.cue -ob SingleBin.bin`
 
 If there are issues with CD playback, please try this first. The previous recommendation was to use an old unsupported software which does not properly support conversion.
 

--- a/addon/displayservice/st7789/display.cpp
+++ b/addon/displayservice/st7789/display.cpp
@@ -161,7 +161,9 @@ bool ST7789Display::Initialize() {
         LOGNOTE("Registered buttons");
     }
 
-    if (bOK) {
+    // backlight_pin=0 means no backlight control; pwm_configured stays false
+    // so the sleep/low-power paths never touch the PWM either
+    if (bOK && m_backlight_pin) {
         m_Backlight = new CGPIOPin(m_backlight_pin, GPIOModeAlternateFunction0, m_GPIOManager);
         m_PWMOutput.Start();
         unsigned brightness = configservice->GetST7789Brightness(1024);

--- a/addon/displayservice/st7789/display.h
+++ b/addon/displayservice/st7789/display.h
@@ -59,8 +59,9 @@ class ST7789Display : public IDisplay {
 
     ConfigService* configservice;
 
-    int m_backlight_pin;
-    CGPIOPin* m_Backlight;
+    // 0 = no backlight control (backlight_pin=0 in config disables it)
+    int m_backlight_pin = 0;
+    CGPIOPin* m_Backlight = nullptr;
     int backlightTimer;
     int lowPowerTimer;
     bool sleeping = false;

--- a/addon/ftpserver/ftpdaemon.cpp
+++ b/addon/ftpserver/ftpdaemon.cpp
@@ -33,7 +33,10 @@
 LOGMODULE("ftpd");
 
 constexpr u16 ListenPort = 21;
-constexpr u8 MaxConnections = 1;
+// FTP clients like FileZilla open several connections at once (browsing +
+// parallel transfers); a limit of 1 made them fail with 421 whenever a
+// second connection or a not-yet-timed-out stale session existed.
+constexpr u8 MaxConnections = CFTPWorker::MaxSessions;
 
 CFTPDaemon::CFTPDaemon(const char* pUser, const char* pPassword)
     : CTask(TASK_STACK_SIZE, true),

--- a/addon/ftpserver/ftpworker.cpp
+++ b/addon/ftpserver/ftpworker.cpp
@@ -91,6 +91,7 @@ const TFTPCommand CFTPWorker::Commands[] =
 };
 
 u8 CFTPWorker::s_nInstanceCount = 0;
+u8 CFTPWorker::s_nSlotsInUse = 0;
 
 // Volume names from ffconf.h
 // TODO: Share with soundfontmanager.cpp
@@ -133,7 +134,20 @@ CFTPWorker::CFTPWorker(CSocket* pControlSocket, const char* pExpectedUser, const
       m_CurrentPath("1:"),
       m_RenameFrom() {
     ++s_nInstanceCount;
-    m_LogName.Format("ftpd[%d]", s_nInstanceCount);
+
+    // Claim the lowest free session slot; it determines the passive-mode
+    // data port, so it must stay stable for the whole session even as
+    // other sessions come and go. (Task context only, so no locking.)
+    m_nSlot = 0;
+    for (u8 i = 0; i < MaxSessions; ++i) {
+        if (!(s_nSlotsInUse & (1 << i))) {
+            m_nSlot = i;
+            break;
+        }
+    }
+    s_nSlotsInUse |= (1 << m_nSlot);
+
+    m_LogName.Format("ftpd[%d]", m_nSlot + 1);
     
     // Allocate buffers
     WriteBuffer = new (HEAP_LOW) BYTE[WRITE_BUFFER_SIZE];
@@ -157,6 +171,7 @@ CFTPWorker::~CFTPWorker() {
     if (WriteBuffer != nullptr)
         delete[] WriteBuffer;
 
+    s_nSlotsInUse &= ~(1 << m_nSlot);
     --s_nInstanceCount;
     LOGNOTE("Instance count is now %d", s_nInstanceCount);
 }
@@ -164,7 +179,7 @@ CFTPWorker::~CFTPWorker() {
 void CFTPWorker::Run() {
     assert(m_pControlSocket != nullptr);
 
-    const size_t nWorkerNumber = s_nInstanceCount;
+    const size_t nWorkerNumber = m_nSlot + 1;
     CScheduler* const pScheduler = CScheduler::Get();
 
     LOGNOTE("Worker task %d spawned", nWorkerNumber);
@@ -547,7 +562,7 @@ bool CFTPWorker::Passive(const char* pArgs) {
 
     if (m_pDataSocket == nullptr) {
         m_TransferMode = TTransferMode::Passive;
-        m_nDataSocketPort = PassivePortBase + s_nInstanceCount - 1;
+        m_nDataSocketPort = PassivePortBase + m_nSlot;
 
         CNetSubSystem* const pNet = CNetSubSystem::Get();
         m_pDataSocket = new CSocket(pNet, IPPROTO_TCP);

--- a/addon/ftpserver/ftpworker.h
+++ b/addon/ftpserver/ftpworker.h
@@ -88,6 +88,11 @@ class CFTPWorker : protected CTask {
 
     static u8 GetInstanceCount() { return s_nInstanceCount; }
 
+    // Concurrent session limit; each session owns a slot that fixes its
+    // passive-mode data port (PassivePortBase + slot), so slots must never
+    // be shared between live sessions.
+    static constexpr u8 MaxSessions = 4;
+
    private:
     CSocket* OpenDataConnection();
 
@@ -159,6 +164,8 @@ class CFTPWorker : protected CTask {
 
     static const TFTPCommand Commands[];
     static u8 s_nInstanceCount;
+    static u8 s_nSlotsInUse; // bitmask of live sessions' slots
+    u8 m_nSlot;
 };
 
 #endif

--- a/addon/usbcdgadget/scsi_misc.cpp
+++ b/addon/usbcdgadget/scsi_misc.cpp
@@ -77,6 +77,13 @@ void SCSIMisc::PreventAllowMediumRemoval(CUSBCDGadget *gadget)
 
 void SCSIMisc::ReadCapacity(CUSBCDGadget *gadget)
 {
+    if (!gadget->m_CDReady)
+    {
+        gadget->setSenseData(0x02, 0x3A, 0x00); // MEDIUM NOT PRESENT
+        gadget->sendCheckCondition();
+        return;
+    }
+
     gadget->m_ReadCapReply.nLastBlockAddr = htonl(CDUtils::GetLeadoutLBA(gadget) - 1); // this value is the Start address of last recorded lead-out minus 1
     memcpy(gadget->m_InBuffer, &gadget->m_ReadCapReply, SIZE_READCAPREP);
     gadget->m_nnumber_blocks = 0; // nothing more after this send

--- a/addon/usbcdgadget/scsi_read.cpp
+++ b/addon/usbcdgadget/scsi_read.cpp
@@ -145,6 +145,13 @@ void SCSIRead::DoPlayAudio(CUSBCDGadget* gadget, int cdbSize)
 {
     MLOGNOTE("SCSIRead::DoPlayAudio", cdbSize == 12 ? "PLAY AUDIO (12)" : "PLAY AUDIO (10)");
 
+    if (!gadget->m_CDReady)
+    {
+        gadget->setSenseData(0x02, 0x04, 0x00); // LOGICAL UNIT NOT READY
+        gadget->sendCheckCondition();
+        return;
+    }
+
     // Where to start reading (LBA)
     gadget->m_nblock_address = (u32)(gadget->m_CBW.CBWCB[2] << 24) | (u32)(gadget->m_CBW.CBWCB[3] << 16) | (u32)(gadget->m_CBW.CBWCB[4] << 8) | gadget->m_CBW.CBWCB[5];
 

--- a/addon/usbcdgadget/tcdstate_update.cpp
+++ b/addon/usbcdgadget/tcdstate_update.cpp
@@ -56,6 +56,15 @@ void CUSBCDGadget::Update()
                          elapsed);
                 break;
 
+            case MediaState::MEDIUM_PRESENT_READY:
+                // Host consumed the UNIT ATTENTION with a REQUEST SENSE
+                // inside the settle window - the swap already completed.
+                m_bPendingDiscSwap = false;
+                CDROM_DEBUG_LOG("CUSBCDGadget::Update",
+                         "Disc swap: Host cleared UNIT_ATTENTION early, complete after %u ms",
+                         elapsed);
+                break;
+
             default:
                 // Shouldn't happen
                 m_bPendingDiscSwap = false;

--- a/addon/usbcdgadget/usbcdgadget.cpp
+++ b/addon/usbcdgadget/usbcdgadget.cpp
@@ -510,16 +510,22 @@ void CUSBCDGadget::SetDevice(IImageDevice *dev)
     if (bDiscSwap || !m_CDReady)
     {
         MLOGNOTE("CUSBCDGadget::SetDevice", "Disc swap detected - ejecting old media");
-        delete m_pDevice;
-        m_pDevice = nullptr;
 
+        // SCSI commands arrive in IRQ context and gate on m_CDReady, so the
+        // unit must read as not-ready before the old device is torn down.
         m_CDReady = false;
         m_mediaState = MediaState::NO_MEDIUM;
         m_SenseParams.bSenseKey = 0x02;
         m_SenseParams.bAddlSenseCode = 0x3a;
         m_SenseParams.bAddlSenseCodeQual = 0x00;
         bmCSWStatus = CD_CSW_STATUS_FAIL;
-        discChanged = true;
+
+        delete m_pDevice;
+        m_pDevice = nullptr;
+
+        // discChanged (the GESN NewMedia event) is armed when the new medium
+        // becomes present, not here: signalling NewMedia while the drive still
+        // reports NO_MEDIUM makes hosts mount twice per swap.
 
         MLOGNOTE("CUSBCDGadget::SetDevice", "Media ejected: state=NO_MEDIUM, sense=02/3a/00");
     }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -34,6 +34,7 @@
 #include <setupstatus/setupstatus.h>
 #include <upgradestatus/upgradestatus.h>
 #include <circle/memory.h>
+#include <circle/machineinfo.h>
 
 #include <circle/time.h>
 
@@ -263,6 +264,25 @@ TShutdownMode CKernel::Run(void)
 
     // Initialize the CD Player service
     const char *pSoundDevice = m_Options.GetSoundDevice();
+
+#ifndef USE_PWM_AUDIO_ON_ZERO
+    // Zero-family boards have no headphone jack, so Circle maps PWM audio to
+    // the Pi 3 jack pins GPIO 40/41 - but on these boards GPIO 41 is WL_REG_ON,
+    // the onboard WLAN chip's regulator enable. Starting PWM sound there cuts
+    // power to the WLAN chip and panics the ether4330 driver within
+    // milliseconds (SDIO I/O errors, then error-stack overflow).
+    if (strcmp(pSoundDevice, "sndpwm") == 0)
+    {
+        TMachineModel model = CMachineInfo::Get()->GetMachineModel();
+        if (model == MachineModelZero || model == MachineModelZeroW
+            || model == MachineModelZero2W || model == MachineModelCM0)
+        {
+            LOGWARN("sounddev=sndpwm is not supported on this board "
+                    "(PWM audio pins control the onboard WLAN regulator) - audio disabled");
+            pSoundDevice = "";
+        }
+    }
+#endif
 
     // Currently supporting PWM and I2S sound devices. HDMI needs more work.
     if (strcmp(pSoundDevice, "sndi2s") == 0 || strcmp(pSoundDevice, "sndpwm") == 0)


### PR DESCRIPTION
Five independent fixes on top of 3.1.0, one commit each (11 files, +88/−11).

## Disc-swap race fixes (`usbcdgadget`)
Three related issues in the disc-swap state machine:
- `SetDevice()` deleted the old image device **before** clearing `m_CDReady`. SCSI commands arrive in IRQ context and gate on `m_CDReady`, so a command in that window passed the ready check against a dead device. Media state is now cleared before teardown.
- A host that consumed UNIT ATTENTION early (via REQUEST SENSE) was logged as `Unexpected state 2` and treated as an error; it is actually the success path — trace captures show Windows 11 does this on **every** swap.
- `discChanged` was armed at eject time, producing **two** NewMedia GESN events per swap — the prime suspect for the "two Explorer windows open after a swap" reports. It is now armed once, when the new medium becomes present.
- Also adds missing `m_CDReady` gates to PLAY AUDIO and READ CAPACITY (both previously dereferenced the cue parser from IRQ context while no medium was present).

**Tested:** 7 consecutive Win11 disc swaps — single Explorer window each time, ~1.1–1.5 s to ready, clean 3-transition media-state sequence in SCSI traces; CD audio and data reads regression-tested on Win11 and a USB 1.1 / 440LX Pentium II host.

## Refuse PWM audio on Zero-family boards (fixes the "only sndi2s works" report)
On Pi Zero / Zero W / Zero 2 W / CM0 there is no headphone jack, so Circle maps PWM audio to the Pi 3 jack pins GPIO 40/41 — but on these boards **GPIO 41 is WL_REG_ON, the onboard WLAN chip's regulator enable**. Selecting `sounddev=sndpwm` cut power to the WLAN chip and panicked the ether4330 driver within milliseconds (`p9error.cpp(33) PANIC`), reproduced 3× in the reporter's log and independently on a second Zero 2 W. Worse, the device then panicked on **every** boot until cmdline.txt was edited on another machine. USBODE now refuses `sndpwm` on these boards with a log warning (builds defining `USE_PWM_AUDIO_ON_ZERO` keep working, on GPIO 12/13).

**Tested:** on a Zero 2 W — old kernel + `sndpwm` reproduces the reporter's exact panic; fixed kernel logs the warning, stays on WiFi, `sndi2s` unaffected.

## ST7789: fix hang when `backlight_pin=0`
With `backlight_pin=0` the constructor skipped the assignment but `Initialize()` still passed the **uninitialized** member to `CGPIOPin(..., AlternateFunction0)` — garbage pin number, assert/hang ("goes into limbo", as reported). `0` now means "no backlight control" and the whole backlight PWM block is skipped (sleep/low-power paths were already gated).

## FTP: allow 4 concurrent sessions with stable per-session slots
`MaxConnections` has been 1 since the initial commit. FileZilla routinely opens a second control connection (browse + transfer, or a quick reconnect), which failed with `421 Maximum number of connections reached` until the 20 s stale-session timeout expired. Raised to 4 sessions using a slot bitmask; this also fixes a latent PASV data-port collision (the port was derived from the live instance count, which is only stable with a single session).

**Tested:** FileZilla browse + transfers with parallel connections, no 421s; heavy mixed curl/FileZilla use during development.

## README: fix chdman command typo
`extractct` → `extractcd` in the BIN/CUE conversion instructions. Closes #210.