### PR TITLE
ui: wrap the cursor around in the settings menus

### DIFF
--- a/addon/displayservice/sh1106/classicmacmodepage.cpp
+++ b/addon/displayservice/sh1106/classicmacmodepage.cpp
@@ -87,9 +87,9 @@ void SH1106ClassicMacModePage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/sh1106/configpage.cpp
+++ b/addon/displayservice/sh1106/configpage.cpp
@@ -115,9 +115,9 @@ void SH1106ConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
 	LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/sh1106/logconfigpage.cpp
+++ b/addon/displayservice/sh1106/logconfigpage.cpp
@@ -74,9 +74,9 @@ void SH1106LogConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/sh1106/powerpage.cpp
+++ b/addon/displayservice/sh1106/powerpage.cpp
@@ -81,9 +81,9 @@ void SH1106PowerPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/sh1106/soundconfig.cpp
+++ b/addon/displayservice/sh1106/soundconfig.cpp
@@ -104,9 +104,9 @@ void SH1106SoundConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/sh1106/timeoutconfigpage.cpp
+++ b/addon/displayservice/sh1106/timeoutconfigpage.cpp
@@ -145,9 +145,9 @@ void SH1106TimeoutConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(m_OptionCount))
         newIndex = static_cast<int>(m_OptionCount - 1);
+    else if (newIndex >= static_cast<int>(m_OptionCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
 	LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/sh1106/usbconfigpage.cpp
+++ b/addon/displayservice/sh1106/usbconfigpage.cpp
@@ -86,9 +86,9 @@ void SH1106USBConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/ssd1306/classicmacmodepage.cpp
+++ b/addon/displayservice/ssd1306/classicmacmodepage.cpp
@@ -87,9 +87,9 @@ void SSD1306ClassicMacModePage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/ssd1306/configpage.cpp
+++ b/addon/displayservice/ssd1306/configpage.cpp
@@ -115,9 +115,9 @@ void SSD1306ConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
 	LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/ssd1306/logconfigpage.cpp
+++ b/addon/displayservice/ssd1306/logconfigpage.cpp
@@ -74,9 +74,9 @@ void SSD1306LogConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/ssd1306/powerpage.cpp
+++ b/addon/displayservice/ssd1306/powerpage.cpp
@@ -81,9 +81,9 @@ void SSD1306PowerPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/ssd1306/soundconfig.cpp
+++ b/addon/displayservice/ssd1306/soundconfig.cpp
@@ -104,9 +104,9 @@ void SSD1306SoundConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/ssd1306/timeoutconfigpage.cpp
+++ b/addon/displayservice/ssd1306/timeoutconfigpage.cpp
@@ -145,9 +145,9 @@ void SSD1306TimeoutConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(m_OptionCount))
         newIndex = static_cast<int>(m_OptionCount - 1);
+    else if (newIndex >= static_cast<int>(m_OptionCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
 	LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/ssd1306/usbconfigpage.cpp
+++ b/addon/displayservice/ssd1306/usbconfigpage.cpp
@@ -86,9 +86,9 @@ void SSD1306USBConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/st7789/classicmacmodepage.cpp
+++ b/addon/displayservice/st7789/classicmacmodepage.cpp
@@ -88,9 +88,9 @@ void ST7789ClassicMacModePage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/st7789/configpage.cpp
+++ b/addon/displayservice/st7789/configpage.cpp
@@ -118,9 +118,9 @@ void ST7789ConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
 	LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/st7789/logconfigpage.cpp
+++ b/addon/displayservice/st7789/logconfigpage.cpp
@@ -73,9 +73,9 @@ void ST7789LogConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/st7789/lowpowertimeoutconfigpage.cpp
+++ b/addon/displayservice/st7789/lowpowertimeoutconfigpage.cpp
@@ -160,9 +160,9 @@ void ST7789LowPowerTimeoutConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(m_OptionCount))
         newIndex = static_cast<int>(m_OptionCount - 1);
+    else if (newIndex >= static_cast<int>(m_OptionCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
 	LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/st7789/powerpage.cpp
+++ b/addon/displayservice/st7789/powerpage.cpp
@@ -80,9 +80,9 @@ void ST7789PowerPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/st7789/soundconfig.cpp
+++ b/addon/displayservice/st7789/soundconfig.cpp
@@ -104,9 +104,9 @@ void ST7789SoundConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/st7789/timeoutconfigpage.cpp
+++ b/addon/displayservice/st7789/timeoutconfigpage.cpp
@@ -160,9 +160,9 @@ void ST7789TimeoutConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(m_OptionCount))
         newIndex = static_cast<int>(m_OptionCount - 1);
+    else if (newIndex >= static_cast<int>(m_OptionCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
 	LOGDBG("New menu index is %d", newIndex);

--- a/addon/displayservice/st7789/usbconfigpage.cpp
+++ b/addon/displayservice/st7789/usbconfigpage.cpp
@@ -85,9 +85,9 @@ void ST7789USBConfigPage::MoveSelection(int delta) {
     LOGDBG("Selected index is %d, Menu delta is %d", m_SelectedIndex, delta);
     int newIndex = static_cast<int>(m_SelectedIndex) + delta;
     if (newIndex < 0)
-        newIndex = 0;
-    else if (newIndex >= static_cast<int>(fileCount))
         newIndex = static_cast<int>(fileCount - 1);
+    else if (newIndex >= static_cast<int>(fileCount))
+        newIndex = 0;
 
     if (static_cast<size_t>(newIndex) != m_SelectedIndex) {
         LOGDBG("New menu index is %d", newIndex);


### PR DESCRIPTION
Reported against 3.2.2: in the settings menus the cursor stops dead at the top
and bottom entries, while the disc image list wraps around. Pressing up on the
first item should select the last one, and pressing down on the last should
return to the first.

The clamp was copy-pasted into every settings page rather than living in one
place, so this was not specific to any one panel or display. The same two-line
pattern appears 22 times across all three display drivers:

- `addon/displayservice/sh1106/`
- `addon/displayservice/ssd1306/`
- `addon/displayservice/st7789/`

covering the classic Mac mode, config, log config, power, sound, timeout and USB
config pages, plus the ST7789 low power timeout page. All of them now wrap
instead of clamping, so SH1106, SSD1306 and Pirate Audio behave identically and
match the image list.

Checked that the paginated config page still scrolls correctly with wrapping
enabled, and that the timeout page's `nullptr` sentinel remains unreachable.

Integration suite: 112 tests, 0 failed.

One pre-existing bug found while in here and deliberately **not** touched, since
it is unrelated to the cursor: the SH1106 timeout page draws 8 items at 10px on
a 64px display with no pagination, so the last entries are off screen.