### PR TITLE
Web UI: upload and delete disc images from the main page

### DIFF
--- a/addon/webserver/Makefile
+++ b/addon/webserver/Makefile
@@ -26,7 +26,8 @@ OBJS    = webserver.o \
 	handlers/listapi.o \
 	handlers/traceapi.o \
 	handlers/tracepage.o \
-	handlers/discarthandler.o
+	handlers/discarthandler.o \
+	handlers/deleteapi.o
 
 libwebserver.a: $(OBJS)
 	@echo "  AR    $@"

--- a/addon/webserver/handlers/deleteapi.cpp
+++ b/addon/webserver/handlers/deleteapi.cpp
@@ -1,0 +1,65 @@
+#include <circle/logger.h>
+#include <circle/net/httpdaemon.h>
+#include <circle/sched/scheduler.h>
+#include <fatfs/ff.h>
+#include <json/json.hpp>
+#include <scsitbservice/scsitbservice.h>
+#include <string>
+#include <cstring>
+#include <map>
+#include "deleteapi.h"
+#include "../util.h"
+
+LOGMODULE("deleteapi");
+
+THTTPStatus DeleteImageAPIHandler::GetJson(nlohmann::json& j,
+                const char *pPath,
+                const char *pParams,
+                const char *pFormData)
+{
+    auto params = parse_query_params(pParams);
+    auto it = params.find("file");
+    if (it == params.end() || it->second.empty()) {
+        j["status"] = "error";
+        j["error"] = "missing file parameter";
+        return HTTPOK;
+    }
+
+    std::string rel = it->second;
+    if (rel.find("..") != std::string::npos || rel[0] == '/') {
+        j["status"] = "error";
+        j["error"] = "invalid path";
+        return HTTPOK;
+    }
+
+    SCSITBService* svc = static_cast<SCSITBService*>(
+        CScheduler::Get()->GetTask("scsitbservice"));
+    if (!svc) {
+        return HTTPInternalServerError;
+    }
+
+    std::string full = "1:/" + rel;
+
+    const char* current = svc->GetCurrentCDPath();
+    if (current && full == current) {
+        j["status"] = "error";
+        j["error"] = "cannot delete the mounted image - mount another one first";
+        return HTTPOK;
+    }
+
+    FRESULT res = f_unlink(full.c_str());
+    if (res != FR_OK) {
+        LOGERR("f_unlink(%s) failed: %d", full.c_str(), (int)res);
+        j["status"] = "error";
+        j["error"] = std::string("delete failed (") +
+                     (res == FR_NO_FILE || res == FR_NO_PATH ? "not found" : "fs error") + ")";
+        return HTTPOK;
+    }
+
+    LOGNOTE("Deleted image %s", full.c_str());
+    svc->RefreshCache();
+
+    j["status"] = "ok";
+    j["deleted"] = rel;
+    return HTTPOK;
+}

--- a/addon/webserver/handlers/deleteapi.h
+++ b/addon/webserver/handlers/deleteapi.h
@@ -1,0 +1,17 @@
+#ifndef _webserver_handlers_deleteapi_h
+#define _webserver_handlers_deleteapi_h
+
+#include "apihandlerbase.h"
+
+// DELETE an image from the images volume: /api/images/delete?file=<relativePath>
+// Refuses to delete the currently mounted image.
+class DeleteImageAPIHandler : public APIHandlerBase
+{
+public:
+    THTTPStatus GetJson(nlohmann::json& j,
+                        const char *pPath,
+                        const char *pParams,
+                        const char *pFormData) override;
+};
+
+#endif

--- a/addon/webserver/pagehandlerregistry.cpp
+++ b/addon/webserver/pagehandlerregistry.cpp
@@ -23,6 +23,7 @@
 #include "handlers/traceapi.h"
 #include "handlers/tracepage.h"
 #include "handlers/discarthandler.h"
+#include "handlers/deleteapi.h"
 
 // instances of your page handlers
 static HomePageHandler s_homePageHandler;
@@ -42,6 +43,7 @@ static TraceAPIHandler s_traceAPIHandler;
 static TraceDownloadHandler s_traceDownloadHandler;
 static TracePageHandler s_tracePageHandler;
 static DiscArtHandler s_discArtHandler;
