### PR TITLE
Post-3.2.0 fixes: log level, .cue listing, read-ahead cache, Win98-derived SCSI compat

### DIFF
--- a/addon/configservice/cmdline.cpp
+++ b/addon/configservice/cmdline.cpp
@@ -54,6 +54,15 @@ bool CmdLine::Load(const char* filename) {
                 strcpy(pairs[count].value, equal + 1);
                 ++count;
             }
+        } else {
+            // Keep bare tokens (options without a value) so that Save()
+            // doesn't silently drop them when rewriting the file
+            size_t key_len = strlen(token);
+            if (key_len > 0 && key_len < MAX_KEY_LEN) {
+                strcpy(pairs[count].key, token);
+                pairs[count].value[0] = '\0';
+                ++count;
+            }
         }
         token = strtok_r(nullptr, " ", &saveptr);
     }
@@ -90,7 +99,9 @@ bool CmdLine::Save() {
     size_t pos = 0;
 
     for (int i = 0; i < count; ++i) {
-        int n = sprintf(line + pos, "%s=%s", pairs[i].key, pairs[i].value);
+        int n = (pairs[i].value[0] != '\0')
+                    ? sprintf(line + pos, "%s=%s", pairs[i].key, pairs[i].value)
+                    : sprintf(line + pos, "%s", pairs[i].key);
         if (n < 0 || pos + (size_t)n >= sizeof(line)) {
             f_close(&file);
             LOGNOTE("Failed: buffer overflow");

--- a/addon/discimage/cuebinfile.cpp
+++ b/addon/discimage/cuebinfile.cpp
@@ -55,15 +55,19 @@ CCueBinFileDevice::CCueBinFileDevice(FIL *pFile, char *cue_str, MEDIA_TYPE media
         m_nLogicalPos = f_tell(m_pFile);
     }
 
-    m_pCacheBuffer = new u8[CacheSize];
+    for (int i = 0; i < NumCacheWindows; i++) {
+        m_CacheWindows[i].pBuffer = new u8[CacheSize];
+    }
 }
 
 CCueBinFileDevice::~CCueBinFileDevice(void) {
     // NEW: Use shared Fast Seek helper
     FatFsOptimizer::DisableFastSeek(&m_pCLMT);
 
-    delete[] m_pCacheBuffer;
-    m_pCacheBuffer = nullptr;
+    for (int i = 0; i < NumCacheWindows; i++) {
+        delete[] m_CacheWindows[i].pBuffer;
+        m_CacheWindows[i].pBuffer = nullptr;
+    }
 
     if (m_pFile) {
         f_close(m_pFile);
@@ -84,16 +88,20 @@ int CCueBinFileDevice::Read(void *pBuffer, size_t nSize) {
     }
 
     // Cache hit: entirely served from RAM, no SD card access.
-    if (m_pCacheBuffer && nSize <= m_nCacheLen &&
-        m_nLogicalPos >= m_nCacheStart &&
-        m_nLogicalPos + nSize <= m_nCacheStart + m_nCacheLen) {
-        memcpy(pBuffer, m_pCacheBuffer + (m_nLogicalPos - m_nCacheStart), nSize);
-        m_nLogicalPos += nSize;
-        return nSize;
+    for (int i = 0; i < NumCacheWindows; i++) {
+        CacheWindow &win = m_CacheWindows[i];
+        if (win.pBuffer && nSize <= win.nLen &&
+            m_nLogicalPos >= win.nStart &&
+            m_nLogicalPos + nSize <= win.nStart + win.nLen) {
+            memcpy(pBuffer, win.pBuffer + (m_nLogicalPos - win.nStart), nSize);
+            m_nLogicalPos += nSize;
+            win.nLastUse = ++m_nCacheUseCounter;
+            return nSize;
+        }
     }
 
     // Requests larger than the cache go straight through and don't disturb it.
-    if (!m_pCacheBuffer || nSize > CacheSize) {
+    if (!m_CacheWindows[0].pBuffer || nSize > CacheSize) {
         FRESULT result = f_lseek(m_pFile, m_nLogicalPos);
         if (result != FR_OK) {
             LOGERR("Seek to offset %llu failed, err %d", m_nLogicalPos, result);
@@ -110,8 +118,29 @@ int CCueBinFileDevice::Read(void *pBuffer, size_t nSize) {
         return nBytesRead;
     }
 
-    // Cache miss: read a larger window than requested, so the next
-    // sequential read (the common case) is served from the cache.
+    // Cache miss: refill a window with a larger read than requested, so
+    // the next sequential read of this stream (the common case) is served
+    // from the cache. Prefer the window this stream just ran off the end
+    // of - plain LRU would pick the other stream's window here, since our
+    // own was touched most recently - and fall back to least recently
+    // used, so the window the other stream is running in is left alone.
+    CacheWindow *pVictim = nullptr;
+    for (int i = 0; i < NumCacheWindows; i++) {
+        CacheWindow &win = m_CacheWindows[i];
+        if (win.pBuffer && win.nLen > 0 && win.nStart + win.nLen == m_nLogicalPos) {
+            pVictim = &win;
+            break;
+        }
+    }
+    if (pVictim == nullptr) {
+        for (int i = 0; i < NumCacheWindows; i++) {
+            CacheWindow &win = m_CacheWindows[i];
+            if (win.pBuffer && (!pVictim || win.nLastUse < pVictim->nLastUse)) {
+                pVictim = &win;
+            }
+        }
+    }
+
     FRESULT result = f_lseek(m_pFile, m_nLogicalPos);
     if (result != FR_OK) {
         LOGERR("Seek to offset %llu failed, err %d", m_nLogicalPos, result);
@@ -119,18 +148,19 @@ int CCueBinFileDevice::Read(void *pBuffer, size_t nSize) {
     }
 
     UINT nBytesRead = 0;
-    result = f_read(m_pFile, m_pCacheBuffer, CacheSize, &nBytesRead);
+    result = f_read(m_pFile, pVictim->pBuffer, CacheSize, &nBytesRead);
     if (result != FR_OK) {
         LOGERR("Failed to read %d bytes into memory, err %d", (int)CacheSize, result);
-        m_nCacheLen = 0;
+        pVictim->nLen = 0;
         return -1;
     }
 
-    m_nCacheStart = m_nLogicalPos;
-    m_nCacheLen = nBytesRead;
+    pVictim->nStart = m_nLogicalPos;
+    pVictim->nLen = nBytesRead;
+    pVictim->nLastUse = ++m_nCacheUseCounter;
 
     size_t nServe = ((size_t)nBytesRead < nSize) ? (size_t)nBytesRead : nSize;
-    memcpy(pBuffer, m_pCacheBuffer, nServe);
+    memcpy(pBuffer, pVictim->pBuffer, nServe);
     m_nLogicalPos += nServe;
     return nServe;
 }

--- a/addon/discimage/cuebinfile.h
+++ b/addon/discimage/cuebinfile.h
@@ -76,10 +76,21 @@ class CCueBinFileDevice : public ICueDevice {
     // Redbook streaming) becomes a cache hit instead of another SD card
     // access - this avoids the additional read latency showing up as
     // stutter on the low-bandwidth USB 1.1 link.
+    //
+    // Two windows, LRU-replaced: CD audio playback and host data reads are
+    // both sequential but run at different file positions, so a single
+    // window thrashes (each stream's miss evicts the other stream's
+    // window). One window per stream keeps both sequential.
+    struct CacheWindow {
+        u8* pBuffer = nullptr;
+        u64 nStart = 0;
+        size_t nLen = 0;
+        unsigned nLastUse = 0;
+    };
     static constexpr size_t CacheSize = 128 * 1024;
-    u8* m_pCacheBuffer = nullptr;
-    u64 m_nCacheStart = 0;
-    size_t m_nCacheLen = 0;
+    static constexpr int NumCacheWindows = 2;
+    CacheWindow m_CacheWindows[NumCacheWindows];
+    unsigned m_nCacheUseCounter = 0;
     u64 m_nLogicalPos = 0;
     
     static constexpr const char* default_cue_sheet =

--- a/addon/filelogdaemon/filelogdaemon.cpp
+++ b/addon/filelogdaemon/filelogdaemon.cpp
@@ -32,14 +32,23 @@ LOGMODULE("filelogdaemon");
 
 CFileLogDaemon *CFileLogDaemon::s_pThis = nullptr;
 
-CFileLogDaemon::CFileLogDaemon(const char *pLogFilePath)
-    : m_pLogFilePath(pLogFilePath) {
+CFileLogDaemon::CFileLogDaemon(const char *pLogFilePath, unsigned uiLogLevel)
+    : m_pLogFilePath(pLogFilePath),
+      m_uiLogLevel(uiLogLevel > 5 ? 5 : uiLogLevel) {
     // I am the one and only!
     assert(s_pThis == nullptr);
     s_pThis = this;
 
     SetName(FromFileLogDaemon);
     Initialize();
+}
+
+CFileLogDaemon *CFileLogDaemon::Get(void) {
+    return s_pThis;
+}
+
+void CFileLogDaemon::SetLogLevel(unsigned uiLogLevel) {
+    m_uiLogLevel = uiLogLevel > 5 ? 5 : uiLogLevel;
 }
 
 boolean CFileLogDaemon::Initialize() {
@@ -96,6 +105,13 @@ void CFileLogDaemon::Run(void) {
         int nTimeZone;
         while (pLogger->ReadEvent(&Severity, Source, Message,
                                   &Time, &nHundredthTime, &nTimeZone)) {
+            // CLogger queues every event regardless of its loglevel (that
+            // only filters the serial/screen target), so the configured
+            // level is applied here. Severity LogPanic(0)..LogDebug(4)
+            // maps to config levels 1..5; level 0 drops everything.
+            if ((unsigned)Severity >= m_uiLogLevel) {
+                continue;
+            }
             if (!LogMessage(Severity, Time, nHundredthTime, nTimeZone, Source, Message)) {
                 CScheduler::Get()->Sleep(20);
             }

--- a/addon/filelogdaemon/filelogdaemon.h
+++ b/addon/filelogdaemon/filelogdaemon.h
@@ -34,10 +34,19 @@
 
 class CFileLogDaemon : public CTask {
    public:
-    CFileLogDaemon(const char *pLogFilePath);
+    // uiLogLevel uses the USBODE config scale (0=no logging, 1=panic only,
+    // 2=+errors, 3=+warnings, 4=+notices, 5=+debug). This is one more than
+    // Circle's TLogSeverity, whose scale has no "off" value.
+    CFileLogDaemon(const char *pLogFilePath, unsigned uiLogLevel = 4);
     ~CFileLogDaemon(void);
     boolean Initialize();
     void Run(void);
+
+    // Takes effect immediately; only affects the log file, not the
+    // loglevel= filtering Circle applies to the serial/screen target.
+    void SetLogLevel(unsigned uiLogLevel);
+
+    static CFileLogDaemon *Get(void);
 
    private:
     boolean LogMessage(TLogSeverity Severity,
@@ -52,6 +61,7 @@ class CFileLogDaemon : public CTask {
     static CFileLogDaemon *s_pThis;
     boolean m_bFileInitialized;
     const char *m_pLogFilePath;
+    unsigned m_uiLogLevel;
     FIL m_LogFile;
 };
 

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -379,6 +379,29 @@ bool SCSITBService::RefreshCache() {
         }
     }
 
+    // A saved .bin whose cue/bin pair is now listed as the .cue: retry
+    // with the .cue path, so upgrading doesn't silently switch the
+    // mounted disc to the first entry
+    if (!found && searchPath && searchPath[0] != '\0') {
+        size_t len = strlen(searchPath);
+        if (len >= 4 && len < MAX_PATH_LEN && iequals(searchPath + len - 4, ".bin")) {
+            char cuePath[MAX_PATH_LEN];
+            memcpy(cuePath, searchPath, len - 4);
+            strcpy(cuePath + len - 4, ".cue");
+            for (size_t i = 0; i < m_FileCount; ++i) {
+                if (!m_FileEntries[i].isDirectory && strcasecmp(m_FileEntries[i].relativePath, cuePath) == 0) {
+                    if (current_cd < 0) {
+                        next_cd = i;
+                    }
+                    found = true;
+                    LOGNOTE("SCSITBService::RefreshCache() Current image %s now listed as %s (index %d)",
+                            searchPath, m_FileEntries[i].relativePath, (int)i);
+                    break;
+                }
+            }
+        }
+    }
+
     // Fallback to first image file if not found
     if (!found && m_FileCount > 0) {
         for (size_t i = 0; i < m_FileCount; ++i) {

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -51,6 +51,24 @@ static bool iequals(const char* a, const char* b) {
     return *a == *b;
 }
 
+// True if a file with the same stem but a different extension exists next to
+// fileName in dirFullPath (e.g. "game.bin" + ".cue" -> "1:/Games/game.cue").
+// FAT name matching is case-insensitive, so GAME.CUE is found too.
+static bool siblingWithExtExists(const char* dirFullPath, const char* fileName, const char* newExt) {
+    const char* dot = strrchr(fileName, '.');
+    if (dot == nullptr)
+        return false;
+
+    char sibling[MAX_PATH_LEN];
+    int n = snprintf(sibling, sizeof(sibling), "%s/%.*s%s",
+                     dirFullPath, (int)(dot - fileName), fileName, newExt);
+    if (n < 0 || (size_t)n >= sizeof(sibling))
+        return false;
+
+    FILINFO fi;
+    return f_stat(sibling, &fi) == FR_OK && !(fi.fattrib & AM_DIR);
+}
+
 int compareFileEntries(const void* a, const void* b) {
     const FileEntry* fa = (const FileEntry*)a;
     const FileEntry* fb = (const FileEntry*)b;
@@ -283,8 +301,17 @@ void SCSITBService::ScanDirectoryRecursive(const char* fullPath, const char* rel
             // Check for image files
             const char* ext = strrchr(fno.fname, '.');
             if (ext != nullptr) {
-                if (iequals(ext, ".iso") || iequals(ext, ".bin") || 
-                    iequals(ext, ".mds") || iequals(ext, ".chd") || iequals(ext, ".toast")) {
+                bool listIt = iequals(ext, ".iso") || iequals(ext, ".mds") ||
+                              iequals(ext, ".chd") || iequals(ext, ".toast");
+                if (!listIt && iequals(ext, ".cue")) {
+                    // Mounting a .cue opens the same-stem .bin, so only list
+                    // cue sheets whose data file is actually there
+                    listIt = siblingWithExtExists(fullPath, fno.fname, ".bin");
+                } else if (!listIt && iequals(ext, ".bin")) {
+                    // Hide the raw .bin of a cue/bin pair; its .cue is listed
+                    listIt = !siblingWithExtExists(fullPath, fno.fname, ".cue");
+                }
+                if (listIt) {
                     size_t len = my_strnlen(fno.fname, MAX_FILENAME_LEN - 1);
                     memcpy(m_FileEntries[m_FileCount].name, fno.fname, len);
                     m_FileEntries[m_FileCount].name[len] = '\0';

--- a/addon/usbcdgadget/cd_utils.cpp
+++ b/addon/usbcdgadget/cd_utils.cpp
@@ -309,13 +309,13 @@ int CDUtils::GetSkipbytesForTrack(CUSBCDGadget* gadget, CUETrackInfo trackInfo)
 
 int CDUtils::GetMediumType(CUSBCDGadget* gadget)
 {
-    // Modern MMC: Medium Type should be 0x00, rely on GET CONFIGURATION
-    if (gadget->m_USBTargetOS != USBTargetOS::Apple)
-    {
-        return 0x13;  // Modern drives return 0x13
-    }
-    
-    // Legacy Mac OS 9 needs actual detection
+    // Report the actual medium type (SFF-8020i codes) for every target OS.
+    // Win9x MCICDA reads this byte from the MODE SENSE header to decide
+    // whether a disc can play audio, and only accepts the classic codes
+    // (0x02 audio, 0x03 data+audio): the previous hardcoded 0x13
+    // ("CD-R data & audio") made it treat every disc as data-only
+    // ("data or no disc loaded", PLAY AUDIO never issued). Modern hosts
+    // ignore this byte in favor of GET CONFIGURATION.
     bool hasAudio = false;
     bool hasData = false;
     

--- a/addon/usbcdgadget/scsi_inquiry.cpp
+++ b/addon/usbcdgadget/scsi_inquiry.cpp
@@ -680,6 +680,19 @@ void SCSIInquiry::ModeSense10(CUSBCDGadget *gadget)
     if (allocationLength < length)
         length = allocationLength;
 
+    // Pad short responses up to the allocation length (BOT case Hi > Di:
+    // real drives pad instead of short-terminating). The Win9x/WinME
+    // usbstor.sys stack rejects and retries a MODE SENSE whose data phase
+    // ends short of the requested length, which blocked CD audio playback
+    // (volume query fails, PLAY is never sent). The mode data length
+    // field above still reports the true length, so padding bytes are
+    // ignored by well-behaved hosts.
+    if (length < allocationLength && allocationLength <= (int)sizeof(gadget->m_InBuffer))
+    {
+        memset(gadget->m_InBuffer + length, 0, allocationLength - length);
+        length = allocationLength;
+    }
+
     CDROM_DEBUG_LOG("SCSIInquiry::ModeSense10", "Mode Sense (%d), Sending response with length %d", cdbSize, length);
 
     gadget->m_nnumber_blocks = 0; // nothing more after this send

--- a/addon/usbcdgadget/scsi_toc.cpp
+++ b/addon/usbcdgadget/scsi_toc.cpp
@@ -50,6 +50,15 @@ void SCSITOC::ReadTOC(CUSBCDGadget *gadget)
         useBCD = true;
         CDROM_DEBUG_LOG("SCSITOC::ReadTOC", "Matshita vendor extension: Full TOC with BCD");
     }
+    else if (format == 0 && (gadget->m_CBW.CBWCB[9] & 0xC0) == 0x40)
+    {
+        // Old SFF-8020i/ATAPI encoding: TOC format in CDB[9] bits 7-6.
+        // Win9x's CD-ROM class driver requests session info this way;
+        // answering with a full TOC makes it misread the session count
+        // and refuse to play audio ("data or no disc loaded").
+        format = 1;
+        CDROM_DEBUG_LOG("SCSITOC::ReadTOC", "Legacy CDB[9] encoding: Session Info");
+    }
 
     CDROM_DEBUG_LOG("SCSITOC::ReadTOC", "Format=%d MSF=%d StartTrack=%d AllocLen=%d Control=0x%02x",
                     format, msf, startingTrack, allocationLength, gadget->m_CBW.CBWCB[9]);

--- a/addon/usbcdgadget/usbcdgadget.cpp
+++ b/addon/usbcdgadget/usbcdgadget.cpp
@@ -652,6 +652,10 @@ void CUSBCDGadget::OnTransferComplete(boolean bIn, size_t nLength)
         case TCDState::DataIn:
         {
             CTraceLab::Get()->TraceTransferComplete((u32)nLength);
+            if (m_CSW.dCSWDataResidue >= (u32)nLength)
+                m_CSW.dCSWDataResidue -= (u32)nLength;
+            else
+                m_CSW.dCSWDataResidue = 0;
             if (m_nnumber_blocks > 0)
             {
                 if (m_CDReady)
@@ -711,6 +715,12 @@ void CUSBCDGadget::OnTransferComplete(boolean bIn, size_t nLength)
                 break;
             }
             m_CSW.dCSWTag = m_CBW.dCBWTag;
+            // BOT 6.7: dCSWDataResidue = expected transfer length minus the
+            // amount actually transferred. Start at the full expected length;
+            // the data-phase completions below subtract what was moved.
+            // Strict hosts (Win98 USB storage stacks) discard a short
+            // response whose CSW claims residue 0 and retry the command.
+            m_CSW.dCSWDataResidue = m_CBW.dCBWDataTransferLength;
             if (m_CBW.bCBWCBLength <= 16 && m_CBW.bCBWLUN == 0) // meaningful CBW
             {
                 HandleSCSICommand(); // will update m_nstate
@@ -724,6 +734,11 @@ void CUSBCDGadget::OnTransferComplete(boolean bIn, size_t nLength)
             CDROM_DEBUG_LOG("OnXferComplete", "state = %i, dir = %s, len=%i ", m_nState, bIn ? "IN" : "OUT", nLength);
             // process block from host
             // assert(m_nnumber_blocks>0);
+
+            if (m_CSW.dCSWDataResidue >= (u32)nLength)
+                m_CSW.dCSWDataResidue -= (u32)nLength;
+            else
+                m_CSW.dCSWDataResidue = 0;
 
             ProcessOut(nLength);
 
@@ -907,7 +922,9 @@ void CUSBCDGadget::sendCheckCondition()
 void CUSBCDGadget::sendGoodStatus()
 {
     m_CSW.bmCSWStatus = CD_CSW_STATUS_OK;
-    m_CSW.dCSWDataResidue = 0; // Command succeeded, all data (if any) transferred
+    // dCSWDataResidue was initialized to the expected transfer length when
+    // the CBW arrived and decremented by the data-phase completions, so it
+    // is already correct here (full length if no data phase happened).
 
     SendCSW();
 }

--- a/addon/webserver/handlers/configpage.cpp
+++ b/addon/webserver/handlers/configpage.cpp
@@ -16,6 +16,7 @@
 #include "../util.h"
 #include <configservice/configservice.h>
 #include <cdplayer/cdplayer.h>
+#include <filelogdaemon/filelogdaemon.h>
 #include "../webglobals.h"
 
 
@@ -149,7 +150,14 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
             
             // Log level configuration
             if (form_params.count("loglevel")) {
-                config->SetLogLevel(std::atoi(form_params["loglevel"].c_str()));
+                int loglevel = std::atoi(form_params["loglevel"].c_str());
+                if (loglevel < 0) loglevel = 0;
+                if (loglevel > 5) loglevel = 5;
+                config->SetLogLevel(loglevel);
+                // Apply to the file log immediately; no reboot needed
+                if (CFileLogDaemon::Get() != nullptr) {
+                    CFileLogDaemon::Get()->SetLogLevel(loglevel);
+                }
             }
 
             // Trace Lab configuration

--- a/addon/webserver/handlers/configpage.cpp
+++ b/addon/webserver/handlers/configpage.cpp
@@ -203,7 +203,7 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
                 // Schedule a shutdown in 3 seconds
                 new CShutdown(ShutdownHalt, 3000);
             } else {
-                success_message = "Configuration saved successfully. Reboot required for changes to take effect.";
+                success_message = "Configuration saved successfully. Log level applies immediately; other changes take effect after a reboot.";
             }
         }
     }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -146,7 +146,7 @@ boolean CKernel::Initialize(void)
             const char *logfile = m_pConfigService->GetLogfile();
             if (logfile)
             {
-                new CFileLogDaemon(logfile);
+                new CFileLogDaemon(logfile, m_pConfigService->GetLogLevel());
                 // CScheduler::Get()->MsSleep(100);
                 LOGNOTE("Started early file logging");
             }


### PR DESCRIPTION
Post-3.2.0 bug fixes plus a set of SCSI/USB compatibility fixes that came out of debugging CD audio on a real Windows 98 SE machine (440LX, USB 1.1). Everything here has been hardware-tested on a Pi Zero 2 W.

## Bug fixes

- **Web UI log level now actually works.** Circle's `CLogger` queues every event for the file log daemon *before* checking the severity threshold, so `loglevel` only ever filtered the serial/screen target while the log file got everything. The filter is now applied in `filelogdaemon` itself. The level also applies live — the config page no longer (falsely) claims a reboot is required for it.
- **File browser lists `.cue` sheets instead of raw `.bin` files.** For a cue/bin pair, only the `.cue` is shown (previously both appeared, and picking the `.bin` mounted it without its cue sheet). Lone `.bin` files without a cue sheet are hidden.
  - **Upgrade migration:** if `current_image` in config.txt points at a `.bin` whose `.cue` exists, the scanner transparently remaps it to the `.cue` on first boot, so the mounted disc doesn't silently fall back to the first image in the list after upgrading.
- **Two-window read-ahead cache in the cue/bin layer.** The single read-ahead window thrashed when two streams hit the same file (e.g. CD audio playback while the host copies data). There are now two 128 KB windows with LRU eviction that prefers refilling the sequentially-continuing window. Validated: audio playback + 200 MB file copy concurrently over USB 1.1 with no audio skipping.
- **cmdline.txt bare tokens survive a config save.** Options without a value (e.g. flags) were dropped when the config service rewrote the file.

## SCSI/USB compatibility fixes (from the Win98 investigation)

These are real spec violations that affected every host; Win98's picky WinME-era `usbstor.sys` stack is just what exposed them:

- **READ TOC: honor the legacy SFF-8020i/ATAPI encoding** where the TOC format lives in CDB[9] bits 7–6 (session-info variant), alongside the existing Matshita full-TOC case.
- **CSW `dCSWDataResidue` was stale garbage on all data-in/data-out commands** — only explicit good/error status paths ever wrote it. It's now initialized to `dCBWDataTransferLength` at CBW receipt and decremented as data phases complete (USB BOT 6.7).
- **MODE SENSE medium type is now detected from the mounted disc** (data / audio / mixed) for all hosts instead of a hardcoded 0x13 for everyone except Apple. This is the fix that made Win98's CD Player list audio tracks at all.
- **Short MODE SENSE responses are padded to the requested allocation length**, matching real drive behavior for the BOT Hi > Di case.

### Win98 outcome, for the record

With all responses byte-perfect (verified via Trace Lab captures), Win98's CD Player still never issues PLAY AUDIO — MCICDA analog Red Book playback on USB CD drives appears to be a dead end in the Win9x driver stack itself, not something firmware can fix. Digital extraction (Winamp, READ CD 0xBE) works fine on the same machine.

## Release-notes flag

⚠️ The file-browser change is user-visible: cue/bin discs now appear as their `.cue` entry and the `.bin` no longer shows. Existing configs pointing at a `.bin` are migrated automatically.