### PR TITLE
eject: present a genuinely empty drive to the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ The browser interface is used to load images, shutdown/reboot the device, config
 
 The Web Interface displays a list of available images, and denotes the currently loaded image. Images can be switched at any time by clicking on them.
 
+### Ejecting a Disc
+
+USBODE can present an empty drive, the same as a real drive with no disc in it. Click *Eject Disc* on the homepage, or press the B button on a display HAT, and the drive stays empty until you click *Insert Disc*, press B again, or load another image. The eject state survives a power cycle: if you power the USBODE off while ejected, it comes back up as an empty drive, and the image you had loaded is remembered so Insert brings it straight back. Ejecting also works from the host itself, so the operating system's own eject command does what you would expect.
+
+**macOS users: eject from Finder, not from USBODE.** macOS locks the drive while a disc is mounted and then stops checking it, on the assumption that a locked disc cannot go anywhere. If you eject from the web interface or the HAT button instead, macOS keeps showing the disc until you click it in Finder, at which point it disappears and you get a "Disk Not Ejected Properly" warning. This is not a USBODE bug; it is what macOS does with any drive whose disc leaves without its permission. DOS, Windows and Linux all notice the eject on their own, so this only affects macOS.
+
 ### Configuration
 - The Configuration page can be used to change HAT settings, configure audio output, USB speed, and whether logging is enabled and how verbose it is.
 - The Display Configuration section lets you change what kind of HAT you have connected, if any. It also lets you change the screen's timeout, brightness when in use, brightness when asleep, and how long the sleep timeout is.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,18 @@ The Web Interface displays a list of available images, and denotes the currently
 
 ### Ejecting a Disc
 
-USBODE can present an empty drive, the same as a real drive with no disc in it. Click *Eject Disc* on the homepage, or press the B button on a display HAT, and the drive stays empty until you click *Insert Disc*, press B again, or load another image. The eject state survives a power cycle: if you power the USBODE off while ejected, it comes back up as an empty drive, and the image you had loaded is remembered so Insert brings it straight back. Ejecting also works from the host itself, so the operating system's own eject command does what you would expect.
+USBODE can present an empty drive, the same as a real drive with no disc in it. Click *Eject Disc* on the homepage and the drive stays empty until you click *Insert Disc* or load another image. Ejecting also works from the host itself, so the operating system's own eject command does what you would expect.
+
+**Tip: your HAT can eject too.** From the home screen, the same control both ejects and re-inserts:
+
+| HAT | Control |
+|-----|---------|
+| Waveshare OLED (SH1106 / SSD1306) | Push the joystick **down** |
+| Pirate Audio (ST7789) | Press the **B** button |
+
+Press it once to eject, again to insert. It only does this on the home screen — on any other page, down still moves the cursor. It also works even when the host has locked the drive, so it doubles as an emergency eject in the way a real drive's pinhole does. If you have set up a custom button mapping, this follows whichever button you assigned to *Down* rather than the defaults above.
+
+The eject state survives a power cycle: if you power the USBODE off while ejected, it comes back up as an empty drive, and the image you had loaded is remembered so Insert brings it straight back.
 
 **macOS users: eject from Finder, not from USBODE.** macOS locks the drive while a disc is mounted and then stops checking it, on the assumption that a locked disc cannot go anywhere. If you eject from the web interface or the HAT button instead, macOS keeps showing the disc until you click it in Finder, at which point it disappears and you get a "Disk Not Ejected Properly" warning. This is not a USBODE bug; it is what macOS does with any drive whose disc leaves without its permission. DOS, Windows and Linux all notice the eject on their own, so this only affects macOS.
 

--- a/addon/cdromservice/cdromservice.cpp
+++ b/addon/cdromservice/cdromservice.cpp
@@ -70,6 +70,35 @@ void CDROMService::SetDevice(IImageDevice *pDevice)
     m_CDGadget->SetDevice(pDevice);
 }
 
+void CDROMService::Eject(void)
+{
+    if (m_CDGadget)
+        m_CDGadget->Eject();
+}
+
+void CDROMService::Insert(void)
+{
+    if (m_CDGadget)
+        m_CDGadget->Insert();
+}
+
+bool CDROMService::IsEjected(void) const
+{
+    return m_CDGadget && m_CDGadget->IsEjected();
+}
+
+void CDROMService::ArmBootEject(void)
+{
+    if (m_CDGadget)
+        m_CDGadget->ArmBootEject();
+}
+
+void CDROMService::DisarmBootEject(void)
+{
+    if (m_CDGadget)
+        m_CDGadget->DisarmBootEject();
+}
+
 boolean CDROMService::Initialize()
 {
     LOGNOTE("CDROM Initializing");

--- a/addon/cdromservice/cdromservice.h
+++ b/addon/cdromservice/cdromservice.h
@@ -38,6 +38,14 @@ public:
     ~CDROMService(void);
     boolean Initialize();
     void SetDevice(IImageDevice* pDevice);
+    void Eject(void);
+    void Insert(void);
+    bool IsEjected(void) const;
+
+    // Boot restore: make the drive come up empty because it was ejected when it
+    // was last powered off. Must be armed before the first SetDevice().
+    void ArmBootEject(void);
+    void DisarmBootEject(void);
     void Run(void);
 
 private:

--- a/addon/configservice/configservice.cpp
+++ b/addon/configservice/configservice.cpp
@@ -213,6 +213,16 @@ void ConfigService::SetCurrentImage(const char* value)
     m_config->SetString("current_image", value);
 }
 