+static DeleteImageAPIHandler s_deleteImageAPIHandler;
 
 // routes for your handlers
 static const std::map<std::string, IPageHandler*> g_pageHandlers = {
@@ -66,6 +68,9 @@ static const std::map<std::string, IPageHandler*> g_pageHandlers = {
     { "/api/trace/save", &s_traceAPIHandler },
     { "/usbode.utrace", &s_traceDownloadHandler },
     { "/trace", &s_tracePageHandler },
+    // /api/images/upload is dispatched directly in CWebServer::GetContent
+    // (it needs the protected multipart API), not through this registry.
+    { "/api/images/delete", &s_deleteImageAPIHandler },
 
     // Disc art
     { "/discart", &s_discArtHandler },

--- a/addon/webserver/pages/index.html
+++ b/addon/webserver/pages/index.html
@@ -25,10 +25,10 @@
 			{{/is_folder}}
 			{{^is_folder}}
 			{{#flat_display_path}}
-			<div class="file{{{style}}}"><a href="/mount?file={{file_path_encoded}}">{{file_path}}</a>{{current}}</div>
+			<div class="file{{{style}}}"><a href="/mount?file={{file_path_encoded}}">{{file_path}}</a>{{current}} <a href="#" class="delete-image" title="Delete image" onclick="deleteImage('{{file_path_encoded}}');return false">&#10006;</a></div>
 			{{/flat_display_path}}
 			{{^flat_display_path}}
-			<div class="file{{{style}}}"><a href="/mount?file={{file_path_encoded}}">{{file_name}}</a>{{current}}</div>
+			<div class="file{{{style}}}"><a href="/mount?file={{file_path_encoded}}">{{file_name}}</a>{{current}} <a href="#" class="delete-image" title="Delete image" onclick="deleteImage('{{file_path_encoded}}');return false">&#10006;</a></div>
 			{{/flat_display_path}}
 			{{/is_folder}}
 		{{/links}}
@@ -50,4 +50,74 @@
 		{{/pages}}
 	</div>
 	{{/pagination}}
+
+	<h4>Upload Image</h4>
+	<div class="info-box">
+		<input type="file" id="upload-file" accept=".iso,.bin,.cue,.chd,.mds,.mdf,.img">
+		<button type="button" id="upload-btn" onclick="uploadImage()">Upload</button>
+		<div id="upload-status"></div>
+	</div>
+	<script>
+	async function uploadImage() {
+		var input = document.getElementById('upload-file');
+		var st = document.getElementById('upload-status');
+		var btn = document.getElementById('upload-btn');
+		if (!input.files.length) { st.textContent = 'Choose a file first.'; return; }
+		var f = input.files[0];
+		// Server multipart buffer is ~1 MB; chunk + boundary must fit.
+		var CHUNK = 1024 * 1024;
+		var name = encodeURIComponent(f.name);
+		btn.disabled = true;
+		try {
+			var off = 0;
+			do {
+				var end = Math.min(off + CHUNK, f.size);
+				var done = (end >= f.size) ? 1 : 0;
+				// Retry transient network failures (WiFi hiccups abort
+				// Safari fetches easily); server-side errors still abort.
+				var j = null;
+				for (var attempt = 1; ; attempt++) {
+					try {
+						var fd = new FormData();
+						fd.append('chunk', f.slice(off, end), f.name);
+						var r = await fetch('/api/images/upload?name=' + name +
+						                    '&offset=' + off + '&done=' + done,
+						                    { method: 'POST', body: fd });
+						j = await r.json();
+						break;
+					} catch (e) {
+						if (attempt >= 5) throw e;
+						st.textContent = 'Uploading ' + f.name + ': retrying chunk (attempt ' +
+							(attempt + 1) + ' of 5) ...';
+						await new Promise(function (res) { setTimeout(res, attempt * 2000); });
+					}
+				}
+				if (j.status !== 'ok') {
+					st.textContent = 'Upload failed: ' + (j.error || 'server error');
+					return;
+				}
+				off = end;
+				st.textContent = 'Uploading ' + f.name + ': ' +
+					(f.size ? Math.round(off / f.size * 100) : 100) + '%';
+			} while (off < f.size);
+			st.textContent = 'Upload complete: ' + f.name;
+			setTimeout(function () { location.reload(); }, 800);
+		} catch (e) {
+			st.textContent = 'Upload failed after retries: ' + e;
+		} finally {
+			btn.disabled = false;
+		}
+	}
+	async function deleteImage(encodedPath) {
+		var name = decodeURIComponent(encodedPath);
+		if (!confirm('Delete ' + name + ' from the SD card?')) return;
+		var r = await fetch('/api/images/delete?file=' + encodedPath);
+		var j = await r.json();
+		if (j.status !== 'ok') {
+			alert(j.error || 'Delete failed');
+			return;
+		}
+		location.reload();
+	}
+	</script>
 {{/cdrom}}

--- a/addon/webserver/webserver.cpp
+++ b/addon/webserver/webserver.cpp
@@ -22,13 +22,20 @@
 
 #include <assert.h>
 #include <circle/logger.h>
-#include <circle/new.h>
 #include <circle/string.h>
+#include <scsitbservice/scsitbservice.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
 #include "pagehandlerregistry.h"
+#include "util.h"
 
 // Large enough for a Trace Lab capture up to trace_buffer_kb=1024 (plus
 // file header) to be downloaded via /usbode.utrace in a single response.
 #define MAX_CONTENT_SIZE 1114112
+// Multipart buffer for /api/images/upload: fits one 1 MB chunk from the
+// browser-side chunked uploader plus multipart boundary overhead.
+#define MAX_UPLOAD_PART_SIZE 1114112
 #define MAX_FILES 1024
 #define MAX_FILES_PER_PAGE 50
 #define MAX_FILENAME 255
@@ -39,7 +46,7 @@
 LOGMODULE("webserver");
 
 CWebServer::CWebServer (CNetSubSystem *pNetSubSystem, CActLED *pActLED, CSocket *pSocket)
-:       CHTTPDaemon (pNetSubSystem, pSocket, MAX_CONTENT_SIZE),
+:       CHTTPDaemon (pNetSubSystem, pSocket, MAX_CONTENT_SIZE, HTTP_PORT, MAX_UPLOAD_PART_SIZE),
         m_pActLED (pActLED)
 {
     cdromservice = static_cast<CDROMService*>(CScheduler::Get()->GetTask("cdromservice"));
@@ -63,11 +70,148 @@ THTTPStatus CWebServer::GetContent (const char  *pPath,
                                    unsigned    *pLength,
                                    const char **ppContentType)
 {
+    // Handled here rather than in a registry handler because the multipart
+    // body is only reachable via CHTTPDaemon::GetMultipartFormPart(), which
+    // is a protected member of this class.
+    if (strcmp(pPath, "/api/images/upload") == 0)
+        return HandleImageUpload(pParams, pBuffer, pLength, ppContentType);
+
     IPageHandler* handler = PageHandlerRegistry::getHandler(pPath);
 
     if (handler)
 	    return handler->GetContent(pPath, pParams, pFormData, pBuffer, pLength, ppContentType);
 
     return HTTPInternalServerError;
+}
+
+static THTTPStatus UploadReply (u8 *pBuffer, unsigned *pLength,
+                                const char **ppContentType, const char *pJson)
+{
+    unsigned n = strlen(pJson);
+    if (n >= *pLength)
+        return HTTPInternalServerError;
+    memcpy(pBuffer, pJson, n);
+    *pLength = n;
+    *ppContentType = "application/json";
+    return HTTPOK;
+}
+
+THTTPStatus CWebServer::HandleImageUpload (const char *pParams,
+                                           u8 *pBuffer,
+                                           unsigned *pLength,
+                                           const char **ppContentType)
+{
+    auto params = parse_query_params(pParams);
+    std::string name = params.count("name") ? params["name"] : "";
+    unsigned long offset = params.count("offset")
+        ? strtoul(params["offset"].c_str(), nullptr, 10) : 0;
+    boolean bDone = params.count("done") && params["done"] == "1";
+
+    // Uploads land in the root of the images volume; reject anything that
+    // could escape it or collide with in-progress upload temp files.
+    if (name.empty() || name.length() > 200 || name[0] == '.'
+        || name.find('/') != std::string::npos
+        || name.find('\\') != std::string::npos
+        || name.find("..") != std::string::npos)
+        return UploadReply(pBuffer, pLength, ppContentType,
+                           "{\"status\":\"error\",\"error\":\"invalid file name\"}");
+
+    std::string partPath = "1:/" + name + ".part";
+    std::string finalPath = "1:/" + name;
+
+    const char *pHeader;
+    const u8 *pData;
+    unsigned nDataLength = 0;
+    if (!GetMultipartFormPart(&pHeader, &pData, &nDataLength))
+    {
+        pData = nullptr;
+        nDataLength = 0; // final rename-only request or empty file
+    }
+
+    FIL file;
+    FRESULT res;
+    if (offset == 0)
+    {
+        res = f_open(&file, partPath.c_str(), FA_WRITE | FA_CREATE_ALWAYS);
+    }
+    else
+    {
+        res = f_open(&file, partPath.c_str(), FA_WRITE | FA_OPEN_EXISTING);
+        if (res == FR_OK && f_size(&file) != offset)
+        {
+            unsigned long haveSize = (unsigned long)f_size(&file);
+            f_close(&file);
+            if (haveSize == offset + nDataLength && !bDone)
+            {
+                // Retry of a chunk that was already written but whose
+                // response got lost - acknowledge it instead of failing.
+                char reply[96];
+                snprintf(reply, sizeof(reply),
+                         "{\"status\":\"ok\",\"received\":%u,\"size\":%lu}",
+                         nDataLength, haveSize);
+                return UploadReply(pBuffer, pLength, ppContentType, reply);
+            }
+            // Chunk out of sequence; the uploader must restart.
+            LOGERR("Upload %s: offset %lu != file size %lu",
+                   name.c_str(), offset, haveSize);
+            return UploadReply(pBuffer, pLength, ppContentType,
+                               "{\"status\":\"error\",\"error\":\"chunk out of sequence, restart upload\"}");
+        }
+        if (res == FR_OK)
+            res = f_lseek(&file, offset);
+    }
+    if (res != FR_OK)
+        return UploadReply(pBuffer, pLength, ppContentType,
+                           "{\"status\":\"error\",\"error\":\"cannot open file on images volume\"}");
+
+    if (nDataLength > 0)
+    {
+        UINT written = 0;
+        res = f_write(&file, pData, nDataLength, &written);
+        if (res != FR_OK || written != nDataLength)
+        {
+            f_close(&file);
+            f_unlink(partPath.c_str());
+            LOGERR("Upload %s: write failed at offset %lu (res=%d, wrote %u/%u)",
+                   name.c_str(), offset, (int)res, written, nDataLength);
+            return UploadReply(pBuffer, pLength, ppContentType,
+                               "{\"status\":\"error\",\"error\":\"write failed (card full?)\"}");
+        }
+    }
+    f_close(&file);
+
+    if (bDone)
+    {
+        SCSITBService* svc = static_cast<SCSITBService*>(
+            CScheduler::Get()->GetTask("scsitbservice"));
+
+        const char *current = svc ? svc->GetCurrentCDPath() : nullptr;
+        if (current && finalPath == current)
+        {
+            f_unlink(partPath.c_str());
+            return UploadReply(pBuffer, pLength, ppContentType,
+                               "{\"status\":\"error\",\"error\":\"cannot replace the mounted image\"}");
+        }
+
+        f_unlink(finalPath.c_str()); // ignore result; may not exist
+        res = f_rename(partPath.c_str(), finalPath.c_str());
+        if (res != FR_OK)
+        {
+            LOGERR("Upload %s: rename failed (res=%d)", name.c_str(), (int)res);
+            return UploadReply(pBuffer, pLength, ppContentType,
+                               "{\"status\":\"error\",\"error\":\"rename failed\"}");
+        }
+
+        LOGNOTE("Upload complete: %s (%lu bytes)",
+                finalPath.c_str(), offset + nDataLength);
+        if (svc)
+            svc->RefreshCache();
+    }
+
+    char reply[96];
+    snprintf(reply, sizeof(reply),
+             "{\"status\":\"ok\",\"received\":%u,\"size\":%lu}",
+             nDataLength, offset + nDataLength);
+    return UploadReply(pBuffer, pLength, ppContentType, reply);
 }
 

--- a/addon/webserver/webserver.cpp
+++ b/addon/webserver/webserver.cpp
@@ -103,8 +103,10 @@ THTTPStatus CWebServer::HandleImageUpload (const char *pParams,
 {
     auto params = parse_query_params(pParams);
     std::string name = params.count("name") ? params["name"] : "";
-    unsigned long offset = params.count("offset")
-        ? strtoul(params["offset"].c_str(), nullptr, 10) : 0;
+    // strtoull, not strtoul: unsigned long is 32-bit on AARCH32 kernels,
+    // which silently clamped offsets of >4 GB uploads.
+    unsigned long long offset = params.count("offset")
+        ? strtoull(params["offset"].c_str(), nullptr, 10) : 0;
     boolean bDone = params.count("done") && params["done"] == "1";
 
     // Uploads land in the root of the images volume; reject anything that
@@ -139,7 +141,7 @@ THTTPStatus CWebServer::HandleImageUpload (const char *pParams,
         res = f_open(&file, partPath.c_str(), FA_WRITE | FA_OPEN_EXISTING);
         if (res == FR_OK && f_size(&file) != offset)
         {
-            unsigned long haveSize = (unsigned long)f_size(&file);
+            unsigned long long haveSize = f_size(&file);
             f_close(&file);
             if (haveSize == offset + nDataLength && !bDone)
             {
@@ -147,12 +149,12 @@ THTTPStatus CWebServer::HandleImageUpload (const char *pParams,
                 // response got lost - acknowledge it instead of failing.
                 char reply[96];
                 snprintf(reply, sizeof(reply),
-                         "{\"status\":\"ok\",\"received\":%u,\"size\":%lu}",
+                         "{\"status\":\"ok\",\"received\":%u,\"size\":%llu}",
                          nDataLength, haveSize);
                 return UploadReply(pBuffer, pLength, ppContentType, reply);
             }
             // Chunk out of sequence; the uploader must restart.
-            LOGERR("Upload %s: offset %lu != file size %lu",
+            LOGERR("Upload %s: offset %llu != file size %llu",
                    name.c_str(), offset, haveSize);
             return UploadReply(pBuffer, pLength, ppContentType,
                                "{\"status\":\"error\",\"error\":\"chunk out of sequence, restart upload\"}");
@@ -172,7 +174,7 @@ THTTPStatus CWebServer::HandleImageUpload (const char *pParams,
         {
             f_close(&file);
             f_unlink(partPath.c_str());
-            LOGERR("Upload %s: write failed at offset %lu (res=%d, wrote %u/%u)",
+            LOGERR("Upload %s: write failed at offset %llu (res=%d, wrote %u/%u)",
                    name.c_str(), offset, (int)res, written, nDataLength);
             return UploadReply(pBuffer, pLength, ppContentType,
                                "{\"status\":\"error\",\"error\":\"write failed (card full?)\"}");
@@ -202,7 +204,7 @@ THTTPStatus CWebServer::HandleImageUpload (const char *pParams,
                                "{\"status\":\"error\",\"error\":\"rename failed\"}");
         }
 
-        LOGNOTE("Upload complete: %s (%lu bytes)",
+        LOGNOTE("Upload complete: %s (%llu bytes)",
                 finalPath.c_str(), offset + nDataLength);
         if (svc)
             svc->RefreshCache();
@@ -210,7 +212,7 @@ THTTPStatus CWebServer::HandleImageUpload (const char *pParams,
 
     char reply[96];
     snprintf(reply, sizeof(reply),
-             "{\"status\":\"ok\",\"received\":%u,\"size\":%lu}",
+             "{\"status\":\"ok\",\"received\":%u,\"size\":%llu}",
              nDataLength, offset + nDataLength);
     return UploadReply(pBuffer, pLength, ppContentType, reply);
 }

--- a/addon/webserver/webserver.h
+++ b/addon/webserver/webserver.h
@@ -56,6 +56,13 @@ class CWebServer : public CHTTPDaemon {
                           u8          *pBuffer,
                           unsigned    *pLength,
                           const char **ppContentType);
+
+    // Chunked image upload (/api/images/upload); lives here because it
+    // needs the protected CHTTPDaemon::GetMultipartFormPart().
+    THTTPStatus HandleImageUpload (const char *pParams,
+                                   u8 *pBuffer,
+                                   unsigned *pLength,
+                                   const char **ppContentType);
 private:
     CActLED *m_pActLED;
     CDROMService *cdromservice = nullptr;


### PR DESCRIPTION
> **Stacked on #212 — merge that first.** (7 files, +314/−5 on top of PR 2.)

Adds image upload and per-file delete to the main page, so images can be managed without an FTP client — a request that comes up regularly, and a big quality-of-life win when iterating on test images.

## Upload
- Browser-side **1 MB chunking** through Circle's multipart form support (enabled via the `CHTTPDaemon` max-multipart-size ctor argument, previously unset/disabled in USBODE). Works within the stock HTTP daemon — no protocol changes.
- Chunks stream to a `.part` file that is **renamed into place only on the final chunk**, so an interrupted upload never leaves a truncated image visible.
- Per-chunk **retry ×5 with backoff** on transient network failures, and the server acknowledges duplicate chunks idempotently — a WiFi hiccup mid-upload resumes instead of failing (Safari aborts fetches easily on marginal WiFi).
- Filename validation (no traversal, no hidden files), offset cross-check against the file size on card, refuses to overwrite the currently mounted image.
- Throughput ≈ 20 % slower than FTP for a full ISO (measured 2:14 vs 1:50) — acceptable for the convenience.

## Delete
- Per-file ✕ link with confirmation; `/api/images/delete` refuses to delete the currently mounted image; the image list refreshes after either operation.

**Tested:** full-ISO uploads over WiFi incl. deliberate interruption/retry; MD5-verified round-trips (upload → FTP download → compare) on both 64-bit and 32-bit kernels; 40-chunk server stress test; delete + mounted-image guard verified.