+bool ConfigService::GetEjected(bool defaultValue)
+{
+    return m_config->GetNumber("ejected", defaultValue ? 1 : 0) != 0;
+}
+
+void ConfigService::SetEjected(bool value)
+{
+    m_config->SetNumber("ejected", value ? 1 : 0);
+}
+
 void ConfigService::SetMode(unsigned value)
 {
     m_config->SetNumber("mode", value);

--- a/addon/configservice/configservice.h
+++ b/addon/configservice/configservice.h
@@ -22,6 +22,7 @@ public:
     static ConfigService* Get() { return s_pThis; }
 
     const char* GetCurrentImage(const char *defaultValue="image.iso");
+    bool GetEjected(bool defaultValue=false);
     unsigned GetDefaultVolume(unsigned defaultValue=255);
     const char* GetDisplayHat(const char *defaultValue="none");
     const char* GetTimezone(const char *defaultValue="UTC");
@@ -44,6 +45,7 @@ public:
     void SetLogfile(const char* value);
     void SetFlatFileList(bool value);
     void SetCurrentImage(const char* value);
+    void SetEjected(bool value);
     void SetDefaultVolume(unsigned value);
     void SetDisplayHat(const char* value);
     void SetTimezone(const char* value);

--- a/addon/displayservice/sh1106/homepage.cpp
+++ b/addon/displayservice/sh1106/homepage.cpp
@@ -41,6 +41,8 @@ void SH1106HomePage::OnEnter() {
     m_ISOScrollDirLeft = true;
 
     GetIPAddress(pIPAddress, sizeof(pIPAddress));
+    if (m_Service)
+        m_bEjectedShown = m_Service->IsEjected();
     Draw();
 }
 
@@ -66,8 +68,14 @@ void SH1106HomePage::OnButtonPress(Button button) {
             break;
 
         case Button::Down:
-            m_NextPageName = "imagespage";
-            m_ShouldChangePage = true;
+            // Down button: toggle eject / insert. Always works (emergency
+            // eject), even if the host locked the door.
+            if (m_Service) {
+                if (m_Service->IsEjected())
+                    m_Service->SetPendingInsert();
+                else
+                    m_Service->SetPendingEject();
+            }
             break;
 
         case Button::Cancel:
@@ -87,6 +95,12 @@ void SH1106HomePage::OnButtonPress(Button button) {
 }
 
 void SH1106HomePage::Refresh() {
+    // Redraw if the eject state changed (path may be unchanged across eject)
+    if (m_Service && m_Service->IsEjected() != m_bEjectedShown) {
+        Draw();
+        return;
+    }
+
     // Check if ISO path changed
     const char* currentPath = GetCurrentImagePath();
     if (strcmp(currentPath, pISOPath) != 0) {
@@ -107,8 +121,9 @@ void SH1106HomePage::Refresh() {
         return;
     }
 
-    // Scroll the ISO path if needed
-    RefreshISOScroll();
+    // Scroll the ISO path if needed (not while ejected - the path is hidden)
+    if (!(m_Service && m_Service->IsEjected()))
+        RefreshISOScroll();
 }
 
 void SH1106HomePage::GetIPAddress(char* buffer, size_t size) {
@@ -207,7 +222,14 @@ void SH1106HomePage::Draw() {
     size_t pathLen = strlen(pISOPath);
     int fullTextPx = (int)pathLen * m_ISOCharWidth;
 
-    if (fullTextPx <= m_ISOMaxTextPx) {
+    bool ejected = m_Service && m_Service->IsEjected();
+    m_bEjectedShown = ejected;
+
+    if (ejected) {
+        // Drive empty: show status instead of the (still-remembered) path.
+        m_Graphics->DrawText(12, 30, COLOR2D(255, 255, 255), "No Disc (Ejected)",
+                             C2DGraphics::AlignLeft, Font6x7);
+    } else if (fullTextPx <= m_ISOMaxTextPx) {
         // Short path fits on one line - just display it
         m_Graphics->DrawText(12, 30, COLOR2D(255, 255, 255), pISOPath, C2DGraphics::AlignLeft, Font6x7);
     } else {

--- a/addon/displayservice/sh1106/homepage.h
+++ b/addon/displayservice/sh1106/homepage.h
@@ -51,5 +51,6 @@ class SH1106HomePage : public IPage {
     bool m_ISOScrollDirLeft = true;
     int m_ISOCharWidth = 6;  // Font6x7 char width
     int m_ISOMaxTextPx = 0;  // Max pixels for ISO display area
+    bool m_bEjectedShown = false;  // last-drawn eject state (redraw trigger)
 };
 #endif

--- a/addon/displayservice/ssd1306/homepage.cpp
+++ b/addon/displayservice/ssd1306/homepage.cpp
@@ -41,6 +41,8 @@ void SSD1306HomePage::OnEnter() {
     m_ISOScrollDirLeft = true;
 
     GetIPAddress(pIPAddress, sizeof(pIPAddress));
+    if (m_Service)
+        m_bEjectedShown = m_Service->IsEjected();
     Draw();
 }
 
@@ -66,8 +68,14 @@ void SSD1306HomePage::OnButtonPress(Button button) {
             break;
 
         case Button::Down:
-            m_NextPageName = "imagespage";
-            m_ShouldChangePage = true;
+            // Down button: toggle eject / insert. Always works (emergency
+            // eject), even if the host locked the door.
+            if (m_Service) {
+                if (m_Service->IsEjected())
+                    m_Service->SetPendingInsert();
+                else
+                    m_Service->SetPendingEject();
+            }
             break;
 
         case Button::Cancel:
@@ -87,6 +95,12 @@ void SSD1306HomePage::OnButtonPress(Button button) {
 }
 
 void SSD1306HomePage::Refresh() {
+    // Redraw if the eject state changed (path may be unchanged across eject)
+    if (m_Service && m_Service->IsEjected() != m_bEjectedShown) {
+        Draw();
+        return;
+    }
+
     // Check if ISO path changed
     const char* currentPath = GetCurrentImagePath();
     if (strcmp(currentPath, pISOPath) != 0) {
@@ -107,8 +121,9 @@ void SSD1306HomePage::Refresh() {
         return;
     }
 
-    // Scroll the ISO path if needed
-    RefreshISOScroll();
+    // Scroll the ISO path if needed (not while ejected - the path is hidden)
+    if (!(m_Service && m_Service->IsEjected()))
+        RefreshISOScroll();
 }
 
 void SSD1306HomePage::GetIPAddress(char* buffer, size_t size) {
@@ -207,7 +222,14 @@ void SSD1306HomePage::Draw() {
     size_t pathLen = strlen(pISOPath);
     int fullTextPx = (int)pathLen * m_ISOCharWidth;
 
-    if (fullTextPx <= m_ISOMaxTextPx) {
+    bool ejected = m_Service && m_Service->IsEjected();
+    m_bEjectedShown = ejected;
+
+    if (ejected) {
+        // Drive empty: show status instead of the (still-remembered) path.
+        m_Graphics->DrawText(12, 30, COLOR2D(255, 255, 255), "No Disc (Ejected)",
+                             C2DGraphics::AlignLeft, Font6x7);
+    } else if (fullTextPx <= m_ISOMaxTextPx) {
         // Short path fits on one line - just display it
         m_Graphics->DrawText(12, 30, COLOR2D(255, 255, 255), pISOPath, C2DGraphics::AlignLeft, Font6x7);
     } else {

--- a/addon/displayservice/ssd1306/homepage.h
+++ b/addon/displayservice/ssd1306/homepage.h
@@ -51,5 +51,6 @@ class SSD1306HomePage : public IPage {
     bool m_ISOScrollDirLeft = true;
     int m_ISOCharWidth = 6;  // Font6x7 char width
     int m_ISOMaxTextPx = 0;  // Max pixels for ISO display area
+    bool m_bEjectedShown = false;  // last-drawn eject state (redraw trigger)
 };
 #endif

--- a/addon/displayservice/st7789/homepage.cpp
+++ b/addon/displayservice/st7789/homepage.cpp
@@ -35,6 +35,8 @@ void ST7789HomePage::OnEnter() {
     TruncatePathWithEllipsis(pISOPath, pISOPathDisplay, sizeof(pISOPathDisplay), 75);
 
     GetIPAddress(pIPAddress, sizeof(pIPAddress));
+    if (m_Service)
+        m_bEjectedShown = m_Service->IsEjected();
     Draw();
 }
 
@@ -60,8 +62,15 @@ void ST7789HomePage::OnButtonPress(Button button) {
             break;
 
         case Button::Down:
-            m_NextPageName = "imagespage";
-            m_ShouldChangePage = true;
+            // B button: toggle eject / insert. The physical control always
+            // works (acts as the emergency eject), even if the host locked the
+            // door. A/X/Y are unchanged.
+            if (m_Service) {
+                if (m_Service->IsEjected())
+                    m_Service->SetPendingInsert();
+                else
+                    m_Service->SetPendingEject();
+            }
             break;
 
         case Button::Cancel:
@@ -80,6 +89,12 @@ void ST7789HomePage::OnButtonPress(Button button) {
 }
 
 void ST7789HomePage::Refresh() {
+    // Redraw if the eject state changed (path may be unchanged across eject)
+    if (m_Service && m_Service->IsEjected() != m_bEjectedShown) {
+        Draw();
+        return;
+    }
+
     // Check if ISO path changed
     const char* currentPath = GetCurrentImagePath();
     if (strcmp(currentPath, pISOPath) != 0) {
@@ -235,6 +250,15 @@ void ST7789HomePage::Draw() {
         m_Graphics->DrawText(35, cd_y + 40, COLOR2D(0, 0, 0), third_line, C2DGraphics::AlignLeft);
     }
 
+    // Eject status indicator: show a red EJECTED banner when the drive is
+    // empty so the remembered image name still reads as "not currently loaded".
+    bool ejected = m_Service && m_Service->IsEjected();
+    m_bEjectedShown = ejected;
+    if (ejected) {
+        m_Graphics->DrawText(35, cd_y + 60, COLOR2D(200, 0, 0), "EJECTED - No Disc",
+                             C2DGraphics::AlignLeft);
+    }
+
     // Use the helper function to draw navigation bar (false = main screen layout)
     DrawNavigationBar("main");
 
@@ -338,33 +362,19 @@ void ST7789HomePage::DrawNavigationBar(const char* screenType) {
     arrow_y = 225;
 
     if (strcmp(screenType, "main") == 0) {
-        // CHANGED: Show CD icon for B button (same as A button)
-        unsigned cd_x = 85;  // Adjusted X position for B button
-        unsigned cd_y = 215;
-        unsigned cd_radius = 10;
-        
-        // Draw outer circle of CD
-        m_Graphics->DrawCircleOutline(cd_x + cd_radius, cd_y + cd_radius, cd_radius, COLOR2D(255, 255, 255));
-
-        // Draw middle circle of CD
-        m_Graphics->DrawCircleOutline(cd_x + cd_radius, cd_y + cd_radius, 5, COLOR2D(255, 255, 255));
-
-        // Draw center hole of CD
-        m_Graphics->DrawCircle(cd_x + cd_radius, cd_y + cd_radius, 2, COLOR2D(255, 255, 255));
-
-        // Old power icon for B button
-        /*
-        int radius = 7;            // Adjust radius as needed
-        int cx = arrow_x + radius;  // Center x
-        int cy = arrow_y;          // Center y
-
-        // Draw the circle outline
-        m_Graphics->DrawCircleOutline(cx, cy, radius, COLOR2D(255, 255, 255));
-
-        // Draw the vertical line ("I") - top center of the circle downward
-        int line_length = 6;  // Length of the line
-        m_Graphics->DrawLine(cx, cy - radius - 2, cx, cy - radius + line_length, COLOR2D(255, 255, 255));
-        */
+        // B button is Eject/Insert: draw an eject glyph (triangle above a bar).
+        unsigned eject_cx = 95;
+        unsigned eject_top = 218;
+        int eject_h = 8;      // triangle height
+        int eject_half = 7;   // triangle base half-width
+        for (int i = 0; i <= eject_h; i++) {
+            int halfW = (i * eject_half) / eject_h;
+            m_Graphics->DrawLine(eject_cx - halfW, eject_top + i,
+                                 eject_cx + halfW, eject_top + i, COLOR2D(255, 255, 255));
+        }
+        // Bar beneath the triangle
+        m_Graphics->DrawRect(eject_cx - eject_half, eject_top + eject_h + 3,
+                             2 * eject_half + 1, 3, COLOR2D(255, 255, 255));
     } else {
         // Stem (3px thick)
         m_Graphics->DrawLine(arrow_x, arrow_y, arrow_x, arrow_y + 13, COLOR2D(255, 255, 255));

--- a/addon/displayservice/st7789/homepage.h
+++ b/addon/displayservice/st7789/homepage.h
@@ -45,5 +45,6 @@ class ST7789HomePage : public IPage {
     char pISOPathDisplay[128];           // Truncated path for display
     const char* pUSBSpeed;
     const char* pTitle;
+    bool m_bEjectedShown = false;        // last-drawn eject state (redraw trigger)
 };
 #endif

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -105,8 +105,25 @@ SCSITBService::SCSITBService()
     m_FileEntries = new FileEntry[MAX_FILES]();
     m_CurrentImagePath[0] = '\0';  // Initialize empty path
 
+    // Read the persisted eject state once at startup, before anything can mount.
+    // If the drive was ejected when last powered off, come up as an empty drive:
+    // the remembered image still loads (so the gadget knows the geometry and
+    // Insert is instant) but the gadget never reports it ready. Arming this
+    // before any SetDevice() is what makes it reliable - ejecting after the
+    // mount left a window in which the host could enumerate, see a disc and
+    // mount it.
+    if (configservice) {
+        m_bBootEjectPending = configservice->GetEjected();
+        m_bPersistedEjected = m_bBootEjectPending;
+        if (m_bBootEjectPending) {
+            LOGNOTE("Boot: drive was ejected at power-off, coming up empty");
+            cdromservice->ArmBootEject();
+        }
+    }
+
     bool ok = RefreshCache();
     assert(ok && "Failed to refresh SCSITBService on construction");
+
     SetName("scsitbservice");
 }
 
@@ -208,6 +225,24 @@ bool SCSITBService::SetNextCD(size_t cd) {
     //TODO bounds checking
     next_cd = cd;
     return true;
+}
+
+void SCSITBService::SetPendingEject() {
+    m_Lock.Acquire();
+    m_bPendingEject = true;
+    m_bPendingInsert = false;
+    m_Lock.Release();
+}
+
+void SCSITBService::SetPendingInsert() {
+    m_Lock.Acquire();
+    m_bPendingInsert = true;
+    m_bPendingEject = false;
+    m_Lock.Release();
+}
+
+bool SCSITBService::IsEjected() const {
+    return cdromservice && cdromservice->IsEjected();
 }
 
 const char* SCSITBService::GetCurrentCDName() {
@@ -402,8 +437,11 @@ bool SCSITBService::RefreshCache() {
         }
     }
 
-    // Fallback to first image file if not found
-    if (!found && m_FileCount > 0) {
+    // Fallback to first image file if not found. Never while ejected: an empty
+    // drive must stay empty, and this path also runs on rescans (upload, delete,
+    // FTP), where auto-mounting a substitute would undo the user's eject and
+    // then persist "inserted" over the saved state.
+    if (!found && m_FileCount > 0 && !IsEjected()) {
         for (size_t i = 0; i < m_FileCount; ++i) {
             if (!m_FileEntries[i].isDirectory) {
                 LOGNOTE("SCSITBService::RefreshCache() Current image not found, using: %s", 
@@ -418,6 +456,51 @@ bool SCSITBService::RefreshCache() {
     return true;
 }
 
+// Mount whatever SetNextCD/SetNextCDByName queued. Split out of Run() so every
+// failure path can simply return: the caller still has to consume the one-shot
+// boot-eject arm, which an early `continue` in the loop used to skip.
+// Called with m_Lock held.
+void SCSITBService::ProcessPendingMount() {
+    if (next_cd <= -1)
+        return;
+
+    if ((size_t)next_cd >= m_FileCount) {
+        next_cd = -1;
+        return;
+    }
+
+    // Build full path using relativePath from cache
+    const char* relativePath = m_FileEntries[next_cd].relativePath;
+    // Ensure we have room for "1:/" prefix (3 chars) + relativePath + null terminator
+    if (strlen(relativePath) > MAX_PATH_LEN - 4) {
+        LOGERR("Path too long: %s", relativePath);
+        next_cd = -1;
+        return;
+    }
+    snprintf(m_CurrentImagePath, sizeof(m_CurrentImagePath), "1:/%s", relativePath);
+
+    IImageDevice* imageDevice = loadImageDevice(m_CurrentImagePath);
+
+    if (imageDevice == nullptr) {
+        LOGERR("Failed to load image: %s", m_CurrentImagePath);
+        next_cd = -1;
+        return;
+    }
+
+    LOGNOTE("Loaded image: %s (format: %d, has subchannels: %s)",
+            m_CurrentImagePath,
+            (int)imageDevice->GetFileType(),
+            imageDevice->HasSubchannelData() ? "yes" : "no");
+
+    cdromservice->SetDevice(imageDevice);
+
+    // Save relative path to config (without "1:/" prefix)
+    configservice->SetCurrentImage(relativePath);
+
+    current_cd = next_cd;
+    next_cd = -1;
+}
+
 void SCSITBService::Run() {
     LOGNOTE("SCSITBService::Run started");
 
@@ -425,45 +508,43 @@ void SCSITBService::Run() {
         m_Lock.Acquire();
 
         // Handle load by index (SetNextCD or SetNextCDByName was called)
-        if (next_cd > -1) {
-            if ((size_t)next_cd >= m_FileCount) {
-                next_cd = -1;
-                m_Lock.Release();
-                continue;
+        ProcessPendingMount();
+
+        // The boot-eject arm is one-shot and is consumed by the first
+        // SetDevice(). If the remembered image never loaded (missing, renamed,
+        // unreadable) no SetDevice() came, so clear it here - otherwise it would
+        // sit armed and silently eject the next image the user mounts by hand.
+        // The drive itself stays ejected either way, which is the saved state.
+        if (m_bBootEjectPending) {
+            m_bBootEjectPending = false;
+            cdromservice->DisarmBootEject();
+        }
+
+        // Handle eject / insert requests (button, web, or deferred here from a
+        // caller). Mounting a new image above implicitly re-inserts, so process
+        // these after the load so a queued eject can't strand a fresh mount.
+        if (m_bPendingEject) {
+            m_bPendingEject = false;
+            LOGNOTE("Ejecting current medium");
+            cdromservice->Eject();
+        }
+        if (m_bPendingInsert) {
+            m_bPendingInsert = false;
+            LOGNOTE("Inserting current medium");
+            cdromservice->Insert();
+        }
+
+        // Persist the eject state whenever it changes. The gadget is the source
+        // of truth, so this captures every source uniformly - button, web, and
+        // the host START STOP UNIT (which runs in IRQ context and must not touch
+        // the SD card itself).
+        if (configservice) {
+            bool ejected = cdromservice->IsEjected();
+            if (ejected != m_bPersistedEjected) {
+                m_bPersistedEjected = ejected;
+                configservice->SetEjected(ejected);
+                LOGNOTE("Persisted eject state: %s", ejected ? "ejected" : "inserted");
             }
-
-            // Build full path using relativePath from cache
-            const char* relativePath = m_FileEntries[next_cd].relativePath;
-            // Ensure we have room for "1:/" prefix (3 chars) + relativePath + null terminator
-            if (strlen(relativePath) > MAX_PATH_LEN - 4) {
-                LOGERR("Path too long: %s", relativePath);
-                next_cd = -1;
-                m_Lock.Release();
-                continue;
-            }
-            snprintf(m_CurrentImagePath, sizeof(m_CurrentImagePath), "1:/%s", relativePath);
-
-            IImageDevice* imageDevice = loadImageDevice(m_CurrentImagePath);
-
-            if (imageDevice == nullptr) {
-                LOGERR("Failed to load image: %s", m_CurrentImagePath);
-                next_cd = -1;
-                m_Lock.Release();
-                continue;
-            }
-
-            LOGNOTE("Loaded image: %s (format: %d, has subchannels: %s)",
-                    m_CurrentImagePath,
-                    (int)imageDevice->GetFileType(),
-                    imageDevice->HasSubchannelData() ? "yes" : "no");
-
-            cdromservice->SetDevice(imageDevice);
-
-            // Save relative path to config (without "1:/" prefix)
-            configservice->SetCurrentImage(relativePath);
-
-            current_cd = next_cd;
-            next_cd = -1;
         }
 
         m_Lock.Release();

--- a/addon/scsitbservice/scsitbservice.h
+++ b/addon/scsitbservice/scsitbservice.h
@@ -50,6 +50,12 @@ public:
     bool SetNextCD(size_t index);
     bool SetNextCDByName(const char* file_name);
 
+    // Eject / insert the current medium. These queue the request for the Run()
+    // loop (task context), matching how SetNextCD defers the actual work.
+    void SetPendingEject();
+    void SetPendingInsert();
+    bool IsEjected() const;  // delegates to cdromservice
+
     // Task entry point
     void Run(void);
 
@@ -65,12 +71,23 @@ private:
     int next_cd = -1;
     int current_cd = -1;
 
+    bool m_bPendingEject = false;
+    bool m_bPendingInsert = false;
+
+    // Eject-state persistence. m_bBootEjectPending latches the saved "was
+    // ejected" state read once at startup, applied after the initial image
+    // loads so the drive comes up empty. m_bPersistedEjected mirrors what is
+    // currently written to config, so the Run loop only writes on a change.
+    bool m_bBootEjectPending = false;
+    bool m_bPersistedEjected = false;
+
     // Full path of currently mounted image (e.g., "1:/Games/game.iso")
     char m_CurrentImagePath[MAX_PATH_LEN];
 
     mutable CGenericLock m_Lock;
 
     void ClearCache();
+    void ProcessPendingMount();  // called from Run() with m_Lock held
     void ScanDirectoryRecursive(const char* fullPath, const char* relativePath);  // Recursive scanner
 };
 

--- a/addon/usbcdgadget/cd_utils.cpp
+++ b/addon/usbcdgadget/cd_utils.cpp
@@ -332,9 +332,16 @@ int CDUtils::GetMediumType(CUSBCDGadget* gadget)
     // ("CD-R data & audio") made it treat every disc as data-only
     // ("data or no disc loaded", PLAY AUDIO never issued). Modern hosts
     // ignore this byte in favor of GET CONFIGURATION.
+    // An empty drive has no medium to describe. 0x00 ("default") is the neutral
+    // code: reporting 0x01/0x02/0x03 while ejected tells the host a data or
+    // audio disc is loaded. Only the no-medium case is special-cased, so the
+    // Win9x MCICDA audio behavior for a real disc is untouched.
+    if (gadget->m_mediaState == CUSBCDGadget::MediaState::NO_MEDIUM)
+        return 0x00;
+
     bool hasAudio = false;
     bool hasData = false;
-    
+
     gadget->cueParser.restart();
     const CUETrackInfo *trackInfo = nullptr;
     

--- a/addon/usbcdgadget/scsi_inquiry.cpp
+++ b/addon/usbcdgadget/scsi_inquiry.cpp
@@ -707,6 +707,13 @@ void SCSIInquiry::GetConfiguration(CUSBCDGadget *gadget)
     int startFeature = (gadget->m_CBW.CBWCB[2] << 8) | gadget->m_CBW.CBWCB[3];
     u16 allocationLength = gadget->m_CBW.CBWCB[7] << 8 | (gadget->m_CBW.CBWCB[8]);
 
+    // MMC: with no medium loaded there is no current profile. Reporting one
+    // anyway is read by hosts as "a disc is in the drive" - macOS mounts on it
+    // and keeps re-mounting an ejected image no matter what TEST UNIT READY
+    // says. The feature list itself still describes what the drive can do; only
+    // the "currently active" markers are cleared.
+    bool bNoMedium = (gadget->m_mediaState == CUSBCDGadget::MediaState::NO_MEDIUM);
+
     int dataLength = 0;
     dataLength += sizeof(gadget->header);
 
@@ -746,14 +753,14 @@ void SCSIInquiry::GetConfiguration(CUSBCDGadget *gadget)
             if (gadget->m_mediaType == MEDIA_TYPE::DVD)
             {
                 TUSBCProfileDescriptorReply activeDVD = gadget->dvd_profile;
-                activeDVD.currentP = 0x01; // Mark as current profile
+                activeDVD.currentP = bNoMedium ? 0x00 : 0x01; // Mark as current profile
                 memcpy(gadget->m_InBuffer + dataLength, &activeDVD, sizeof(activeDVD));
                 dataLength += sizeof(activeDVD);
             }
 
             // CD profile - always present (our base capability)
             TUSBCProfileDescriptorReply activeCD = gadget->cdrom_profile;
-            activeCD.currentP = (gadget->m_mediaType != MEDIA_TYPE::DVD) ? 0x01 : 0x00;
+            activeCD.currentP = (!bNoMedium && gadget->m_mediaType != MEDIA_TYPE::DVD) ? 0x01 : 0x00;
             memcpy(gadget->m_InBuffer + dataLength, &activeCD, sizeof(activeCD));
             dataLength += sizeof(activeCD);
         }
@@ -842,7 +849,12 @@ void SCSIInquiry::GetConfiguration(CUSBCDGadget *gadget)
     // Build the feature header with current profile and total data length
     TUSBCDFeatureHeaderReply dynHeader = gadget->header;
 
-    if (gadget->m_mediaType == MEDIA_TYPE::DVD)
+    if (bNoMedium)
+    {
+        dynHeader.currentProfile = htons(PROFILE_NONE);
+        CDROM_DEBUG_LOG("SCSIInquiry::GetConfiguration", "GET CONFIGURATION: no medium, current profile 0x0000");
+    }
+    else if (gadget->m_mediaType == MEDIA_TYPE::DVD)
     {
         dynHeader.currentProfile = htons(PROFILE_DVD_ROM);
         CDROM_DEBUG_LOG("SCSIInquiry::GetConfiguration", "GET CONFIGURATION: Returning PROFILE_DVD_ROM (0x0010)");

--- a/addon/usbcdgadget/scsi_misc.cpp
+++ b/addon/usbcdgadget/scsi_misc.cpp
@@ -53,14 +53,49 @@ void SCSIMisc::StartStopUnit(CUSBCDGadget *gadget)
 {
     int start = gadget->m_CBW.CBWCB[4] & 1;
     int loej = (gadget->m_CBW.CBWCB[4] >> 1) & 1;
-    // TODO: Emulate a disk eject/load
     // loej Start Action
     // 0    0     Stop the disc - no action for us
     // 0    1     Start the disc - no action for us
-    // 1    0     Eject the disc - perhaps we need to throw a check condition?
-    // 1    1     Load the disc - perhaps we need to throw a check condition?
+    // 1    0     Eject the disc
+    // 1    1     Load the disc
 
     CDROM_DEBUG_LOG("SCSIMisc::StartStopUnit", "start/stop, start = %d, loej = %d", start, loej);
+
+    if (loej)
+    {
+        if (start)
+        {
+            // Load ("close the tray"). Deliberately does NOT bring the medium
+            // back. Ejecting on USBODE models the user taking the disc out, so
+            // the tray is empty and closing it finds nothing - exactly what a
+            // real drive does. Hosts poll with LOAD while looking for new media
+            // (macOS does this after its own eject), and honoring it made the
+            // drive silently re-mount the image the user had just ejected, then
+            // persist "inserted" over the saved ejected state. Re-inserting is
+            // a physical act: the ODE button, the web UI, or mounting an image.
+            if (gadget->m_bEjected)
+            {
+                MLOGNOTE("SCSIMisc::StartStopUnit",
+                         "Host LOAD ignored - tray is empty until the user re-inserts");
+            }
+        }
+        else
+        {
+            // Eject: honor the host's PREVENT MEDIUM REMOVAL lock like a real
+            // drive - refuse with 05/53/02 (MEDIUM REMOVAL PREVENTED) while
+            // locked. (The physical button / web UI bypass this on purpose.)
+            if (gadget->m_bMediumRemovalPrevented)
+            {
+                MLOGNOTE("SCSIMisc::StartStopUnit",
+                         "Host eject refused - medium removal prevented");
+                gadget->setSenseData(0x05, 0x53, 0x02);
+                gadget->sendCheckCondition();
+                return;
+            }
+            gadget->Eject();
+        }
+    }
+
     gadget->sendGoodStatus();
 }
 
@@ -69,9 +104,11 @@ void SCSIMisc::PreventAllowMediumRemoval(CUSBCDGadget *gadget)
     int prevent = gadget->m_CBW.CBWCB[4] & 0x01;
 
     CDROM_DEBUG_LOG("SCSIMisc::PreventAllowMediumRemoval",
-                    "PREVENT/ALLOW: prevent=%d (accepting but not locking)", prevent);
+                    "PREVENT/ALLOW: prevent=%d", prevent);
 
-    // Accept the command - we just won't actually lock anything
+    // Track the lock so a host-issued eject can be refused per SCSI spec.
+    // We never physically hold anything; this only gates host eject commands.
+    gadget->m_bMediumRemovalPrevented = (prevent != 0);
     gadget->sendGoodStatus();
 }
 
@@ -115,7 +152,10 @@ void SCSIMisc::MechanismStatus(CUSBCDGadget *gadget)
     status.changer_state = 0;      // No changer
     status.current_slot = 0;       // Slot 0
     status.mechanism_state = 0x00; // Idle
-    status.door_open = 0;          // Door closed (tray loaded)
+    // Report the tray as open while ejected - that is what a real drive shows
+    // after the eject button, and it stops hosts probing an "empty but closed"
+    // tray with LOAD commands.
+    status.door_open = gadget->m_bEjected ? 1 : 0;
     status.num_slots = 1;          // Single slot device
     status.slot_table_length = 0;  // No slot table
 
@@ -175,7 +215,10 @@ void SCSIMisc::GetEventStatusNotification(CUSBCDGadget *gadget)
         {
             MLOGNOTE("SCSIMisc::GetEventStatusNotification", "NO_MEDIUM state - sending Media Removal event");
             event.eventCode = 0x03; // Media Removal
-            event.data[0] = 0x00;
+            // Media status: bit 1 = medium present (never set here), bit 0 =
+            // door/tray open. A user eject leaves the tray open; a disc swap in
+            // flight is a closed tray that briefly has no medium.
+            event.data[0] = gadget->m_bEjected ? 0x01 : 0x00;
         }
         else if (gadget->m_CDReady)
         {

--- a/addon/usbcdgadget/scsi_read.cpp
+++ b/addon/usbcdgadget/scsi_read.cpp
@@ -140,8 +140,7 @@ void SCSIRead::DoRead(CUSBCDGadget* gadget, int cdbSize)
     {
         CDROM_DEBUG_LOG("SCSIRead::DoRead", "failed, %s",
                         gadget->m_CDReady ? "ready" : "not ready");
-        gadget->setSenseData(0x02, 0x04, 0x00); // LOGICAL UNIT NOT READY
-        gadget->sendCheckCondition();
+        gadget->sendNotReady();
     }
 }
 
@@ -151,8 +150,7 @@ void SCSIRead::DoPlayAudio(CUSBCDGadget* gadget, int cdbSize)
 
     if (!gadget->m_CDReady)
     {
-        gadget->setSenseData(0x02, 0x04, 0x00); // LOGICAL UNIT NOT READY
-        gadget->sendCheckCondition();
+        gadget->sendNotReady();
         return;
     }
 
@@ -306,8 +304,7 @@ void SCSIRead::ReadCD(CUSBCDGadget* gadget)
 {
     if (!gadget->m_CDReady)
     {
-        gadget->setSenseData(0x02, 0x04, 0x00); // LOGICAL UNIT NOT READY
-        gadget->sendCheckCondition();
+        gadget->sendNotReady();
         return;
     }
 

--- a/addon/usbcdgadget/scsi_toc.cpp
+++ b/addon/usbcdgadget/scsi_toc.cpp
@@ -26,8 +26,7 @@ void SCSITOC::ReadTOC(CUSBCDGadget *gadget)
     if (!gadget->m_CDReady)
     {
         MLOGNOTE("SCSITOC::ReadTOC", "FAILED - CD not ready");
-        gadget->setSenseData(0x02, 0x04, 0x00); // NOT READY, LOGICAL UNIT NOT READY
-        gadget->sendCheckCondition();
+        gadget->sendNotReady();
         return;
     }
 
@@ -66,8 +65,7 @@ void SCSITOC::ReadTOC(CUSBCDGadget *gadget)
     if (!gadget->m_CDReady)
     {
         MLOGNOTE("SCSITOC::ReadTOC", "FAILED - CD not ready");
-        gadget->setSenseData(0x02, 0x04, 0x00); // LOGICAL UNIT NOT READY
-        gadget->sendCheckCondition();
+        gadget->sendNotReady();
         return;
     }
 
@@ -496,6 +494,15 @@ void SCSITOC::ReadDiscInformation(CUSBCDGadget *gadget)
 {
     CDROM_DEBUG_LOG("SCSITOC::ReadDiscInformation", "Read Disc Information");
 
+    // Describing a finalized single-session disc while the drive is empty reads
+    // to the host as "a disc is loaded" - macOS calls this while working out the
+    // media type and mounts on a good reply.
+    if (!gadget->m_CDReady)
+    {
+        gadget->sendNotReady();
+        return;
+    }
+
     // Update disc information with current media state
     gadget->m_DiscInfoReply.disc_status = 0x0E; // Complete disc, finalized, last session complete
     gadget->m_DiscInfoReply.first_track_number = 0x01;
@@ -545,8 +552,7 @@ void SCSITOC::ReadTrackInformation(CUSBCDGadget *gadget)
 
     if (!gadget->m_CDReady)
     {
-        gadget->setSenseData(0x02, 0x04, 0x00); // LOGICAL UNIT NOT READY
-        gadget->sendCheckCondition();
+        gadget->sendNotReady();
         return;
     }
 
@@ -663,8 +669,7 @@ void SCSITOC::ReadHeader(CUSBCDGadget *gadget)
 
     if (!gadget->m_CDReady)
     {
-        gadget->setSenseData(0x02, 0x04, 0x00); // LOGICAL UNIT NOT READY
-        gadget->sendCheckCondition();
+        gadget->sendNotReady();
         return;
     }
 
@@ -727,6 +732,12 @@ void SCSITOC::ReadSubChannel(CUSBCDGadget *gadget)
     // unsigned int track_number = gadget->m_CBW.CBWCB[6]; // Ignore track number for now. It's used only for ISRC
     int allocationLength = (gadget->m_CBW.CBWCB[7] << 8) | gadget->m_CBW.CBWCB[8];
     int length = 0;
+
+    if (!gadget->m_CDReady)
+    {
+        gadget->sendNotReady();
+        return;
+    }
 
     // CDROM_DEBUG_LOG("CUSBCDGadget::HandleSCSICommand", "READ SUB-CHANNEL CMD (0x42), allocationLength = %d, msf = %u, parameter_list = 0x%02x", allocationLength, msf, parameter_list);
 
@@ -842,6 +853,12 @@ void SCSITOC::ReadDiscStructure(CUSBCDGadget *gadget)
     u8 format = gadget->m_CBW.CBWCB[7];
     u16 allocationLength = ((u16)gadget->m_CBW.CBWCB[8] << 8) | gadget->m_CBW.CBWCB[9];
     u8 agid = (gadget->m_CBW.CBWCB[10] >> 6) & 0x03; // Authentication Grant ID
+
+    if (!gadget->m_CDReady)
+    {
+        gadget->sendNotReady();
+        return;
+    }
 
     CDROM_DEBUG_LOG("SCSITOC::ReadDiscStructure",
                     "READ DISC STRUCTURE: media=%d, format=0x%02x, layer=%d, address=0x%08x, alloc=%d, AGID=%d, mediaType=%d",

--- a/addon/usbcdgadget/scsidefs.h
+++ b/addon/usbcdgadget/scsidefs.h
@@ -16,6 +16,7 @@
 #define LEADOUT_OFFSET 150
 
 // Profile codes (MMC-3)
+#define PROFILE_NONE 0x0000 // no current profile: drive is empty
 #define PROFILE_CDROM 0x0008
 #define PROFILE_DVD_ROM 0x0010
 

--- a/addon/usbcdgadget/usbcdgadget.cpp
+++ b/addon/usbcdgadget/usbcdgadget.cpp
@@ -511,6 +511,25 @@ void CUSBCDGadget::SetDevice(IImageDevice *dev)
         MLOGNOTE("CUSBCDGadget::SetDevice", "Passed CueBinFileDevice to cd player");
     }
 
+    // Loading a device normally means a disc is present, so clear any ejected
+    // latch. The exception is the boot restore: when the drive was ejected at
+    // power-off we adopt the image (so the cue sheet and geometry are known and
+    // Insert is instant) but stay empty to the host. Deciding that here rather
+    // than ejecting again afterwards matters - SetDevice() can yield, and any
+    // window in which the gadget reports ready lets the host mount the disc the
+    // user had ejected.
+    if (m_bEjectOnLoad)
+    {
+        m_bEjectOnLoad = false;
+        m_bEjected = true;
+        MLOGNOTE("CUSBCDGadget::SetDevice",
+                 "Boot restore: adopting image but staying ejected (empty drive)");
+    }
+    else
+    {
+        m_bEjected = false;
+    }
+
     boolean bDiscSwap = (m_pDevice != nullptr && m_pDevice != dev);
 
     if (bDiscSwap || !m_CDReady)
@@ -576,6 +595,85 @@ void CUSBCDGadget::SetDevice(IImageDevice *dev)
                     "=== EXIT === m_CDReady=%d, mediaState=%d, sense=%02x/%02x/%02x",
                     m_CDReady, (int)m_mediaState,
                     m_SenseParams.bSenseKey, m_SenseParams.bAddlSenseCode, m_SenseParams.bAddlSenseCodeQual);
+}
+
+// Eject the current medium. The image device stays allocated (m_pDevice is
+// left intact) so no SCSI read path can dereference a null device; the host
+// simply sees an empty drive. Called from TASK level (button/web/SCSI-handler),
+// never freeing anything, so it is safe against the IRQ-context command path
+// that gates on m_CDReady.
+void CUSBCDGadget::Eject(void)
+{
+    if (m_bEjected)
+    {
+        MLOGNOTE("CUSBCDGadget::Eject", "Already ejected, ignoring");
+        return;
+    }
+
+    MLOGNOTE("CUSBCDGadget::Eject", "Ejecting medium: state -> NO_MEDIUM, sense=02/3a/00");
+
+    CTraceLab::Get()->TraceMediaState((u8)m_mediaState, (u8)MediaState::NO_MEDIUM);
+    m_bEjected = true;
+    m_bPendingDiscSwap = false; // cancel any in-flight insert/swap sequence
+    // A mechanical tray release clears the host's removal lock the same way
+    // opening the tray does on real hardware: the medium is gone, and the host
+    // re-asserts PREVENT when it next mounts. This keeps a stale lock from
+    // later refusing a legitimate host eject.
+    m_bMediumRemovalPrevented = false;
+    m_CDReady = false;
+    m_mediaState = MediaState::NO_MEDIUM;
+    m_SenseParams.bSenseKey = 0x02;
+    m_SenseParams.bAddlSenseCode = 0x3a; // MEDIUM NOT PRESENT
+    m_SenseParams.bAddlSenseCodeQual = 0x00;
+    bmCSWStatus = CD_CSW_STATUS_FAIL;
+    discChanged = false;
+}
+
+// Re-insert a previously ejected medium. Reuses the disc-swap state machine in
+// Update(): NO_MEDIUM -> UNIT_ATTENTION (with discChanged/NewMedia) -> READY.
+// The device was never freed, so nothing needs reloading here.
+void CUSBCDGadget::Insert(void)
+{
+    if (!m_bEjected)
+    {
+        MLOGNOTE("CUSBCDGadget::Insert", "Not ejected, ignoring");
+        return;
+    }
+    if (m_pDevice == nullptr)
+    {
+        MLOGERR("CUSBCDGadget::Insert", "No device to re-insert");
+        return;
+    }
+
+    MLOGNOTE("CUSBCDGadget::Insert", "Re-inserting medium via media-change sequence");
+
+    m_bEjected = false;
+    m_mediaState = MediaState::NO_MEDIUM;
+    m_CDReady = false;
+    m_bPendingDiscSwap = true;
+    m_nDiscSwapStartTick = CTimer::Get()->GetTicks();
+}
+
+// Arm the boot restore. Called before the first SetDevice(), so the drive is
+// already ejected from the very first moment the host can talk to it - there is
+// no "mounted then ejected" flicker for the host to latch onto.
+void CUSBCDGadget::ArmBootEject(void)
+{
+    MLOGNOTE("CUSBCDGadget::ArmBootEject", "Drive will come up empty (was ejected at power-off)");
+    m_bEjectOnLoad = true;
+    m_bEjected = true;
+    m_CDReady = false;
+    m_mediaState = MediaState::NO_MEDIUM;
+    m_bPendingDiscSwap = false;
+    discChanged = false;
+}
+
+// The arm is one-shot. If the remembered image never loaded there is no
+// SetDevice() to consume it, and leaving it armed would silently eject the next
+// image the user deliberately mounts.
+void CUSBCDGadget::DisarmBootEject(void)
+{
+    m_bEjectOnLoad = false;
 }
 
 void CUSBCDGadget::CreateDevice(void)
@@ -878,8 +976,10 @@ void CUSBCDGadget::OnActivate()
                     IsEffectiveFullSpeed() ? "Full-Speed (USB 1.1)" : "High-Speed (USB 2.0)",
                     m_CDReady, (int)m_mediaState);
     CTimer::Get()->MsDelay(10);
-    // Set media ready NOW - USB endpoints are active
-    if (m_pDevice && !m_CDReady)
+    // Set media ready NOW - USB endpoints are active.
+    // Skip while ejected: the drive must stay empty across a re-enumeration
+    // until the user (or host) explicitly re-inserts.
+    if (m_pDevice && !m_CDReady && !m_bEjected)
     {
         CTraceLab::Get()->TraceMediaState((u8)m_mediaState, (u8)MediaState::MEDIUM_PRESENT_UNIT_ATTENTION);
         m_CDReady = true;
@@ -961,6 +1061,15 @@ void CUSBCDGadget::sendCheckCondition()
     }
 
     SendCSW();
+}
+
+void CUSBCDGadget::sendNotReady()
+{
+    if (m_mediaState == MediaState::NO_MEDIUM)
+        setSenseData(0x02, 0x3a, 0x00); // MEDIUM NOT PRESENT (empty / ejected)
+    else
+        setSenseData(0x02, 0x04, 0x00); // LOGICAL UNIT NOT READY
+    sendCheckCondition();
 }
 
 void CUSBCDGadget::sendGoodStatus()

--- a/addon/usbcdgadget/usbcdgadget.h
+++ b/addon/usbcdgadget/usbcdgadget.h
@@ -85,6 +85,28 @@ public:
     /// \note Call this, if pDevice has not been specified in the constructor.
     void SetDevice(IImageDevice *pDevice);
 
+    /// \brief Eject the current medium: report NO_MEDIUM to the host without
+    /// freeing the underlying image device. No-op if already ejected.
+    void Eject(void);
+
+    /// \brief Re-insert the previously ejected medium, driving the normal
+    /// media-change (UNIT ATTENTION -> READY) sequence. No-op if not ejected.
+    void Insert(void);
+
+    /// \brief True while the medium is ejected (drive reports empty).
+    boolean IsEjected(void) const { return m_bEjected; }
+
+    /// \brief Come up empty: the drive was ejected when it was last powered
+    /// off, so the next SetDevice() adopts the image (geometry, cue sheet)
+    /// without ever presenting it to the host. Must be called before the first
+    /// SetDevice() so there is no window in which the host can see a disc.
+    void ArmBootEject(void);
+
+    /// \brief Consume a boot-eject arm that was never used (the remembered
+    /// image failed to load, so no SetDevice() came). Leaves the drive ejected
+    /// but lets the next deliberate mount insert normally.
+    void DisarmBootEject(void);
+
     /// \brief Call this periodically from TASK_LEVEL to allow I/O operations!
     void Update(void);
     boolean m_bNeedsAudioInit = FALSE;
@@ -141,6 +163,9 @@ private:
     void clearSenseData();
     void sendCheckCondition();
     void sendGoodStatus();
+    // Fail a command because the unit is not ready: sends 02/3a/00 (MEDIUM NOT
+    // PRESENT) when the drive is empty/ejected, else 02/04/00 (LU NOT READY).
+    void sendNotReady();
     USBTargetOS m_USBTargetOS;
     
     // Friend declarations for command classes and utilities
@@ -154,6 +179,16 @@ private:
 
     boolean m_bPendingDiscSwap = false;
     unsigned m_nDiscSwapStartTick = 0;
+
+    // Eject / medium-removal state. m_bEjected latches an empty drive (the
+    // image device stays allocated in m_pDevice; the host just sees NO_MEDIUM).
+    // m_bMediumRemovalPrevented mirrors the host's PREVENT ALLOW MEDIUM REMOVAL
+    // lock so a host-issued eject can be refused per SCSI spec.
+    boolean m_bEjected = false;
+    boolean m_bMediumRemovalPrevented = false;
+    // Armed by ArmBootEject() so the first SetDevice() keeps the drive empty
+    // instead of clearing the ejected latch.
+    boolean m_bEjectOnLoad = false;
 
     // ========================================================================
     // Device Initialization

--- a/addon/webserver/Makefile
+++ b/addon/webserver/Makefile
@@ -27,7 +27,8 @@ OBJS    = webserver.o \
 	handlers/traceapi.o \
 	handlers/tracepage.o \
 	handlers/discarthandler.o \
-	handlers/deleteapi.o
+	handlers/deleteapi.o \
+	handlers/ejectapi.o
 
 libwebserver.a: $(OBJS)
 	@echo "  AR    $@"

--- a/addon/webserver/handlers/ejectapi.cpp
+++ b/addon/webserver/handlers/ejectapi.cpp
@@ -1,0 +1,41 @@
+#include <circle/logger.h>
+#include <circle/util.h>
+#include <circle/net/httpdaemon.h>
+#include <circle/sched/scheduler.h>
+#include <json/json.hpp>
+#include <scsitbservice/scsitbservice.h>
+#include <string>
+#include <cstring>
+#include <map>
+#include "ejectapi.h"
+#include "../util.h"
+
+LOGMODULE("ejectapi");
+
+THTTPStatus EjectAPIHandler::GetJson(nlohmann::json& j,
+                const char *pPath,
+                const char *pParams,
+                const char *pFormData)
+{
+    auto params = parse_query_params(pParams);
+
+    SCSITBService* svc = static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
+    if (!svc) {
+        LOGERR("Couldn't fetch SCSITB Service");
+        return HTTPInternalServerError;
+    }
+
+    bool insert = params.count("insert") != 0 && params["insert"] != "0";
+
+    if (insert) {
+        LOGNOTE("EjectAPI: inserting medium");
+        svc->SetPendingInsert();
+        j = {{"status", "ok"}, {"ejected", false}};
+    } else {
+        LOGNOTE("EjectAPI: ejecting medium");
+        svc->SetPendingEject();
+        j = {{"status", "ok"}, {"ejected", true}};
+    }
+
+    return HTTPOK;
+}

--- a/addon/webserver/handlers/ejectapi.h
+++ b/addon/webserver/handlers/ejectapi.h
@@ -1,0 +1,16 @@
+
+#ifndef EJECTAPI_HANDLER_H
+#define EJECTAPI_HANDLER_H
+
+#include "apihandlerbase.h"
+
+// /api/eject         -> eject the current medium (report empty drive)
+// /api/eject?insert=1 -> re-insert the previously ejected medium
+class EjectAPIHandler : public APIHandlerBase {
+public:
+   THTTPStatus GetJson(nlohmann::json& j,
+		const char *pPath,
+		const char *pParams,
+		const char *pFormData);
+};
+#endif

--- a/addon/webserver/handlers/homepage.cpp
+++ b/addon/webserver/handlers/homepage.cpp
@@ -147,6 +147,10 @@ THTTPStatus HomePageHandler::PopulateContext(kainjow::mustache::data& context,
     context.set("image_name", current_image_name);
     context.set("image_path", current_image_path ? current_image_path : "");
 
+    // Eject state: drives the Eject/Insert toggle button in the header
+    bool ejected = svc->IsEjected();
+    context.set("ejected", ejected);
+
     // Check if disc art exists for current image
     bool has_disc_art = false;
     if (current_image_path && current_image_path[0] != '\0') {

--- a/addon/webserver/handlers/listapi.cpp
+++ b/addon/webserver/handlers/listapi.cpp
@@ -45,6 +45,7 @@ THTTPStatus ListAPIHandler::GetJson(nlohmann::json& j,
 
     const char* currentPath = svc->GetCurrentCDPath();
     j["currentImage"] = currentPath ? currentPath : "";
+    j["ejected"] = svc->IsEjected();
 
     // Build entries array - iterate and filter
     LOGNOTE("ListAPIHandler: Building entries array");

--- a/addon/webserver/pagehandlerregistry.cpp
+++ b/addon/webserver/pagehandlerregistry.cpp
@@ -24,6 +24,7 @@
 #include "handlers/tracepage.h"
 #include "handlers/discarthandler.h"
 #include "handlers/deleteapi.h"
+#include "handlers/ejectapi.h"
 
 // instances of your page handlers
 static HomePageHandler s_homePageHandler;
@@ -44,6 +45,7 @@ static TraceDownloadHandler s_traceDownloadHandler;
 static TracePageHandler s_tracePageHandler;
 static DiscArtHandler s_discArtHandler;
 static DeleteImageAPIHandler s_deleteImageAPIHandler;
+static EjectAPIHandler s_ejectAPIHandler;
 
 // routes for your handlers
 static const std::map<std::string, IPageHandler*> g_pageHandlers = {
@@ -58,6 +60,7 @@ static const std::map<std::string, IPageHandler*> g_pageHandlers = {
 
     // API
     { "/api/mount", &s_mountAPIHandler },
+    { "/api/eject", &s_ejectAPIHandler },
     { "/api/list", &s_listAPIHandler },
     { "/api/shutdown", &s_shutdownAPIHandler },
     { "/api/reboot", &s_shutdownAPIHandler },

--- a/addon/webserver/pages/index.html
+++ b/addon/webserver/pages/index.html
@@ -6,10 +6,20 @@
 			<img src="/discart?{{boot_id}}" alt="Disc Art" />
 		</div>
 		{{/has_disc_art}}
-		<p>Current File Loaded: <br/><strong>{{image_name}}</strong></p>
+		<p>Current File Loaded: <br/><strong>{{image_name}}</strong>{{#ejected}} <span class="eject-status">(Ejected - No Disc)</span>{{/ejected}}</p>
 		{{#show_path}}
 		<p>Current Folder: <strong>/{{current_path}}</strong></p>
 		{{/show_path}}
+		{{#ejected}}
+		<button type="button" id="eject-btn" onclick="toggleEject(true)">Insert Disc</button>
+		{{/ejected}}
+		{{^ejected}}
+		<button type="button" id="eject-btn" onclick="toggleEject(false)">Eject Disc</button>
+		{{/ejected}}
+		<p class="eject-note" style="font-size:0.85em;opacity:0.75">On macOS, eject from Finder instead. macOS locks the
+		drive while a disc is mounted and stops checking it, so ejecting here (or
+		with the device button) leaves a stale disc icon until you click it.
+		DOS, Windows and Linux notice the eject on their own.</p>
 	</div>
 
 	<h4>Available Files</h4>
@@ -106,6 +116,20 @@
 			st.textContent = 'Upload failed after retries: ' + e;
 		} finally {
 			btn.disabled = false;
+		}
+	}
+	async function toggleEject(isEjected) {
+		var btn = document.getElementById('eject-btn');
+		if (btn) btn.disabled = true;
+		try {
+			var url = isEjected ? '/api/eject?insert=1' : '/api/eject';
+			var r = await fetch(url);
+			var j = await r.json();
+			if (j.status !== 'ok') { alert(j.error || 'Eject failed'); if (btn) btn.disabled = false; return; }
+			setTimeout(function () { location.reload(); }, 600);
+		} catch (e) {
+			alert('Eject request failed: ' + e);
+			if (btn) btn.disabled = false;
 		}
 	}
 	async function deleteImage(encodedPath) {

--- a/integration-tests/harness/bench.cpp
+++ b/integration-tests/harness/bench.cpp
@@ -12,7 +12,8 @@
 CGadgetTestBench::CGadgetTestBench(IImageDevice *pDisc, bool bFullSpeed,
                                    CCDPlayer *pPlayer, ConfigService *pConfig,
                                    SCSITBService *pTBService,
-                                   bool bPassDiscToConstructor)
+                                   bool bPassDiscToConstructor,
+                                   bool bBootEjected)
 {
     TestBus::Get().Reset();
     CTimer::Get()->TestReset();
@@ -49,6 +50,14 @@ CGadgetTestBench::CGadgetTestBench(IImageDevice *pDisc, bool bFullSpeed,
     // bench deliberately does not touch them: the toolbox tests only mean
     // something if they run against the state a real gadget actually boots
     // with.
+    // Boot restore: SCSITBService arms this in its constructor, before the
+    // first mount, so the ordering here has to match - arming after SetDevice()
+    // would leave exactly the window the arm exists to close.
+    if (bBootEjected)
+    {
+        gadget->ArmBootEject();
+    }
+
     gadget->SetDevice(pDisc);
 }
 

--- a/integration-tests/harness/bench.h
+++ b/integration-tests/harness/bench.h
@@ -52,7 +52,11 @@ public:
                      CCDPlayer *pPlayer = nullptr,
                      ConfigService *pConfig = nullptr,
                      SCSITBService *pTBService = nullptr,
-                     bool bPassDiscToConstructor = false);
+                     bool bPassDiscToConstructor = false,
+                     // Boot restore: arm the "came up ejected" latch before the
+                     // disc is attached, exactly as SCSITBService does when the
+                     // drive was ejected at power-off.
+                     bool bBootEjected = false);
 
     // AddEndpoints + endpoint activation: after this the drive is in
     // UNIT ATTENTION state with a CBW transfer armed, same as right after

--- a/integration-tests/test-suite/test_mediacontrol.cpp
+++ b/integration-tests/test-suite/test_mediacontrol.cpp
@@ -11,11 +11,23 @@
 // with START=1 as part of bringing the drive online, and PREVENT ALLOW
 // MEDIUM REMOVAL whenever a volume is opened.
 //
-// USBODE has no tray and no motor, so all three are largely no-ops. The point
-// of pinning them is the opposite of the usual one: it is the *no-op* that is
-// load-bearing. An eject that really ejected, or a lock that really locked,
-// would break the web UI's disc swap and leave Windows holding a drive it
-// cannot use.
+// USBODE has no tray and no motor. START STOP UNIT with LOEJ=1/START=0
+// performs a real eject: the drive drops to NO_MEDIUM (MEDIUM NOT PRESENT)
+// while keeping the image file internally. This lets a host, a game, or the
+// device's own button present an empty drive to fix hosts that cache a stale
+// disc across a swap.
+//
+// LOEJ=1/START=1 (load) is accepted but deliberately does NOT bring the medium
+// back: an eject models the user taking the disc out, so the tray is empty.
+// Re-inserting is a physical act -- the button, the web UI, or mounting an
+// image -- which all go through Insert() and the normal media-change
+// (UNIT ATTENTION -> READY) sequence.
+//
+// The door lock still matters, though: like a real drive, a host eject is
+// refused (05/53/02, MEDIUM REMOVAL PREVENTED) while the host holds a PREVENT
+// ALLOW MEDIUM REMOVAL lock. The web UI / button eject bypass the lock on
+// purpose (there is no physical pinhole), and a lock must never block the web
+// UI's out-of-band disc swap.
 //
 // NOTE: two MODE SELECT tests are held out here, for the same reason as in
 // test_toolbox.cpp -- they fail today. ProcessOut() selects the mode page to
@@ -122,33 +134,96 @@ TEST(start_stop_unit_immed_accepted)
     CHECK_EQ(r.csw.dCSWDataResidue, 0u);
 }
 
-// The load-bearing no-op. USBODE's "disc" is a file chosen in the web UI, and
-// there is nothing to eject: after a host asks for an eject the drive must
-// still be ready and still serving the same image. Implementing eject
-// literally -- dropping to NO_MEDIUM on LOEJ=1 -- would mean a user pressing
-// Eject in Explorer, or any host that ejects during shutdown, leaves the
-// drive dead until it is unplugged.
-TEST(start_stop_unit_eject_leaves_medium_readable)
+// A host eject (LOEJ=1, START=0) really ejects: the command itself succeeds,
+// but the drive then reports NO_MEDIUM (02/3a/00, MEDIUM NOT PRESENT) and
+// refuses reads, exactly as an empty drive would. This is what lets a host or
+// a game clear a stale cached disc.
+TEST(start_stop_unit_eject_reports_no_medium)
 {
     CFakeImageDevice *disc = MakeDataISO(1200);
     CGadgetTestBench bench(disc);
     bench.Activate();
     bench.RequestSense();
 
-    const u8 capCDB[10] = {0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    auto before = bench.SendCommand(capCDB, sizeof(capCDB), 8);
-    CHECK_EQ(before.csw.bmCSWStatus, 0);
-
+    // The eject command completes with GOOD status.
     CHECK_EQ(StartStopUnit(bench, 0x02).csw.bmCSWStatus, 0); // LOEJ=1, START=0
 
-    // Still ready, same capacity, and the data still reads correctly.
+    // The drive now reads as empty.
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.data[2], 0x02);  // NOT READY
+    CHECK_EQ(sense.data[12], 0x3a); // MEDIUM NOT PRESENT
+
+    // Reads are refused while ejected.
+    const u8 readCDB[10] = {0x28, 0x00, 0x00, 0x00, 0x00, 0x05,
+                            0x00, 0x00, 0x01, 0x00};
+    auto read = bench.SendCommand(readCDB, sizeof(readCDB), 2048);
+    CHECK_EQ(read.csw.bmCSWStatus, 1);
+}
+
+// LOEJ=1, START=1 (load) closes an empty tray: it succeeds, but it does NOT
+// bring the medium back. Ejecting on USBODE models the user taking the disc
+// out, so there is nothing left for the host to load. This matters because
+// hosts poll with LOAD while hunting for new media -- macOS does it after its
+// own eject -- and honoring it made the drive silently re-mount the image the
+// user had just ejected, then persist "inserted" over the saved ejected state.
+TEST(start_stop_unit_load_after_eject_leaves_drive_empty)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    CHECK_EQ(StartStopUnit(bench, 0x02).csw.bmCSWStatus, 0); // eject
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);       // empty
+    bench.RequestSense();
+
+    CHECK_EQ(StartStopUnit(bench, 0x03).csw.bmCSWStatus, 0); // load
+    SettleDiscSwap(bench);
+
+    // Still empty, and still reporting MEDIUM NOT PRESENT.
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.data[2], 0x02);  // NOT READY
+    CHECK_EQ(sense.data[12], 0x3a); // MEDIUM NOT PRESENT
+    CHECK_EQ(bench.gadget->IsEjected(), true);
+
+    // Repeated LOAD polling cannot wear the eject down either.
+    for (int i = 0; i < 5; ++i)
+    {
+        CHECK_EQ(StartStopUnit(bench, 0x03).csw.bmCSWStatus, 0);
+        SettleDiscSwap(bench);
+    }
+    CHECK_EQ(bench.gadget->IsEjected(), true);
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+}
+
+// Insert() -- the button, the web UI, mounting an image -- is the only way the
+// medium comes back. It comes back through the same media-change path a disc
+// swap uses: UNIT ATTENTION reported once, cleared by REQUEST SENSE, then READY
+// and readable again, serving the same image that was ejected.
+TEST(device_insert_after_eject_restores_medium)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    CHECK_EQ(StartStopUnit(bench, 0x02).csw.bmCSWStatus, 0); // eject
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);       // empty
+    bench.RequestSense();
+
+    bench.gadget->Insert();
+    SettleDiscSwap(bench);
+
+    // Media change reported, then cleared the way a host would.
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.data[2], 0x06);  // UNIT ATTENTION
+    CHECK_EQ(sense.data[12], 0x28); // NOT READY TO READY CHANGE
     CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 0);
 
-    auto after = bench.SendCommand(capCDB, sizeof(capCDB), 8);
-    CHECK_EQ(after.csw.bmCSWStatus, 0);
-    CHECK_BYTES(after.data.data(), after.data.size(),
-                before.data.data(), before.data.size());
-
+    // The same image reads correctly again.
     const u8 readCDB[10] = {0x28, 0x00, 0x00, 0x00, 0x00, 0x05,
                             0x00, 0x00, 0x01, 0x00};
     auto read = bench.SendCommand(readCDB, sizeof(readCDB), 2048);
@@ -157,6 +232,170 @@ TEST(start_stop_unit_eject_leaves_medium_readable)
     u8 expected[2048];
     FillPatternSector(expected, 5, 2048);
     CHECK_BYTES(read.data.data(), read.data.size(), expected, sizeof(expected));
+}
+
+// An ejected drive must not answer any of the "is there a disc?" probes as if
+// one were loaded. GET CONFIGURATION's Current Profile is the decisive one on
+// macOS: it reported CD-ROM (0x0008) unconditionally, which reads as "medium
+// present" no matter what TEST UNIT READY says, and macOS re-mounted the image
+// on every poll. MMC requires 0000h with no medium, and no profile descriptor
+// marked current.
+TEST(ejected_drive_reports_no_current_profile)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 getConfig[10] = {0x46, 0x00, 0x00, 0x00, 0x00, 0x00,
+                              0x00, 0x00, 0x20, 0x00};
+
+    // With a disc loaded the CD-ROM profile is current.
+    auto loaded = bench.SendCommand(getConfig, sizeof(getConfig), 0x20);
+    CHECK_EQ(loaded.csw.bmCSWStatus, 0);
+    CHECK_EQ((loaded.data[6] << 8) | loaded.data[7], 0x0008); // PROFILE_CDROM
+
+    bench.gadget->Eject();
+
+    auto empty = bench.SendCommand(getConfig, sizeof(getConfig), 0x20);
+    CHECK_EQ(empty.csw.bmCSWStatus, 0);
+    CHECK_EQ((empty.data[6] << 8) | empty.data[7], 0x0000); // no current profile
+
+    // The profile descriptor inside the Profile List feature must agree: byte
+    // 2 of each descriptor carries the Current bit in bit 0. Header is 8 bytes,
+    // then the feature header is 4, then the first profile descriptor.
+    CHECK_EQ(empty.data[8 + 4 + 2] & 0x01, 0);
+}
+
+// The other media-presence probes an ejected drive must refuse. READ DISC
+// INFORMATION described a finalized single-session disc while the drive was
+// empty; macOS calls it while working out the media type.
+TEST(ejected_drive_refuses_disc_probes)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    bench.gadget->Eject();
+
+    const u8 discInfo[10] = {0x51, 0x00, 0x00, 0x00, 0x00, 0x00,
+                             0x00, 0x00, 0x20, 0x00};
+    CHECK_EQ(bench.SendCommand(discInfo, sizeof(discInfo), 0x20).csw.bmCSWStatus, 1);
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.data[2], 0x02);  // NOT READY
+    CHECK_EQ(sense.data[12], 0x3a); // MEDIUM NOT PRESENT
+
+    const u8 subChannel[10] = {0x42, 0x02, 0x40, 0x01, 0x00, 0x00,
+                               0x00, 0x00, 0x10, 0x00};
+    CHECK_EQ(bench.SendCommand(subChannel, sizeof(subChannel), 0x10).csw.bmCSWStatus, 1);
+    bench.RequestSense();
+
+    // MODE SENSE still answers (it describes the drive, not the disc), but the
+    // medium type byte must not claim a data or audio disc is loaded.
+    const u8 modeSense[6] = {0x1A, 0x00, 0x2A, 0x00, 0x20, 0x00};
+    auto ms = bench.SendCommand(modeSense, sizeof(modeSense), 0x20);
+    CHECK_EQ(ms.csw.bmCSWStatus, 0);
+    CHECK_EQ(ms.data[1], 0x00); // medium type: none
+}
+
+// Boot restore: the drive was ejected at power-off, so it must come up empty
+// even though the remembered image is loaded behind the scenes. The arm is set
+// before SetDevice() precisely so there is no window -- not even across
+// enumeration -- in which the host can see a disc and mount it.
+TEST(boot_eject_arm_keeps_drive_empty_through_enumeration)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc, false, nullptr, nullptr, nullptr, false,
+                           /* bBootEjected */ true);
+    bench.Activate(); // enumeration: OnActivate() must not make the disc ready
+
+    CHECK_EQ(bench.gadget->IsEjected(), true);
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.data[2], 0x02);  // NOT READY
+    CHECK_EQ(sense.data[12], 0x3a); // MEDIUM NOT PRESENT
+
+    // A host LOAD still cannot conjure the disc back at boot.
+    CHECK_EQ(StartStopUnit(bench, 0x03).csw.bmCSWStatus, 0);
+    SettleDiscSwap(bench);
+    CHECK_EQ(bench.gadget->IsEjected(), true);
+
+    // The user inserting restores the remembered image immediately - it was
+    // loaded all along, which is why Insert needs no disc reload.
+    bench.gadget->Insert();
+    SettleDiscSwap(bench);
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+    bench.RequestSense();
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 0);
+    delete disc;
+}
+
+// The arm is one-shot. A later deliberate mount (user picks an image) must
+// insert normally rather than inheriting the boot-time eject.
+TEST(boot_eject_arm_is_consumed_by_first_set_device)
+{
+    CFakeImageDevice *first = MakeDataISO(1200);
+    CFakeImageDevice *second = MakeDataISO(1200);
+    CGadgetTestBench bench(first, false, nullptr, nullptr, nullptr, false,
+                           /* bBootEjected */ true);
+    bench.Activate();
+    CHECK_EQ(bench.gadget->IsEjected(), true);
+
+    // User mounts a different image: that is a disc insertion.
+    bench.gadget->SetDevice(second);
+    SettleDiscSwap(bench);
+    CHECK_EQ(bench.gadget->IsEjected(), false);
+    delete second;
+}
+
+// Like a real drive, a host-issued eject is refused while the host holds the
+// PREVENT ALLOW MEDIUM REMOVAL lock: CHECK CONDITION 05/53/02, and the medium
+// stays readable. Once the host unlocks, the eject goes through.
+TEST(start_stop_unit_eject_refused_while_locked)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    CHECK_EQ(PreventAllow(bench, 0x01).csw.bmCSWStatus, 0); // lock
+
+    auto refused = StartStopUnit(bench, 0x02); // eject while locked
+    CHECK_EQ(refused.csw.bmCSWStatus, 1);
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.data[2], 0x05);  // ILLEGAL REQUEST
+    CHECK_EQ(sense.data[12], 0x53); // MEDIA LOAD OR EJECT FAILED
+    CHECK_EQ(sense.data[13], 0x02); // MEDIUM REMOVAL PREVENTED
+
+    // Still readable - the eject did not happen.
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 0);
+
+    // After unlocking, the eject succeeds.
+    CHECK_EQ(PreventAllow(bench, 0x00).csw.bmCSWStatus, 0); // unlock
+    CHECK_EQ(StartStopUnit(bench, 0x02).csw.bmCSWStatus, 0);
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1); // now empty
+}
+
+// The device's own eject (button / web UI) is the emergency override: it must
+// work even while the host holds the removal lock, since there is no physical
+// pinhole. Exercised directly through the gadget's Eject(), which is what the
+// button and web paths call.
+TEST(device_eject_overrides_medium_removal_lock)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    CHECK_EQ(PreventAllow(bench, 0x01).csw.bmCSWStatus, 0); // host locks
+
+    bench.gadget->Eject(); // device-initiated eject bypasses the lock
+
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.data[2], 0x02);  // NOT READY
+    CHECK_EQ(sense.data[12], 0x3a); // MEDIUM NOT PRESENT
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
USBODE always had an image mounted, so a host eject request was silently ignored
and there was no way to show an empty drive. This adds eject and insert driven
from three places: the host (START STOP UNIT), the device button, and the web UI.

The drive reports NO_MEDIUM while keeping `m_pDevice` allocated, so no read path
can null-deref on bare metal. Insert reuses the existing disc-swap state machine,
so the host sees a real media-change event.

**Reporting "empty" convincingly took more than TEST UNIT READY.** macOS trusts
GET CONFIGURATION's Current Profile over anything else, so an ejected drive now
reports profile 0000h with no active feature markers; MODE SENSE returns medium
type 0x00; and READ DISC INFORMATION, READ SUB-CHANNEL and READ DISC STRUCTURE
refuse while not ready rather than describing a disc that isn't there. Without
these the image silently re-mounted itself.

**START STOP UNIT LOAD deliberately does not re-insert.** Hosts poll with LOAD
while looking for new media, and honoring it undid the user's eject and then
persisted "inserted" over the saved state. Re-inserting is a physical act: the
button, the web UI, or mounting an image. Host eject honors the PREVENT MEDIUM
REMOVAL lock (05/53/02); the button and web UI bypass it as a real drive's
pinhole would.

**The eject state persists across power cycles.** The latch is armed before the
first `SetDevice()` rather than ejecting after the mount, because `SetDevice()`
can yield and any window in which the gadget reports ready lets the host mount
the disc the user had ejected. The arm is one-shot and is disarmed if the
remembered image never loads, so it cannot leak into the next deliberate mount.
Rescans no longer fall back to auto-mounting a substitute image while ejected.

One host limitation, documented rather than worked around: macOS locks the drive
on mount and stops polling it, so it cannot learn of an eject initiated from the
device side and leaves a stale disc icon until the volume is clicked. That is not
something the gadget can signal around. Noted in both the web UI and the README.

Covered by 6 new integration tests, 120 total passing, including the boot-restore
ordering.

---

Independent of the other open PRs from this batch. This branch and the CD Extra / READ CD one both touch `cd_utils.cpp`, `scsi_read.cpp`, `scsi_toc.cpp` and `usbcdgadget.cpp`, but a test merge of the two is clean, so they can be merged in either order.