### PR TITLE
CD Extra multisession fixes, and correct READ CD field selection

### DIFF
--- a/addon/cueparser/cueparser.cpp
+++ b/addon/cueparser/cueparser.cpp
@@ -54,6 +54,7 @@ void CUEParser::restart() {
     memset(&m_track_info, 0, sizeof(m_track_info));
     m_prev_index01_time = 0;
     m_current_session = 1;
+    m_pending_leadout = 0;
 }
 
 const CUETrackInfo *CUEParser::next_track() {
@@ -112,6 +113,8 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size) {
             m_track_info.track_mode = parse_track_mode(skip_space(endptr));
             m_track_info.sector_length = get_sector_length(m_track_info.file_mode, m_track_info.track_mode);
             m_track_info.session = m_current_session;
+            m_track_info.prev_session_leadout = m_pending_leadout;
+            m_pending_leadout = 0;
             m_track_info.unstored_pregap_length = 0;
             m_track_info.data_start = 0;
             m_track_info.track_start = 0;
@@ -129,6 +132,10 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size) {
             int session = strtoul(session_str, &endptr, 10);
             if (endptr != session_str && session >= 1)
                 m_current_session = session;
+        } else if (strncasecmp(m_parse_pos, "REM LEAD-OUT ", 13) == 0) {
+            // Where the session that is ending puts its lead-out. Held until
+            // the next TRACK line, which belongs to the following session.
+            m_pending_leadout = parse_time(skip_space(m_parse_pos + 13));
         } else if (strncasecmp(m_parse_pos, "PREGAP ", 7) == 0) {
             // Unstored pregap, which offsets the data start on CD but does not
             // affect the offset in data file.

--- a/addon/cueparser/cueparser.cpp
+++ b/addon/cueparser/cueparser.cpp
@@ -53,6 +53,7 @@ void CUEParser::restart() {
     m_parse_pos = m_cue_sheet;
     memset(&m_track_info, 0, sizeof(m_track_info));
     m_prev_index01_time = 0;
+    m_current_session = 1;
 }
 
 const CUETrackInfo *CUEParser::next_track() {
@@ -110,6 +111,7 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size) {
             m_track_info.track_number = strtoul(track_num, &endptr, 10);
             m_track_info.track_mode = parse_track_mode(skip_space(endptr));
             m_track_info.sector_length = get_sector_length(m_track_info.file_mode, m_track_info.track_mode);
+            m_track_info.session = m_current_session;
             m_track_info.unstored_pregap_length = 0;
             m_track_info.data_start = 0;
             m_track_info.track_start = 0;
@@ -118,6 +120,15 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size) {
             got_track = true;
             got_data = false;
             got_pause = false;
+        } else if (strncasecmp(m_parse_pos, "REM SESSION ", 12) == 0) {
+            // Multi-session marker written by most rippers ahead of the first
+            // TRACK of each session. Applies to every track that follows until
+            // the next marker. Other REM lines are comments and are ignored.
+            const char *session_str = skip_space(m_parse_pos + 12);
+            char *endptr;
+            int session = strtoul(session_str, &endptr, 10);
+            if (endptr != session_str && session >= 1)
+                m_current_session = session;
         } else if (strncasecmp(m_parse_pos, "PREGAP ", 7) == 0) {
             // Unstored pregap, which offsets the data start on CD but does not
             // affect the offset in data file.

--- a/addon/cueparser/cueparser.h
+++ b/addon/cueparser/cueparser.h
@@ -63,6 +63,13 @@ struct CUETrackInfo {
     int track_number;
     CUETrackMode track_mode;
 
+    // Session this track belongs to, 1-based. Set from "REM SESSION nn"
+    // markers when the cue sheet carries them; every track is session 1 when
+    // it does not. Cue sheets produced by merging a multi-track rip often
+    // lose these markers, so callers that need a reliable session boundary
+    // should fall back on the track layout (see CDUtils::GetLastSessionStart).
+    int session;
+
     // Sector length for this track in bytes, assuming BINARY or MOTOROLA file modes.
     uint32_t sector_length;
 
@@ -117,6 +124,10 @@ class CUEParser {
     // next_track() to advance file_offset in raw file time; reset on
     // restart() and on each FILE line (INDEX times restart per file).
     uint32_t m_prev_index01_time;
+
+    // Session number most recently announced by a "REM SESSION nn" line.
+    // Applied to each track as it is parsed; 1 until a marker says otherwise.
+    int m_current_session;
 
     // Skip any whitespace at beginning of line.
     // Returns false if at end of string.

--- a/addon/cueparser/cueparser.h
+++ b/addon/cueparser/cueparser.h
@@ -70,6 +70,15 @@ struct CUETrackInfo {
     // should fall back on the track layout (see CDUtils::GetLastSessionStart).
     int session;
 
+    // Lead-out position of the session that ended before this track, in CD
+    // frames, or 0 if the cue sheet did not say. Written from a
+    // "REM LEAD-OUT mm:ss:ff" line. Only the first track of a session carries
+    // it, and only rippers that emit the marker provide it at all -- the gap
+    // between a session's lead-out and the next session's first track is not
+    // recoverable from a single-file cue otherwise, because INDEX times are
+    // file-relative and the gap is stored as ordinary sectors.
+    uint32_t prev_session_leadout;
+
     // Sector length for this track in bytes, assuming BINARY or MOTOROLA file modes.
     uint32_t sector_length;
 
@@ -128,6 +137,10 @@ class CUEParser {
     // Session number most recently announced by a "REM SESSION nn" line.
     // Applied to each track as it is parsed; 1 until a marker says otherwise.
     int m_current_session;
+
+    // Lead-out time from the most recent "REM LEAD-OUT" line, consumed by the
+    // next TRACK. 0 when none is pending.
+    uint32_t m_pending_leadout;
 
     // Skip any whitespace at beginning of line.
     // Returns false if at end of string.

--- a/addon/usbcdgadget/cd_utils.cpp
+++ b/addon/usbcdgadget/cd_utils.cpp
@@ -264,18 +264,25 @@ int CDUtils::GetSessionCount(CUSBCDGadget* gadget)
 
 // Lead-out position of a given session.
 //
-// The last session's lead-out is the disc lead-out. For session 1 of a
-// two-session disc the lead-out sits at the end of the last audio track, well
-// before the next session starts: between them lie session 1's lead-out area
-// and session 2's lead-in, around 11250 frames that hold no track data.
+// The last session's lead-out is the disc lead-out. Session 1 of a two-session
+// disc is the interesting case: its lead-out sits at the end of the last audio
+// track, and between it and the next session's first track lie session 1's
+// lead-out area and session 2's lead-in -- around 11250 frames carrying no
+// track data. Reporting session 1's lead-out at the next session's first track
+// describes a disc where the two sessions touch, which cannot physically
+// happen, so hosts are entitled to reject the whole session structure.
 //
-// Deriving that end from LBAs alone would just measure the gap, so measure the
-// stored data instead: the byte distance between the last track of this session
-// and the first track of the next is exactly the audio that precedes the gap.
-// When an image does store the gap this collapses to the next session's start,
-// which is the same answer a single-session disc would give.
+// The gap cannot be measured from a single-file cue: INDEX times are
+// file-relative, the gap is stored as ordinary sectors, and the byte distance
+// between tracks therefore always equals the LBA distance. Only a
+// "REM LEAD-OUT" marker states it. Without one, fall back on the standard gap
+// so the layout is at least structurally valid.
 u32 CDUtils::GetSessionLeadoutLBA(CUSBCDGadget* gadget, int session)
 {
+    // Orange Book: 90 seconds of lead-out (6750 frames) then 60 seconds of
+    // lead-in (4500). Real CD Extra discs sit at or just above this.
+    static const u32 kSessionGapFrames = 11250;
+
     if (session != 1 || GetSessionCount(gadget) < 2)
         return GetLeadoutLBA(gadget);
 
@@ -302,20 +309,24 @@ u32 CDUtils::GetSessionLeadoutLBA(CUSBCDGadget* gadget, int session)
         }
     }
 
-    if (!haveLast || !haveNext || lastOfSession.sector_length == 0)
+    if (!haveLast || !haveNext)
         return GetLeadoutLBA(gadget);
 
-    // Different source files means the byte offsets are not comparable; fall
-    // back on the next session's start, which errs long by the gap rather than
-    // reporting a lead-out inside the audio.
-    if (lastOfSession.file_index != firstOfNext.file_index ||
-        firstOfNext.file_offset <= lastOfSession.file_offset)
-        return firstOfNext.track_start;
+    // The cue sheet said so outright. This is the only exact source.
+    if (firstOfNext.prev_session_leadout > lastOfSession.data_start &&
+        firstOfNext.prev_session_leadout < firstOfNext.track_start)
+    {
+        return firstOfNext.prev_session_leadout;
+    }
 
-    u64 storedBytes = firstOfNext.file_offset - lastOfSession.file_offset;
-    u32 storedFrames = (u32)(storedBytes / lastOfSession.sector_length);
+    // No marker: assume the standard gap. Guard against a merged image whose
+    // sessions sit closer together than that, where subtracting the full gap
+    // would put the lead-out inside the last audio track -- there, place it at
+    // the start of the next session's pregap, the latest defensible position.
+    if (firstOfNext.track_start > lastOfSession.data_start + kSessionGapFrames)
+        return firstOfNext.track_start - kSessionGapFrames;
 
-    return lastOfSession.data_start + storedFrames;
+    return firstOfNext.track_start;
 }
 
 u32 CDUtils::GetLeadoutLBA(CUSBCDGadget* gadget)

--- a/addon/usbcdgadget/cd_utils.cpp
+++ b/addon/usbcdgadget/cd_utils.cpp
@@ -503,38 +503,165 @@ int CDUtils::GetMediumType(CUSBCDGadget* gadget)
     else
         return 0x01;  // Data CD
 }
-int CDUtils::GetSectorLengthFromMCS(uint8_t mainChannelSelection)
+// READ CD (MMC opcode 0xBE) names the parts of a sector the host wants in the
+// top five bits of CDB byte 9, which SCSIRead::ReadCD extracts as
+// (byte9 >> 3) & 0x1F. Those five bits are the sector's fields in the order
+// they physically appear on the disc:
+//
+//   0x10  SYNC        0x08  SUBHEADER   0x04  HEADER
+//   0x02  USER DATA   0x01  EDC/ECC
+//
+// Note that the header and the subheader bits are not in disc order. CDB byte 9
+// bits 6..5 are a single two-bit Header Codes *value*, not two flags: 00 none,
+// 01 header only, 10 subheader only, 11 both. After the >> 3 those land on 0x08
+// and 0x04, so the low bit of the field - 0x04 - is the 4-byte header and the
+// high bit - 0x08 - is the 8-byte subheader, even though the header physically
+// comes first. Reading them in bit order instead of field order makes Windows
+// XP's second request look like it skips the header when it does not.
+//
+// Their sizes are not fixed: they depend on what kind of sector it is, which
+// is what TCDSectorShape carries. A field this sector kind does not have is
+// zero, and a zero-size field is invisible - it can be neither served nor
+// skipped, and it cannot split the fields on either side of it.
+//
+// Two defects lived here. The bottom three selection bits were read one
+// position high, so the subheader bit was taken for user data, the user data
+// bit for EDC/ECC, and the EDC/ECC bit was never examined at all: a host
+// asking for user data only (byte 9 = 0x10, selection 0x02) was handed 288
+// bytes of error-correction data where it wanted 2048 bytes of file content.
+// Raw reads escaped it because selection 0x1F sets every bit, so the total
+// came to 2352 whichever bit meant what - which is why the one mode Windows 98
+// uses for Mode 2 files always worked while every other mode returned nonsense.
+// And the sizes were hardcoded to Mode 1 Form 1, so a Mode 2 Form 2 sector,
+// whose user data is 2324 bytes and whose EDC is 4, could never be described.
+
+CDUtils::TCDSectorShape CDUtils::GetSectorShape(int expectedSectorType, CUETrackMode trackMode)
+{
+    int type = expectedSectorType;
+
+    if (type == 0)
+    {
+        // Type not specified: take it from the track. A Mode 2 track is
+        // assumed to be Form 1, because the form is a property of the
+        // individual sector and one command serves a single layout. A host
+        // that actually wants Form 2 says so in CDB byte 1, which is the path
+        // Windows XP uses.
+        if (trackMode == CUETrack_AUDIO || trackMode == CUETrack_CDG)
+            type = 1;
+        else if (trackMode == CUETrack_MODE1_2048 || trackMode == CUETrack_MODE1_2352)
+            type = 2;
+        else
+            type = 4;
+    }
+
+    TCDSectorShape shape;
+    switch (type)
+    {
+    case 1: // CD-DA: no structure at all, the whole sector is sample data
+        shape.nSync = 0;  shape.nHeader = 0; shape.nSubheader = 0;
+        shape.nUserData = 2352; shape.nEdcEcc = 0;
+        break;
+
+    case 3: // Mode 2 formless: no subheader, and the tail is user data
+        shape.nSync = 12; shape.nHeader = 4; shape.nSubheader = 0;
+        shape.nUserData = 2336; shape.nEdcEcc = 0;
+        break;
+
+    case 4: // Mode 2 Form 1: the 8 bytes Mode 1 reserves are the subheader,
+            // which is why the EDC/ECC tail is 280 rather than 288
+        shape.nSync = 12; shape.nHeader = 4; shape.nSubheader = 8;
+        shape.nUserData = 2048; shape.nEdcEcc = 280;
+        break;
+
+    case 5: // Mode 2 Form 2: real-time data, 2324 bytes and only an EDC
+        shape.nSync = 12; shape.nHeader = 4; shape.nSubheader = 8;
+        shape.nUserData = 2324; shape.nEdcEcc = 4;
+        break;
+
+    case 2: // Mode 1
+    default:
+        shape.nSync = 12; shape.nHeader = 4; shape.nSubheader = 0;
+        shape.nUserData = 2048; shape.nEdcEcc = 288;
+        break;
+    }
+
+    return shape;
+}
+
+// The transfer is served as one contiguous slice of the sector, so the fields
+// the host asks for have to be adjacent. Asking for the sync and the user data
+// but not the header between them cannot be expressed as an offset and a
+// length, and quietly including the header would be worse than refusing.
+bool CDUtils::McsFieldsAreContiguous(uint8_t mainChannelSelection, const TCDSectorShape& shape)
+{
+    const int sizes[5] = {shape.nSync, shape.nHeader, shape.nSubheader,
+                          shape.nUserData, shape.nEdcEcc};
+    // Disc order: sync, header, subheader, user data, EDC/ECC. The header is
+    // 0x04 and the subheader 0x08 - see the Header Codes note above.
+    const uint8_t bits[5] = {0x10, 0x04, 0x08, 0x02, 0x01};
+
+    bool bStarted = false;
+    bool bEnded = false;
+
+    for (int i = 0; i < 5; i++)
+    {
+        if (sizes[i] == 0)
+            continue; // absent from this sector kind, so it breaks nothing
+
+        if (mainChannelSelection & bits[i])
+        {
+            if (bEnded)
+                return false; // a second run after a gap
+            bStarted = true;
+        }
+        else if (bStarted)
+        {
+            bEnded = true;
+        }
+    }
+
+    return true;
+}
+
+int CDUtils::GetSectorLengthFromMCS(uint8_t mainChannelSelection, const TCDSectorShape& shape)
 {
     int total = 0;
     if (mainChannelSelection & 0x10)
-        total += 12; // SYNC
-    if (mainChannelSelection & 0x08)
-        total += 4; // HEADER
+        total += shape.nSync;
     if (mainChannelSelection & 0x04)
-        total += 2048; // USER DATA
+        total += shape.nHeader; // Header Codes low bit
+    if (mainChannelSelection & 0x08)
+        total += shape.nSubheader; // Header Codes high bit
     if (mainChannelSelection & 0x02)
-        total += 288; // EDC + ECC
+        total += shape.nUserData;
+    if (mainChannelSelection & 0x01)
+        total += shape.nEdcEcc;
 
     return total;
 }
 
-int CDUtils::GetSkipBytesFromMCS(uint8_t mainChannelSelection)
+int CDUtils::GetSkipBytesFromMCS(uint8_t mainChannelSelection, const TCDSectorShape& shape)
 {
+    // Skip the leading fields the host did not ask for and stop at the first
+    // one it did. Skipping unconditionally walks past requested fields and
+    // starts the slice in the wrong place, which is what handed Windows XP a
+    // Mode 2 Form 2 sector beginning 24 bytes into the MPEG payload instead of
+    // at the sync pattern it asked for.
+    const int sizes[5] = {shape.nSync, shape.nHeader, shape.nSubheader,
+                          shape.nUserData, shape.nEdcEcc};
+    // Disc order: sync, header, subheader, user data, EDC/ECC. The header is
+    // 0x04 and the subheader 0x08 - see the Header Codes note above.
+    const uint8_t bits[5] = {0x10, 0x04, 0x08, 0x02, 0x01};
+
     int offset = 0;
+    for (int i = 0; i < 5; i++)
+    {
+        if (sizes[i] == 0)
+            continue;
+        if (mainChannelSelection & bits[i])
+            break;
+        offset += sizes[i];
+    }
 
-    // Skip SYNC if not requested
-    if (!(mainChannelSelection & 0x10))
-        offset += 12;
-
-    // Skip HEADER if not requested
-    if (!(mainChannelSelection & 0x08))
-        offset += 4;
-
-    // USER DATA is next; if also not requested, skip 2048
-    if (!(mainChannelSelection & 0x04))
-        offset += 2048;
-
-    // EDC/ECC is always at the end, so no skipping here — it doesn't affect offset
-    //
     return offset;
 }

--- a/addon/usbcdgadget/cd_utils.cpp
+++ b/addon/usbcdgadget/cd_utils.cpp
@@ -41,12 +41,21 @@ void CDUtils::LBA2MSF(int32_t LBA, uint8_t *MSF, bool relative)
     MSF[0] = rem / 60; // Minutes
 }
 
+uint8_t CDUtils::ToBCD(int value)
+{
+    if (value < 0)
+        value = 0;
+    if (value > 99)
+        value = 99;
+    return (uint8_t)(((value / 10) << 4) | (value % 10));
+}
+
 void CDUtils::LBA2MSFBCD(int32_t LBA, uint8_t *MSF, bool relative)
 {
     LBA2MSF(LBA, MSF, relative);
-    MSF[0] = ((MSF[0] / 10) << 4) | (MSF[0] % 10);
-    MSF[1] = ((MSF[1] / 10) << 4) | (MSF[1] % 10);
-    MSF[2] = ((MSF[2] / 10) << 4) | (MSF[2] % 10);
+    MSF[0] = ToBCD(MSF[0]);
+    MSF[1] = ToBCD(MSF[1]);
+    MSF[2] = ToBCD(MSF[2]);
 }
 
 int32_t CDUtils::MSF2LBA(uint8_t m, uint8_t s, uint8_t f, bool relative)
@@ -177,6 +186,136 @@ int CDUtils::GetLastTrackNumber(CUSBCDGadget* gadget)
             lastTrack = trackInfo->track_number;
     }
     return lastTrack;
+}
+
+// Work out which track begins the last session.
+//
+// Two sources, in order of trust. A cue sheet that carries "REM SESSION"
+// markers has told us outright, so believe it. Merging tools routinely drop
+// those markers, though, leaving a CD Extra indistinguishable from a plain
+// mixed-mode disc except by its layout: audio tracks first, then a data track.
+// A data track that follows audio can only be the start of a later session,
+// because a session's tracks are contiguous and a disc never returns to audio
+// after data within one session.
+//
+// Returns the first track number of the last session, which is the first track
+// on the disc for an ordinary single-session image (data-first mixed mode
+// included, since no data track there follows audio).
+int CDUtils::GetLastSessionStartTrack(CUSBCDGadget* gadget)
+{
+    const CUETrackInfo *trackInfo = nullptr;
+    int firstTrack = -1;
+    int markedStart = -1;
+    int maxSession = 1;
+    int inferredStart = -1;
+    bool prevWasAudio = false;
+    bool anyAudio = false;
+
+    gadget->cueParser.restart();
+    while ((trackInfo = gadget->cueParser.next_track()) != nullptr)
+    {
+        if (firstTrack < 0)
+            firstTrack = trackInfo->track_number;
+
+        if (trackInfo->session > maxSession)
+        {
+            maxSession = trackInfo->session;
+            markedStart = trackInfo->track_number;
+        }
+
+        bool isAudio = (trackInfo->track_mode == CUETrack_AUDIO);
+        if (!isAudio && prevWasAudio && anyAudio)
+            inferredStart = trackInfo->track_number;
+
+        prevWasAudio = isAudio;
+        if (isAudio)
+            anyAudio = true;
+    }
+
+    if (firstTrack < 0)
+        return 1; // No tracks at all; caller handles the empty case
+
+    if (markedStart > 0)
+        return markedStart;
+
+    if (inferredStart > 0)
+        return inferredStart;
+
+    return firstTrack;
+}
+
+int CDUtils::GetSessionCount(CUSBCDGadget* gadget)
+{
+    const CUETrackInfo *trackInfo = nullptr;
+    int firstTrack = -1;
+
+    gadget->cueParser.restart();
+    if ((trackInfo = gadget->cueParser.next_track()) != nullptr)
+        firstTrack = trackInfo->track_number;
+
+    if (firstTrack < 0)
+        return 1;
+
+    // We only ever describe one or two sessions. Real CD Extra discs are two,
+    // and the multi-session images this firmware serves have never carried a
+    // third, so a session count is really "does a later session exist".
+    return (GetLastSessionStartTrack(gadget) != firstTrack) ? 2 : 1;
+}
+
+// Lead-out position of a given session.
+//
+// The last session's lead-out is the disc lead-out. For session 1 of a
+// two-session disc the lead-out sits at the end of the last audio track, well
+// before the next session starts: between them lie session 1's lead-out area
+// and session 2's lead-in, around 11250 frames that hold no track data.
+//
+// Deriving that end from LBAs alone would just measure the gap, so measure the
+// stored data instead: the byte distance between the last track of this session
+// and the first track of the next is exactly the audio that precedes the gap.
+// When an image does store the gap this collapses to the next session's start,
+// which is the same answer a single-session disc would give.
+u32 CDUtils::GetSessionLeadoutLBA(CUSBCDGadget* gadget, int session)
+{
+    if (session != 1 || GetSessionCount(gadget) < 2)
+        return GetLeadoutLBA(gadget);
+
+    int nextSessionStart = GetLastSessionStartTrack(gadget);
+
+    const CUETrackInfo *trackInfo = nullptr;
+    CUETrackInfo lastOfSession = {};
+    CUETrackInfo firstOfNext = {};
+    bool haveLast = false;
+    bool haveNext = false;
+
+    gadget->cueParser.restart();
+    while ((trackInfo = gadget->cueParser.next_track()) != nullptr)
+    {
+        if (trackInfo->track_number < nextSessionStart)
+        {
+            lastOfSession = *trackInfo;
+            haveLast = true;
+        }
+        else if (trackInfo->track_number == nextSessionStart)
+        {
+            firstOfNext = *trackInfo;
+            haveNext = true;
+        }
+    }
+
+    if (!haveLast || !haveNext || lastOfSession.sector_length == 0)
+        return GetLeadoutLBA(gadget);
+
+    // Different source files means the byte offsets are not comparable; fall
+    // back on the next session's start, which errs long by the gap rather than
+    // reporting a lead-out inside the audio.
+    if (lastOfSession.file_index != firstOfNext.file_index ||
+        firstOfNext.file_offset <= lastOfSession.file_offset)
+        return firstOfNext.track_start;
+
+    u64 storedBytes = firstOfNext.file_offset - lastOfSession.file_offset;
+    u32 storedFrames = (u32)(storedBytes / lastOfSession.sector_length);
+
+    return lastOfSession.data_start + storedFrames;
 }
 
 u32 CDUtils::GetLeadoutLBA(CUSBCDGadget* gadget)

--- a/addon/usbcdgadget/cd_utils.h
+++ b/addon/usbcdgadget/cd_utils.h
@@ -40,8 +40,23 @@ public:
     static int GetSkipbytesForTrack(CUSBCDGadget* gadget, CUETrackInfo trackInfo);
 
     static int GetMediumType(CUSBCDGadget* gadget);
-    static int GetSectorLengthFromMCS(uint8_t mainChannelSelection);
-    static int GetSkipBytesFromMCS(uint8_t mainChannelSelection);
+
+    // Sizes of the five fields of one sector, in the order they appear on the
+    // disc. A field that this sector kind does not have is zero: Mode 1 has no
+    // subheader, CD-DA has nothing but user data. See cd_utils.cpp.
+    struct TCDSectorShape
+    {
+        int nSync;
+        int nHeader;
+        int nSubheader;
+        int nUserData;
+        int nEdcEcc;
+    };
+
+    static TCDSectorShape GetSectorShape(int expectedSectorType, CUETrackMode trackMode);
+    static bool McsFieldsAreContiguous(uint8_t mainChannelSelection, const TCDSectorShape& shape);
+    static int GetSectorLengthFromMCS(uint8_t mainChannelSelection, const TCDSectorShape& shape);
+    static int GetSkipBytesFromMCS(uint8_t mainChannelSelection, const TCDSectorShape& shape);
 };
 
 #endif

--- a/addon/usbcdgadget/cd_utils.h
+++ b/addon/usbcdgadget/cd_utils.h
@@ -14,6 +14,7 @@ public:
     // Address Conversion Utilities
     static void LBA2MSF(int32_t LBA, uint8_t *MSF, bool relative);
     static void LBA2MSFBCD(int32_t LBA, uint8_t *MSF, bool relative);
+    static uint8_t ToBCD(int value);
     static int32_t MSF2LBA(uint8_t m, uint8_t s, uint8_t f, bool relative);
     static u32 GetAddress(u32 lba, int msf, boolean relative);
     static u32 lba_to_msf(u32 lba, boolean relative = false);
@@ -24,6 +25,13 @@ public:
     static CUETrackInfo GetTrackInfoForTrack(CUSBCDGadget* gadget, int track);
     static int GetLastTrackNumber(CUSBCDGadget* gadget);
     static u32 GetLeadoutLBA(CUSBCDGadget* gadget);
+
+    // Session layout. A CD Extra / Enhanced CD holds its audio tracks in
+    // session 1 and a single data track in session 2, and hosts locate the
+    // filesystem through the session structure rather than the track list.
+    static int GetSessionCount(CUSBCDGadget* gadget);
+    static int GetLastSessionStartTrack(CUSBCDGadget* gadget);
+    static u32 GetSessionLeadoutLBA(CUSBCDGadget* gadget, int session);
 
     static int GetBlocksize(CUSBCDGadget* gadget);
     static int GetBlocksizeForTrack(CUSBCDGadget* gadget, CUETrackInfo trackInfo);

--- a/addon/usbcdgadget/scsi_read.cpp
+++ b/addon/usbcdgadget/scsi_read.cpp
@@ -412,54 +412,42 @@ void SCSIRead::ReadCD(CUSBCDGadget* gadget)
         return;
     }
 
-    // Determine sector parameters based on expected type or track mode
-    switch (expectedSectorType)
+    // Which parts of the sector to return is decided by the field selection in
+    // CDB byte 9, and by nothing else. The expected sector type in byte 1 says
+    // what kind of sector the host will accept - it was validated above - and
+    // it tells us how big each field is, but it does not choose the fields.
+    //
+    // This used to be a switch on the expected type that set a fixed slice and
+    // ignored byte 9 completely. Windows XP asks for a Mode 2 Form 2 sector
+    // (type 5) with sync, header, subheader and user data, expecting 2348
+    // bytes from the start of the sector; it was handed 2328 bytes beginning 24
+    // bytes in, at the MPEG payload rather than the sync pattern. It retried
+    // once as a formless Mode 2 read, got another wrong slice, and reported the
+    // file as unreadable.
+    CDUtils::TCDSectorShape shape =
+        CDUtils::GetSectorShape(expectedSectorType, (CUETrackMode)trackInfo.track_mode);
+
+    if (!CDUtils::McsFieldsAreContiguous(gadget->mcs, shape))
     {
-    case 0x01: // CD-DA
-        gadget->block_size = 2352;
-        gadget->transfer_block_size = 2352;
-        gadget->skip_bytes = 0;
-        break;
+        CDROM_DEBUG_LOG("SCSIRead::ReadCD",
+                        "READ CD: non-contiguous field selection 0x%02x", gadget->mcs);
+        gadget->setSenseData(0x05, 0x24, 0x00); // INVALID FIELD IN CDB
+        gadget->sendCheckCondition();
+        return;
+    }
 
-    case 0x02: // Mode 1
-        gadget->skip_bytes = CDUtils::GetSkipbytesForTrack(gadget, trackInfo);
-        gadget->block_size = CDUtils::GetBlocksizeForTrack(gadget, trackInfo);
-        gadget->transfer_block_size = 2048;
-        break;
+    gadget->block_size = CDUtils::GetBlocksizeForTrack(gadget, trackInfo);
+    gadget->transfer_block_size = CDUtils::GetSectorLengthFromMCS(gadget->mcs, shape);
+    gadget->skip_bytes = CDUtils::GetSkipBytesFromMCS(gadget->mcs, shape);
 
-    case 0x03: // Mode 2 formless
-        gadget->skip_bytes = 16;
-        gadget->block_size = 2352;
-        gadget->transfer_block_size = 2336;
-        break;
-
-    case 0x04: // Mode 2 form 1
-        gadget->skip_bytes = CDUtils::GetSkipbytesForTrack(gadget, trackInfo);
-        gadget->block_size = CDUtils::GetBlocksizeForTrack(gadget, trackInfo);
-        gadget->transfer_block_size = 2048;
-        break;
-
-    case 0x05: // Mode 2 form 2
-        gadget->block_size = 2352;
-        gadget->skip_bytes = 24;
-        gadget->transfer_block_size = 2328;
-        break;
-
-    case 0x00: // Type not specified - derive from MCS and track mode
-    default:
-        if (trackInfo.track_mode == CUETrack_AUDIO)
-        {
-            gadget->block_size = 2352;
-            gadget->transfer_block_size = 2352;
-            gadget->skip_bytes = 0;
-        }
-        else
-        {
-            gadget->block_size = CDUtils::GetBlocksizeForTrack(gadget, trackInfo);
-            gadget->transfer_block_size = CDUtils::GetSectorLengthFromMCS(gadget->mcs);
-            gadget->skip_bytes = CDUtils::GetSkipBytesFromMCS(gadget->mcs);
-        }
-        break;
+    if (gadget->transfer_block_size == 0)
+    {
+        // No fields at all. Nothing to send, and the block count below divides
+        // by this, so refuse rather than fault.
+        CDROM_DEBUG_LOG("SCSIRead::ReadCD", "READ CD: no sector fields requested");
+        gadget->setSenseData(0x05, 0x24, 0x00); // INVALID FIELD IN CDB
+        gadget->sendCheckCondition();
+        return;
     }
 
     // Add subchannel data size if requested

--- a/addon/usbcdgadget/scsi_read.cpp
+++ b/addon/usbcdgadget/scsi_read.cpp
@@ -112,11 +112,28 @@ void SCSIRead::DoRead(CUSBCDGadget* gadget, int cdbSize)
                         gadget->m_nblock_address, gadget->m_nnumber_blocks, max_lba);
 
         // Transfer Block Size is the size of data to return to host
-        // Block Size and Skip Bytes is worked out from cue sheet
         // For a CDROM, this is always 2048
         gadget->transfer_block_size = 2048;
-        gadget->block_size = gadget->data_block_size; // set at SetDevice
-        gadget->skip_bytes = gadget->data_skip_bytes; // set at SetDevice
+
+        // Sector layout comes from the track the read starts in, not from
+        // track 1. The cached data_block_size/data_skip_bytes are taken from
+        // the first track at SetDevice time, which is right only when the data
+        // track is first. On a CD Extra the first track is audio, so every
+        // read of the data track skipped 0 bytes instead of 24 and handed the
+        // host a sector shifted by its sync, header and subheader -- the
+        // volume descriptor never had "CD001" where the host looked, and the
+        // disc mounted as audio only.
+        CUETrackInfo trackInfo = CDUtils::GetTrackInfoForLBA(gadget, gadget->m_nblock_address);
+        if (trackInfo.track_number != -1)
+        {
+            gadget->block_size = CDUtils::GetBlocksizeForTrack(gadget, trackInfo);
+            gadget->skip_bytes = CDUtils::GetSkipbytesForTrack(gadget, trackInfo);
+        }
+        else
+        {
+            gadget->block_size = gadget->data_block_size; // set at SetDevice
+            gadget->skip_bytes = gadget->data_skip_bytes; // set at SetDevice
+        }
         gadget->mcs = 0;
         // READ(10)/(12) never carry subchannel data. Clear it alongside mcs
         // so a preceding READ CD cannot leave a selection behind for the

--- a/addon/usbcdgadget/scsi_toc.cpp
+++ b/addon/usbcdgadget/scsi_toc.cpp
@@ -330,12 +330,30 @@ void SCSITOC::DoReadSessionInfo(CUSBCDGadget *gadget, bool msf, uint16_t allocat
         0x00, 0x0A, 0x01, 0x01, 0x00, 0x14, 0x01, 0x00,
         0x00, 0x00, 0x00, 0x00};
 
+    // This reply names the first track of the LAST session, which is where a
+    // host goes looking for a filesystem. On a CD Extra that is the data track
+    // sitting after the audio, not track 1.
+    int sessionCount = CDUtils::GetSessionCount(gadget);
+    int lastSessionStart = CDUtils::GetLastSessionStartTrack(gadget);
+
+    sessionTOC[2] = 0x01;                  // First session
+    sessionTOC[3] = (uint8_t)sessionCount; // Last session
+
     gadget->cueParser.restart();
-    const CUETrackInfo *trackinfo = gadget->cueParser.next_track();
+    const CUETrackInfo *trackinfo;
+    while ((trackinfo = gadget->cueParser.next_track()) != nullptr)
+    {
+        if (trackinfo->track_number == lastSessionStart)
+            break;
+    }
+
     if (trackinfo)
     {
-        CDROM_DEBUG_LOG("SCSITOC::DoReadSessionInfo", "First track: num=%d, start=%u",
-                        trackinfo->track_number, trackinfo->data_start);
+        sessionTOC[5] = (trackinfo->track_mode == CUETrack_AUDIO) ? 0x10 : 0x14;
+        sessionTOC[6] = (uint8_t)trackinfo->track_number;
+
+        CDROM_DEBUG_LOG("SCSITOC::DoReadSessionInfo", "Last session (%d) first track: num=%d, start=%u",
+                        sessionCount, trackinfo->track_number, trackinfo->data_start);
 
         if (msf)
         {
@@ -379,77 +397,139 @@ void SCSITOC::DoReadFullTOC(CUSBCDGadget *gadget, uint8_t session, uint16_t allo
         return;
     }
 
-    if (session > 1)
+    int sessionCount = CDUtils::GetSessionCount(gadget);
+    int lastSessionStart = CDUtils::GetLastSessionStartTrack(gadget);
+
+    // The session field selects where the reply starts, not a filter: a drive
+    // returns that session and every one after it. Asking beyond the last
+    // session is the only invalid case.
+    if (session > sessionCount)
     {
-        CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "INVALID SESSION %d", session);
+        CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "INVALID SESSION %d (disc has %d)", session, sessionCount);
         gadget->setSenseData(0x05, 0x24, 0x00);
         gadget->sendCheckCondition();
         return;
     }
 
-    // Base full TOC structure with A0/A1/A2 descriptors
-    uint8_t fullTOCBase[37] = {
-        0x00, 0x2E, 0x01, 0x01,
-        0x01, 0x14, 0x00, 0xA0, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x01, 0x14, 0x00, 0xA1, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x01, 0x14, 0x00, 0xA2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    int firstSession = (session < 1) ? 1 : session;
 
-    uint32_t len = sizeof(fullTOCBase);
-    memcpy(gadget->m_InBuffer, fullTOCBase, len);
-
-    // Find first and last tracks
+    uint32_t len = 4; // Header, filled in once the entries are laid down
+    const CUETrackInfo *trackinfo;
     int firsttrack = -1;
     CUETrackInfo lasttrack = {0};
-    const CUETrackInfo *trackinfo;
 
-    gadget->cueParser.restart();
-    while ((trackinfo = gadget->cueParser.next_track()) != nullptr)
+    CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "Disc has %d session(s), last starts at track %d",
+                    sessionCount, lastSessionStart);
+
+    for (int s = firstSession; s <= sessionCount; s++)
     {
-        if (firsttrack < 0)
+        // Bounds of this session. A single-session disc is the whole track
+        // list; on a two-session disc the split is at lastSessionStart.
+        int sessionFirstTrack = -1;
+        CUETrackInfo sessionLastTrack = {0};
+        CUETrackInfo sessionFirstInfo = {0};
+
+        gadget->cueParser.restart();
+        while ((trackinfo = gadget->cueParser.next_track()) != nullptr)
         {
-            firsttrack = trackinfo->track_number;
-            if (trackinfo->track_mode == CUETrack_AUDIO)
+            int trackSession = (sessionCount < 2 || trackinfo->track_number < lastSessionStart) ? 1 : 2;
+            if (trackSession != s)
+                continue;
+
+            if (sessionFirstTrack < 0)
             {
-                gadget->m_InBuffer[5] = 0x10;  // A0 control for audio
-                gadget->m_InBuffer[16] = 0x10; // A1 control for audio
-                gadget->m_InBuffer[27] = 0x10; // A2 control for audio
+                sessionFirstTrack = trackinfo->track_number;
+                sessionFirstInfo = *trackinfo;
             }
-            CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "First track: %d, mode=%d", firsttrack, trackinfo->track_mode);
+            sessionLastTrack = *trackinfo;
+
+            if (firsttrack < 0)
+                firsttrack = trackinfo->track_number;
+            lasttrack = *trackinfo;
         }
-        lasttrack = *trackinfo;
 
-        // Add track descriptor
-        FormatRawTOCEntry(gadget, trackinfo, &gadget->m_InBuffer[len], useBCD);
+        if (sessionFirstTrack < 0)
+            continue; // No tracks in this session; nothing to describe
 
-        CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "  Track %d: mode=%d, start=%u",
-                        trackinfo->track_number, trackinfo->track_mode, trackinfo->data_start);
+        bool sessionIsAudio = (sessionFirstInfo.track_mode == CUETrack_AUDIO);
+        uint8_t control = sessionIsAudio ? 0x10 : 0x14;
 
+        // A CD Extra data session is CD-ROM XA, and hosts read the disc type
+        // out of A0's PSEC field to know that before touching a sector.
+        uint8_t discType = 0x00;
+        if (sessionFirstInfo.track_mode == CUETrack_MODE2_2048 ||
+            sessionFirstInfo.track_mode == CUETrack_MODE2_2324 ||
+            sessionFirstInfo.track_mode == CUETrack_MODE2_2336 ||
+            sessionFirstInfo.track_mode == CUETrack_MODE2_2352)
+        {
+            discType = 0x20; // CD-ROM XA
+        }
+        else if (sessionFirstInfo.track_mode == CUETrack_CDI_2336 ||
+                 sessionFirstInfo.track_mode == CUETrack_CDI_2352)
+        {
+            discType = 0x10; // CD-i
+        }
+
+        u32 sessionLeadout = CDUtils::GetSessionLeadoutLBA(gadget, s);
+
+        CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC",
+                        "Session %d: tracks %d-%d, control=%02x, discType=%02x, leadout LBA=%u",
+                        s, sessionFirstTrack, sessionLastTrack.track_number, control, discType, sessionLeadout);
+
+        // A0: first track of this session, plus the disc type
+        uint8_t *p = &gadget->m_InBuffer[len];
+        memset(p, 0, 11);
+        p[0] = (uint8_t)s;
+        p[1] = control;
+        p[3] = 0xA0;
+        p[8] = useBCD ? CDUtils::ToBCD(sessionFirstTrack) : (uint8_t)sessionFirstTrack;
+        p[9] = discType;
         len += 11;
+
+        // A1: last track of this session
+        p = &gadget->m_InBuffer[len];
+        memset(p, 0, 11);
+        p[0] = (uint8_t)s;
+        p[1] = control;
+        p[3] = 0xA1;
+        p[8] = useBCD ? CDUtils::ToBCD(sessionLastTrack.track_number) : (uint8_t)sessionLastTrack.track_number;
+        len += 11;
+
+        // A2: lead-out of this session
+        p = &gadget->m_InBuffer[len];
+        memset(p, 0, 11);
+        p[0] = (uint8_t)s;
+        p[1] = control;
+        p[3] = 0xA2;
+        if (useBCD)
+            CDUtils::LBA2MSFBCD(sessionLeadout, &p[8], false);
+        else
+            CDUtils::LBA2MSF(sessionLeadout, &p[8], false);
+        len += 11;
+
+        // Track descriptors for this session
+        gadget->cueParser.restart();
+        while ((trackinfo = gadget->cueParser.next_track()) != nullptr)
+        {
+            int trackSession = (sessionCount < 2 || trackinfo->track_number < lastSessionStart) ? 1 : 2;
+            if (trackSession != s)
+                continue;
+
+            FormatRawTOCEntry(gadget, trackinfo, &gadget->m_InBuffer[len], useBCD);
+            gadget->m_InBuffer[len] = (uint8_t)s;
+
+            CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "  Session %d Track %d: mode=%d, start=%u",
+                            s, trackinfo->track_number, trackinfo->track_mode, trackinfo->data_start);
+
+            len += 11;
+        }
     }
 
-    // Update A0, A1, A2 descriptors
-    gadget->m_InBuffer[12] = firsttrack;
-    gadget->m_InBuffer[23] = lasttrack.track_number;
+    gadget->m_InBuffer[2] = (uint8_t)firstSession;
+    gadget->m_InBuffer[3] = (uint8_t)sessionCount;
 
-    CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "Header: First=%d, Last=%d. A0: First=%d, A1: Last=%d",
-                    firsttrack, lasttrack.track_number, firsttrack, lasttrack.track_number);
-
-    // A2: Leadout position
-    u32 leadoutLBA = CDUtils::GetLeadoutLBA(gadget);
-    CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "A2: Lead-out LBA=%u", leadoutLBA);
-
-    if (useBCD)
-    {
-        CDUtils::LBA2MSFBCD(leadoutLBA, &gadget->m_InBuffer[34], false);
-        CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "A2 MSF (BCD): %02x:%02x:%02x",
-                        gadget->m_InBuffer[34], gadget->m_InBuffer[35], gadget->m_InBuffer[36]);
-    }
-    else
-    {
-        CDUtils::LBA2MSF(leadoutLBA, &gadget->m_InBuffer[34], false);
-        CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "A2 MSF: %02x:%02x:%02x",
-                        gadget->m_InBuffer[34], gadget->m_InBuffer[35], gadget->m_InBuffer[36]);
-    }
+    CDROM_DEBUG_LOG("SCSITOC::DoReadFullTOC", "Header: FirstSession=%d, LastSession=%d, First=%d, Last=%d",
+                    firstSession, sessionCount, firsttrack, lasttrack.track_number);
 
     // Update TOC length
     uint16_t toclen = len - 2;
@@ -499,8 +579,10 @@ void SCSITOC::ReadDiscInformation(CUSBCDGadget *gadget)
     // Update disc information with current media state
     gadget->m_DiscInfoReply.disc_status = 0x0E; // Complete disc, finalized, last session complete
     gadget->m_DiscInfoReply.first_track_number = 0x01;
-    gadget->m_DiscInfoReply.number_of_sessions = 0x01; // Single session
-    gadget->m_DiscInfoReply.first_track_last_session = 0x01;
+    // Must agree with the full TOC, which Windows reads first: a disc that
+    // reports two sessions there and one here gets treated as neither.
+    gadget->m_DiscInfoReply.number_of_sessions = (uint8_t)CDUtils::GetSessionCount(gadget);
+    gadget->m_DiscInfoReply.first_track_last_session = (uint8_t)CDUtils::GetLastSessionStartTrack(gadget);
     gadget->m_DiscInfoReply.last_track_last_session = CDUtils::GetLastTrackNumber(gadget);
 
     // Set disc type based on track 1 mode

--- a/addon/usbcdgadget/scsi_toc.cpp
+++ b/addon/usbcdgadget/scsi_toc.cpp
@@ -585,15 +585,29 @@ void SCSITOC::ReadDiscInformation(CUSBCDGadget *gadget)
     gadget->m_DiscInfoReply.first_track_last_session = (uint8_t)CDUtils::GetLastSessionStartTrack(gadget);
     gadget->m_DiscInfoReply.last_track_last_session = CDUtils::GetLastTrackNumber(gadget);
 
-    // Set disc type based on track 1 mode
-    CUETrackInfo trackInfo = CDUtils::GetTrackInfoForTrack(gadget, 1);
-    if (trackInfo.track_number != -1 && trackInfo.track_mode == CUETrack_AUDIO)
+    // Disc type of the last session, matching the value carried in that
+    // session's A0 pointer in the full TOC. MMC defines only three: 0x00 for
+    // CD-DA or CD-ROM, 0x10 for CD-i, 0x20 for CD-ROM XA. Plain data discs
+    // were being reported as 0x10, which claims CD-i.
+    CUETrackInfo lastSessionTrack =
+        CDUtils::GetTrackInfoForTrack(gadget, CDUtils::GetLastSessionStartTrack(gadget));
+    if (lastSessionTrack.track_number != -1 &&
+        (lastSessionTrack.track_mode == CUETrack_MODE2_2048 ||
+         lastSessionTrack.track_mode == CUETrack_MODE2_2324 ||
+         lastSessionTrack.track_mode == CUETrack_MODE2_2336 ||
+         lastSessionTrack.track_mode == CUETrack_MODE2_2352))
     {
-        gadget->m_DiscInfoReply.disc_type = 0x00; // CD-DA (audio)
+        gadget->m_DiscInfoReply.disc_type = 0x20; // CD-ROM XA
+    }
+    else if (lastSessionTrack.track_number != -1 &&
+             (lastSessionTrack.track_mode == CUETrack_CDI_2336 ||
+              lastSessionTrack.track_mode == CUETrack_CDI_2352))
+    {
+        gadget->m_DiscInfoReply.disc_type = 0x10; // CD-i
     }
     else
     {
-        gadget->m_DiscInfoReply.disc_type = 0x10; // CD-ROM (data)
+        gadget->m_DiscInfoReply.disc_type = 0x00; // CD-DA or CD-ROM
     }
 
     u32 leadoutLBA = CDUtils::GetLeadoutLBA(gadget);

--- a/addon/usbcdgadget/scsi_toc.cpp
+++ b/addon/usbcdgadget/scsi_toc.cpp
@@ -158,11 +158,15 @@ void SCSITOC::FormatRawTOCEntry(CUSBCDGadget *gadget, const CUETrackInfo *track,
         control_adr = 0x10; // Audio track
     }
 
-    dest[0] = 0x01; // Session always 1
+    dest[0] = 0x01; // Session; the caller overwrites this per session
     dest[1] = control_adr;
-    dest[2] = 0x00;                // TNO, always 0
-    dest[3] = track->track_number; // POINT
-    dest[4] = 0x00;                // ATIME (unused)
+    dest[2] = 0x00; // TNO, always 0
+    // POINT. In BCD mode every numeric field is BCD, this one included: a
+    // binary track number above 9 is not even valid BCD (31 -> 0x1F), so a
+    // host decoding it cannot identify the track. Tracks 1-9 encode
+    // identically either way, which is why this stayed hidden.
+    dest[3] = useBCD ? CDUtils::ToBCD(track->track_number) : (uint8_t)track->track_number;
+    dest[4] = 0x00; // ATIME (unused)
     dest[5] = 0x00;
     dest[6] = 0x00;
     dest[7] = 0; // HOUR

--- a/addon/usbcdgadget/usbcdgadget.cpp
+++ b/addon/usbcdgadget/usbcdgadget.cpp
@@ -690,6 +690,16 @@ void CUSBCDGadget::OnTransferComplete(boolean bIn, size_t nLength)
         }
         case TCDState::SendReqSenseReply:
         {
+            // BOT 6.7: the residue has to account for the sense bytes just
+            // sent, exactly as the DataIn case above does. Leaving it at the
+            // full transfer length tells the host no sense data arrived, so it
+            // cannot see that a failure is permanent and retries a command
+            // that will never succeed.
+            CTraceLab::Get()->TraceTransferComplete((u32)nLength);
+            if (m_CSW.dCSWDataResidue >= (u32)nLength)
+                m_CSW.dCSWDataResidue -= (u32)nLength;
+            else
+                m_CSW.dCSWDataResidue = 0;
             SendCSW();
             break;
         }

--- a/integration-tests/harness/framework.cpp
+++ b/integration-tests/harness/framework.cpp
@@ -58,6 +58,7 @@ namespace
         {"test_toolbox", "Vendor toolbox commands"},
         {"test_realimages", "Real disc images"},
         {"test_mdsimages", "MDS/MDF images"},
+        {"test_multisession", "Multi-session and CD Extra"},
     };
 
     // "test-suite/test_read10.cpp" -> "SCSI read commands"

--- a/integration-tests/test-suite/test_multisession.cpp
+++ b/integration-tests/test-suite/test_multisession.cpp
@@ -50,6 +50,22 @@ static const char *const kCDExtraCueNoMarkers =
     "  TRACK 04 MODE1/2352\n"
     "    INDEX 01 02:48:00\n";
 
+// Same disc again, but the ripper wrote down where session 1's lead-out sits.
+// 02:20:00 = LBA 10500, which is 2100 frames before the data track.
+static const char *const kCDExtraCueWithLeadout =
+    "REM SESSION 01\n"
+    "FILE \"image.bin\" BINARY\n"
+    "  TRACK 01 AUDIO\n"
+    "    INDEX 01 00:00:00\n"
+    "  TRACK 02 AUDIO\n"
+    "    INDEX 01 00:05:25\n"
+    "  TRACK 03 AUDIO\n"
+    "    INDEX 01 00:10:50\n"
+    "  REM LEAD-OUT 02:20:00\n"
+    "REM SESSION 02\n"
+    "  TRACK 04 MODE2/2352\n"
+    "    INDEX 01 02:48:00\n";
+
 static const u32 kDataTrackLBA = 12600; // 02:48:00
 
 static std::vector<u8> PatternImage(u32 sectors, u32 sectorSize)
@@ -180,6 +196,66 @@ TEST(cdextra_session_split_inferred_without_rem_markers)
         CHECK_EQ(without[i].session, withMarkers[i].session);
         CHECK_EQ(without[i].point, withMarkers[i].point);
     }
+}
+
+// MSF in a full TOC entry is absolute: LBA 0 is 00:02:00, so add 150 frames.
+static u32 MSFToLBA(u8 m, u8 s, u8 f)
+{
+    return (u32)m * 60 * 75 + (u32)s * 75 + f - 150;
+}
+
+TEST(cdextra_session1_leadout_precedes_session2)
+{
+    // A lead-out sitting on the next session's first track describes two
+    // sessions that touch, which cannot physically happen -- hosts are
+    // entitled to reject the whole session structure over it.
+    auto entries = ParseFullTOC(FullTOCFor(MakeCDExtra(kCDExtraCueWithMarkers)));
+
+    RawTOCEntry leadout1, track4;
+    CHECK(FindPointer(entries, 1, 0xA2, &leadout1));
+    CHECK(FindPointer(entries, 2, 0x04, &track4));
+
+    u32 leadoutLBA = MSFToLBA(leadout1.pmin, leadout1.psec, leadout1.pframe);
+    u32 trackLBA = MSFToLBA(track4.pmin, track4.psec, track4.pframe);
+
+    CHECK_EQ(trackLBA, kDataTrackLBA);
+    CHECK(leadoutLBA < trackLBA);
+    // No marker in this cue, so the standard 11250-frame gap is assumed.
+    CHECK_EQ(leadoutLBA, kDataTrackLBA - 11250);
+}
+
+TEST(cdextra_session1_leadout_uses_rem_marker_when_present)
+{
+    auto entries = ParseFullTOC(FullTOCFor(MakeCDExtra(kCDExtraCueWithLeadout)));
+
+    RawTOCEntry leadout1;
+    CHECK(FindPointer(entries, 1, 0xA2, &leadout1));
+    // REM LEAD-OUT 02:20:00 = LBA 10500, not the assumed gap position.
+    CHECK_EQ(MSFToLBA(leadout1.pmin, leadout1.psec, leadout1.pframe), 10500u);
+}
+
+TEST(cdextra_leadout_never_lands_inside_the_last_audio_track)
+{
+    // A merged image can place the sessions closer together than the standard
+    // gap. Subtracting it blindly would report a lead-out in the middle of the
+    // audio, truncating the last track for anything that plays it.
+    static const char *const kTightCue =
+        "FILE \"image.bin\" BINARY\n"
+        "  TRACK 01 AUDIO\n"
+        "    INDEX 01 00:00:00\n"
+        "  TRACK 02 AUDIO\n"
+        "    INDEX 01 02:00:00\n"
+        "  TRACK 03 MODE1/2352\n"
+        "    INDEX 01 02:10:00\n"; // only 750 frames after track 2
+
+    auto entries = ParseFullTOC(FullTOCFor(MakeCDExtra(kTightCue, 3)));
+
+    RawTOCEntry leadout1;
+    CHECK(FindPointer(entries, 1, 0xA2, &leadout1));
+    u32 leadoutLBA = MSFToLBA(leadout1.pmin, leadout1.psec, leadout1.pframe);
+
+    CHECK(leadoutLBA > 9000u);  // track 2 starts at LBA 9000
+    CHECK(leadoutLBA <= 9750u); // and the data track at 9750
 }
 
 TEST(cdextra_session_info_names_the_data_track)

--- a/integration-tests/test-suite/test_multisession.cpp
+++ b/integration-tests/test-suite/test_multisession.cpp
@@ -16,6 +16,8 @@
 #include "bench.h"
 #include "framework.h"
 
+#include <string.h>
+
 #include <string>
 #include <vector>
 
@@ -332,6 +334,63 @@ TEST(cdextra_data_track_is_readable_at_its_lba)
 
     CHECK_EQ(r.csw.bmCSWStatus, 0);
     CHECK_EQ(r.data.size(), 2048u);
+}
+
+// A CD Extra whose data track carries a real Mode 2 Form 1 sector: 12 bytes of
+// sync, a 4-byte header, an 8-byte subheader, then 2048 bytes of user data
+// beginning with an ISO 9660 volume descriptor. This is the layout of the
+// reporter's disc, and the shape the reader has to get right.
+static CFakeImageDevice *MakeCDExtraWithFilesystem()
+{
+    const u32 totalSectors = kDataTrackLBA + 600;
+    std::vector<u8> image((size_t)totalSectors * 2352);
+    for (u32 lba = 0; lba < totalSectors; lba++)
+    {
+        FillPatternSector(image.data() + (size_t)lba * 2352, lba, 2352);
+    }
+
+    // Volume descriptor 16 sectors into the data track.
+    u8 *sector = image.data() + (size_t)(kDataTrackLBA + 16) * 2352;
+    static const u8 kSync[12] = {0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00};
+    memcpy(sector, kSync, sizeof(kSync));
+    sector[12] = 0x61; // minute
+    sector[13] = 0x01; // second
+    sector[14] = 0x29; // frame
+    sector[15] = 0x02; // mode 2
+    memset(sector + 16, 0, 8);
+    sector[18] = 0x09; // subheader submode: data, end of record
+    sector[22] = 0x09;
+    u8 *user = sector + 24;
+    user[0] = 0x01; // primary volume descriptor
+    memcpy(user + 1, "CD001", 5);
+    user[6] = 0x01; // version
+
+    CFakeImageDevice *disc = new CFakeImageDevice(kCDExtraCueWithMarkers, std::move(image), 2352);
+    disc->m_numTracks = 4;
+    return disc;
+}
+
+TEST(cdextra_read10_returns_user_data_not_the_sector_header)
+{
+    // The whole failure mode of issue #91 in one assertion: the sector layout
+    // has to come from the track the read lands in, not from track 1. With
+    // track 1 audio, a reader keyed on it skips 0 bytes instead of 24 and the
+    // host sees sync bytes where the volume descriptor should be.
+    CGadgetTestBench bench(MakeCDExtraWithFilesystem());
+    bench.Activate();
+    bench.RequestSense();
+
+    const u32 lba = kDataTrackLBA + 16;
+    const u8 cdb[10] = {0x28, 0x00,
+                        (u8)(lba >> 24), (u8)(lba >> 16), (u8)(lba >> 8), (u8)lba,
+                        0x00, 0x00, 0x01, 0x00};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2048);
+
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    CHECK_EQ(r.data.size(), 2048u);
+    const u8 expected[7] = {0x01, 'C', 'D', '0', '0', '1', 0x01};
+    CHECK_BYTES(r.data.data(), 7, expected, sizeof(expected));
 }
 
 TEST(mixed_mode_data_first_stays_single_session)

--- a/integration-tests/test-suite/test_multisession.cpp
+++ b/integration-tests/test-suite/test_multisession.cpp
@@ -260,6 +260,84 @@ TEST(cdextra_leadout_never_lands_inside_the_last_audio_track)
     CHECK(leadoutLBA <= 9750u); // and the data track at 9750
 }
 
+TEST(cdextra_bcd_full_toc_encodes_track_numbers_in_bcd)
+{
+    // macOS asks for the full TOC through the legacy byte-9 encoding, which
+    // answers in BCD. Every numeric field has to be BCD then, POINT included:
+    // track 31 as binary 0x1F is not a valid BCD value, and a host decoding it
+    // cannot find the data track. Tracks 1-9 are identical in both encodings,
+    // so only a disc with more than nine tracks shows the difference.
+    // Two-digit track numbers, as on the reporter's 31-track disc: the data
+    // track is number 11, which is 0x0B in binary and 0x11 in BCD.
+    static const char *const kCue =
+        "REM SESSION 01\n"
+        "FILE \"image.bin\" BINARY\n"
+        "  TRACK 09 AUDIO\n"
+        "    INDEX 01 00:00:00\n"
+        "  TRACK 10 AUDIO\n"
+        "    INDEX 01 00:05:25\n"
+        "REM SESSION 02\n"
+        "  TRACK 11 MODE2/2352\n"
+        "    INDEX 01 02:48:00\n";
+
+    CGadgetTestBench bench(MakeCDExtra(kCue, 3));
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 cdb[10] = {0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x80};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 768);
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+
+    bool sawDataTrack = false;
+    for (const RawTOCEntry &e : ParseFullTOC(r.data))
+    {
+        if (e.session == 2 && e.point == 0x11)
+        {
+            sawDataTrack = true;
+            CHECK_EQ(e.control_adr, 0x14);
+        }
+        // Nothing in a BCD reply may carry a nibble above 9.
+        CHECK((e.point & 0x0F) <= 9);
+        CHECK((e.pmin & 0x0F) <= 9);
+        CHECK((e.psec & 0x0F) <= 9 || e.point == 0xA0); // A0 PSEC is the disc type
+        CHECK((e.pframe & 0x0F) <= 9);
+    }
+    CHECK(sawDataTrack);
+}
+
+TEST(bcd_full_toc_track_numbers_above_nine)
+{
+    // The plain case the CD Extra test cannot show on its own: a two-digit
+    // track number has to come back as BCD, not binary.
+    static const char *const kTwelveTrackCue =
+        "FILE \"image.bin\" BINARY\n"
+        "  TRACK 09 AUDIO\n"
+        "    INDEX 01 00:00:00\n"
+        "  TRACK 10 AUDIO\n"
+        "    INDEX 01 00:05:00\n"
+        "  TRACK 12 AUDIO\n"
+        "    INDEX 01 00:10:00\n";
+
+    CGadgetTestBench bench(MakeCDExtra(kTwelveTrackCue, 3));
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 cdb[10] = {0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x80};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 768);
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+
+    bool saw09 = false, saw10 = false, saw12 = false;
+    for (const RawTOCEntry &e : ParseFullTOC(r.data))
+    {
+        if (e.point == 0x09) saw09 = true;
+        if (e.point == 0x10) saw10 = true; // BCD 10, not binary 0x0A
+        if (e.point == 0x12) saw12 = true; // BCD 12, not binary 0x0C
+    }
+    CHECK(saw09);
+    CHECK(saw10);
+    CHECK(saw12);
+}
+
 TEST(cdextra_session_info_names_the_data_track)
 {
     CGadgetTestBench bench(MakeCDExtra(kCDExtraCueWithMarkers));

--- a/integration-tests/test-suite/test_multisession.cpp
+++ b/integration-tests/test-suite/test_multisession.cpp
@@ -1,0 +1,295 @@
+//
+// test_multisession.cpp
+//
+// CD Extra / Enhanced CD: audio tracks in session 1, a single data track in
+// session 2. Hosts locate the filesystem through the session structure in the
+// full TOC (READ TOC format 0x02), not through the track list, so a disc
+// described as single-session mounts as "Audio CD" and its data track is never
+// read -- issue #91.
+//
+// Traces of two hosts reading the reporter's disc showed both asking for the
+// full TOC and neither asking for format 0x01: one used format 0x02 in CDB
+// byte 2, the other the legacy byte-9 encoding that answers in BCD. So the
+// full TOC is the reply that decides whether the disc mounts, and READ DISC
+// INFORMATION has to agree with it. Both are pinned here, in both encodings.
+//
+#include "bench.h"
+#include "framework.h"
+
+#include <string>
+#include <vector>
+
+// Three audio tracks then a data track, with the ~11400 frame gap a real CD
+// Extra leaves between session 1's lead-out and session 2's lead-in.
+//
+// Track 1 LBA 0, track 2 LBA 400, track 3 LBA 800, data track LBA 12600.
+static const char *const kCDExtraCueWithMarkers =
+    "REM SESSION 01\n"
+    "FILE \"image.bin\" BINARY\n"
+    "  TRACK 01 AUDIO\n"
+    "    INDEX 01 00:00:00\n"
+    "  TRACK 02 AUDIO\n"
+    "    INDEX 01 00:05:25\n"
+    "  TRACK 03 AUDIO\n"
+    "    INDEX 01 00:10:50\n"
+    "REM SESSION 02\n"
+    "  TRACK 04 MODE2/2352\n"
+    "    INDEX 01 02:48:00\n";
+
+// The same disc after a merging tool has dropped the session markers -- this
+// is what CDFix and friends produce, and what issue #91 was originally
+// reported against. The layout alone has to be enough.
+static const char *const kCDExtraCueNoMarkers =
+    "FILE \"image.bin\" BINARY\n"
+    "  TRACK 01 AUDIO\n"
+    "    INDEX 01 00:00:00\n"
+    "  TRACK 02 AUDIO\n"
+    "    INDEX 01 00:05:25\n"
+    "  TRACK 03 AUDIO\n"
+    "    INDEX 01 00:10:50\n"
+    "  TRACK 04 MODE1/2352\n"
+    "    INDEX 01 02:48:00\n";
+
+static const u32 kDataTrackLBA = 12600; // 02:48:00
+
+static std::vector<u8> PatternImage(u32 sectors, u32 sectorSize)
+{
+    std::vector<u8> image((size_t)sectors * sectorSize);
+    for (u32 lba = 0; lba < sectors; lba++)
+    {
+        FillPatternSector(image.data() + (size_t)lba * sectorSize, lba, sectorSize);
+    }
+    return image;
+}
+
+static CFakeImageDevice *MakeCDExtra(const char *cue, int nTracks = 4)
+{
+    CFakeImageDevice *disc =
+        new CFakeImageDevice(cue, PatternImage(kDataTrackLBA + 600, 2352), 2352);
+    disc->m_numTracks = nTracks;
+    return disc;
+}
+
+// One entry of a full TOC reply: 11 bytes starting at the header.
+struct RawTOCEntry
+{
+    u8 session;
+    u8 control_adr;
+    u8 point;
+    u8 pmin, psec, pframe;
+};
+
+static std::vector<RawTOCEntry> ParseFullTOC(const std::vector<u8> &data)
+{
+    std::vector<RawTOCEntry> entries;
+    for (size_t i = 4; i + 11 <= data.size(); i += 11)
+    {
+        RawTOCEntry e;
+        e.session = data[i + 0];
+        e.control_adr = data[i + 1];
+        e.point = data[i + 3];
+        e.pmin = data[i + 8];
+        e.psec = data[i + 9];
+        e.pframe = data[i + 10];
+        entries.push_back(e);
+    }
+    return entries;
+}
+
+static std::vector<u8> FullTOCFor(CFakeImageDevice *disc, u8 sessionField = 0)
+{
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 cdb[10] = {0x43, 0x00, 0x02, 0x00, 0x00, 0x00, sessionField, 0x03, 0x00, 0x00};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 768);
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    return r.data;
+}
+
+// Finds the A0/A1/A2 pointer entry for a session. point is 0xA0, 0xA1 or 0xA2.
+static bool FindPointer(const std::vector<RawTOCEntry> &entries, u8 session, u8 point,
+                        RawTOCEntry *out)
+{
+    for (const RawTOCEntry &e : entries)
+    {
+        if (e.session == session && e.point == point)
+        {
+            *out = e;
+            return true;
+        }
+    }
+    return false;
+}
+
+TEST(cdextra_full_toc_reports_two_sessions)
+{
+    auto data = FullTOCFor(MakeCDExtra(kCDExtraCueWithMarkers));
+
+    // Header: first session 1, last session 2. Reporting 1 here is what made
+    // Windows treat the disc as audio-only.
+    CHECK_EQ(data[2], 0x01);
+    CHECK_EQ(data[3], 0x02);
+
+    auto entries = ParseFullTOC(data);
+
+    // Both sessions carry their own A0/A1/A2 set.
+    RawTOCEntry p;
+    CHECK(FindPointer(entries, 1, 0xA0, &p));
+    CHECK_EQ(p.pmin, 1); // session 1 first track
+    CHECK_EQ(p.control_adr, 0x10);
+    CHECK(FindPointer(entries, 1, 0xA1, &p));
+    CHECK_EQ(p.pmin, 3); // session 1 last track
+
+    CHECK(FindPointer(entries, 2, 0xA0, &p));
+    CHECK_EQ(p.pmin, 4);        // session 2 first track: the data track
+    CHECK_EQ(p.psec, 0x20);     // disc type CD-ROM XA
+    CHECK_EQ(p.control_adr, 0x14);
+    CHECK(FindPointer(entries, 2, 0xA1, &p));
+    CHECK_EQ(p.pmin, 4); // session 2 last track
+    CHECK(FindPointer(entries, 2, 0xA2, &p));
+}
+
+TEST(cdextra_full_toc_assigns_tracks_to_sessions)
+{
+    auto entries = ParseFullTOC(FullTOCFor(MakeCDExtra(kCDExtraCueWithMarkers)));
+
+    int found = 0;
+    for (const RawTOCEntry &e : entries)
+    {
+        if (e.point < 1 || e.point > 99)
+            continue; // pointer entry, not a track
+        found++;
+        // Audio tracks 1-3 in session 1, data track 4 in session 2.
+        CHECK_EQ(e.session, e.point == 4 ? 2 : 1);
+        CHECK_EQ(e.control_adr, e.point == 4 ? 0x14 : 0x10);
+    }
+    CHECK_EQ(found, 4);
+}
+
+TEST(cdextra_session_split_inferred_without_rem_markers)
+{
+    // A merged cue that lost "REM SESSION" must still split, from layout alone.
+    auto withMarkers = ParseFullTOC(FullTOCFor(MakeCDExtra(kCDExtraCueWithMarkers)));
+    auto without = ParseFullTOC(FullTOCFor(MakeCDExtra(kCDExtraCueNoMarkers)));
+
+    CHECK_EQ(withMarkers.size(), without.size());
+    for (size_t i = 0; i < without.size() && i < withMarkers.size(); i++)
+    {
+        CHECK_EQ(without[i].session, withMarkers[i].session);
+        CHECK_EQ(without[i].point, withMarkers[i].point);
+    }
+}
+
+TEST(cdextra_session_info_names_the_data_track)
+{
+    CGadgetTestBench bench(MakeCDExtra(kCDExtraCueWithMarkers));
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 cdb[10] = {0x43, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 12, 0x00};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 12);
+
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    const u8 expected[12] = {
+        0x00, 0x0A,             // length 10
+        0x01, 0x02,             // first session 1, last session 2
+        0x00, 0x14, 0x04, 0x00, // data track 4, control 0x14
+        0x00, 0x00, 0x31, 0x38, // LBA 12600: where the filesystem lives
+    };
+    CHECK_BYTES(r.data.data(), r.data.size(), expected, sizeof(expected));
+}
+
+TEST(cdextra_disc_information_agrees_with_toc)
+{
+    CGadgetTestBench bench(MakeCDExtra(kCDExtraCueWithMarkers));
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 cdb[10] = {0x51, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 34, 0x00};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 34);
+
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    CHECK(r.data.size() >= 7);
+    CHECK_EQ(r.data[4], 0x02); // number of sessions LSB
+    CHECK_EQ(r.data[5], 0x04); // first track in last session: the data track
+    CHECK_EQ(r.data[6], 0x04); // last track in last session
+}
+
+TEST(cdextra_full_toc_session_field_selects_last_session)
+{
+    // The session field is a starting point, not a filter: asking for session 2
+    // returns session 2 only, and asking past the last session is an error.
+    auto entries = ParseFullTOC(FullTOCFor(MakeCDExtra(kCDExtraCueWithMarkers), 2));
+    CHECK(entries.size() > 0);
+    for (const RawTOCEntry &e : entries)
+    {
+        CHECK_EQ(e.session, 2);
+    }
+}
+
+TEST(cdextra_full_toc_rejects_session_past_the_last)
+{
+    CGadgetTestBench bench(MakeCDExtra(kCDExtraCueWithMarkers));
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 cdb[10] = {0x43, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x03, 0x00, 0x00};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 768);
+    CHECK_EQ(r.csw.bmCSWStatus, 1);
+}
+
+TEST(cdextra_data_track_is_readable_at_its_lba)
+{
+    // The reads were never the problem -- Windows just never asked. Guard that
+    // the track the new TOC points at actually serves data.
+    CGadgetTestBench bench(MakeCDExtra(kCDExtraCueWithMarkers));
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 cdb[10] = {0x28, 0x00,
+                        (u8)(kDataTrackLBA >> 24), (u8)(kDataTrackLBA >> 16),
+                        (u8)(kDataTrackLBA >> 8), (u8)kDataTrackLBA,
+                        0x00, 0x00, 0x01, 0x00};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2048);
+
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    CHECK_EQ(r.data.size(), 2048u);
+}
+
+TEST(mixed_mode_data_first_stays_single_session)
+{
+    // Data track first then audio is an ordinary single-session mixed-mode
+    // disc. No data track follows audio, so nothing should change for it.
+    CFakeImageDevice *disc = MakeMixedModeCD(1000, 2, 400);
+    auto data = FullTOCFor(disc);
+
+    CHECK_EQ(data[2], 0x01);
+    CHECK_EQ(data[3], 0x01);
+    for (const RawTOCEntry &e : ParseFullTOC(data))
+    {
+        CHECK_EQ(e.session, 1);
+    }
+}
+
+TEST(audio_cd_stays_single_session)
+{
+    auto data = FullTOCFor(MakeAudioCD(3, 3000));
+
+    CHECK_EQ(data[2], 0x01);
+    CHECK_EQ(data[3], 0x01);
+    for (const RawTOCEntry &e : ParseFullTOC(data))
+    {
+        CHECK_EQ(e.session, 1);
+        CHECK_EQ(e.control_adr, 0x10);
+    }
+}
+
+TEST(data_only_iso_stays_single_session)
+{
+    auto data = FullTOCFor(MakeDataISO(1200));
+
+    CHECK_EQ(data[2], 0x01);
+    CHECK_EQ(data[3], 0x01);
+}

--- a/integration-tests/test-suite/test_protocol.cpp
+++ b/integration-tests/test-suite/test_protocol.cpp
@@ -264,3 +264,57 @@ TEST(cbw_oversized_cb_length_stalls)
     CHECK(r.stalledIn);
     CHECK(!r.gotCSW);
 }
+
+// ---------------------------------------------------------------------------
+// REQUEST SENSE residue
+// ---------------------------------------------------------------------------
+
+// BOT 6.7: dCSWDataResidue is the difference between what the host asked for
+// and what the device actually sent. REQUEST SENSE answers from a state of its
+// own, and that state never adjusted the residue the way the ordinary data-in
+// path does, so every sense reply arrived with a CSW claiming nothing had been
+// transferred.
+//
+// A host that believes the residue concludes it has no sense data, so it never
+// learns that ILLEGAL REQUEST / LBA OUT OF RANGE is permanent rather than
+// transient. A macOS trace of a read past the end of a disc showed the same
+// sector retried 42 times, each retry followed by a REQUEST SENSE whose CSW
+// said zero bytes had arrived.
+TEST(request_sense_residue_reflects_bytes_sent)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    auto r = Read10(bench, 1200, 1); // first LBA past the leadout
+    CHECK_EQ(r.csw.bmCSWStatus, 1);
+
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.csw.bmCSWStatus, 0);
+    CHECK_EQ(sense.data.size(), (size_t)18);
+    CHECK_EQ(sense.csw.dCSWDataResidue, 0u); // 18 asked for, 18 sent
+    CHECK_EQ(sense.data[2], 0x05);
+    CHECK_EQ(sense.data[12], 0x21);
+}
+
+// A host may ask for less than the full 18 bytes. The reply is truncated to
+// what was asked, so the residue is still zero -- not the shortfall against
+// the full sense structure.
+TEST(request_sense_short_allocation_has_no_residue)
+{
+    CFakeImageDevice *disc = MakeDataISO(1200);
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    Read10(bench, 1200, 1);
+
+    const u8 cdb[6] = {0x03, 0x00, 0x00, 0x00, 8, 0x00};
+    auto sense = bench.SendCommand(cdb, sizeof(cdb), 8);
+
+    CHECK_EQ(sense.csw.bmCSWStatus, 0);
+    CHECK_EQ(sense.data.size(), (size_t)8);
+    CHECK_EQ(sense.csw.dCSWDataResidue, 0u);
+    CHECK_EQ(sense.data[2], 0x05);
+}

--- a/integration-tests/test-suite/test_readcd.cpp
+++ b/integration-tests/test-suite/test_readcd.cpp
@@ -1,0 +1,402 @@
+//
+// test_readcd.cpp
+//
+// READ CD (0xBE) field selection.
+//
+// READ CD is the only command that can serve a Mode 2 Form 2 sector's real
+// 2324-byte payload, because READ(10) has no way to express a sector that is
+// not 2048 bytes. Which parts of the sector come back is chosen by the field
+// selection in CDB byte 9; the expected sector type in byte 1 says what kind of
+// sector the host will accept and how big each field is, but it does not choose
+// the fields.
+//
+// The command used to ignore byte 9 whenever byte 1 named a type, and to
+// mis-map byte 9's bottom three bits when it did not. Both were found from a
+// device trace of a real host reading a real disc, and both are pinned here.
+//
+#include "bench.h"
+#include "framework.h"
+
+#include <discimage/cuebinfile.h>
+#include <fatfs/ff.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <string>
+#include <vector>
+
+// A real Video CD extract: 32 Mode 2 Form 1 sectors followed by 24 Mode 2
+// Form 2 sectors, raw 2352 bytes each. Shared with the MDS tests.
+static const u32 kForm1Sectors = 32;
+static const u32 kForm2Sectors = 24;
+
+// Each test file keeps its own copy: these are separate translation units and
+// the helper is a one-liner over a compile-time define.
+static std::string ReadCdTestDataDir()
+{
+#ifdef USBODE_TESTDATA
+    return USBODE_TESTDATA;
+#else
+    return "out/images";
+#endif
+}
+
+static std::string XaBinPath(void)
+{
+    return ReadCdTestDataDir() + "/videocd-xa.bin";
+}
+
+static std::vector<u8> ReadRawFixture(void)
+{
+    std::vector<u8> out;
+    FILE *f = fopen(XaBinPath().c_str(), "rb");
+    if (!f) {
+        return out;
+    }
+    fseeko(f, 0, SEEK_END);
+    off_t size = ftello(f);
+    fseeko(f, 0, SEEK_SET);
+    if (size > 0) {
+        out.resize((size_t)size);
+        if (fread(out.data(), 1, out.size(), f) != out.size()) {
+            out.clear();
+        }
+    }
+    fclose(f);
+    return out;
+}
+
+static CCueBinFileDevice *OpenXaDisc(void)
+{
+    static const char *cue =
+        "FILE \"videocd-xa.bin\" BINARY\n"
+        "  TRACK 01 MODE2/2352\n"
+        "    INDEX 01 00:00:00\n";
+
+    FIL *fp = new FIL();
+    if (f_open(fp, XaBinPath().c_str(), FA_READ) != FR_OK) {
+        delete fp;
+        return nullptr;
+    }
+    char *copy = new char[strlen(cue) + 1];
+    memcpy(copy, cue, strlen(cue) + 1);
+    CCueBinFileDevice *dev = new CCueBinFileDevice(fp, copy, MEDIA_TYPE::CD);
+    delete[] copy;
+    return dev;
+}
+
+// Build a READ CD CDB. sectorType goes in byte 1 bits 4..2, the field
+// selection in byte 9.
+static void MakeReadCdCdb(u8 *cdb, u8 sectorType, u32 lba, u32 blocks, u8 fields)
+{
+    memset(cdb, 0, 12);
+    cdb[0] = 0xBE;
+    cdb[1] = (u8)(sectorType << 2);
+    cdb[2] = (u8)(lba >> 24);
+    cdb[3] = (u8)(lba >> 16);
+    cdb[4] = (u8)(lba >> 8);
+    cdb[5] = (u8)lba;
+    cdb[6] = (u8)(blocks >> 16);
+    cdb[7] = (u8)(blocks >> 8);
+    cdb[8] = (u8)blocks;
+    cdb[9] = fields;
+}
+
+// ---------------------------------------------------------------------------
+// The Windows XP failure, reproduced exactly
+// ---------------------------------------------------------------------------
+
+TEST(readcd_form2_sync_through_userdata_starts_at_the_sync_pattern)
+{
+    std::vector<u8> raw = ReadRawFixture();
+    CHECK_EQ(raw.size(), (size_t)(kForm1Sectors + kForm2Sectors) * 2352);
+    if (raw.empty()) {
+        return;
+    }
+
+    CCueBinFileDevice *disc = OpenXaDisc();
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Byte 1 = 0x14 (expected sector type 5, Mode 2 Form 2), byte 9 = 0xF0
+    // (sync + header + subheader + user data, no EDC/ECC). This is the exact
+    // CDB Windows XP sends when copying a Form 2 file, taken off the wire.
+    const u32 lba = kForm1Sectors; // first Form 2 sector
+    u8 cdb[12];
+    MakeReadCdCdb(cdb, 5, lba, 1, 0xF0);
+
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2352);
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+
+    // 12 sync + 4 header + 8 subheader + 2324 user data. The old code replied
+    // with 2328 bytes taken from offset 24, i.e. the payload where the host
+    // asked for the sync pattern, and XP called the file unreadable.
+    CHECK_EQ(r.data.size(), (size_t)2348);
+    if (r.data.size() != 2348) {
+        return;
+    }
+
+    // Starts at byte 0 of the sector, so the first 12 bytes are the sync mark.
+    CHECK_EQ(r.data[0], 0x00);
+    for (int i = 1; i <= 10; i++) {
+        CHECK_EQ(r.data[i], 0xFF);
+    }
+    CHECK_EQ(r.data[11], 0x00);
+
+    // Form 2 is what the fixture holds here: submode bit 0x20 set.
+    CHECK((raw[lba * 2352 + 18] & 0x20) == 0x20);
+
+    // Byte-exact against the image, which pins the offset and the length
+    // together - a right-sized reply from the wrong place still fails this.
+    CHECK_BYTES(r.data.data(), r.data.size(), raw.data() + (size_t)lba * 2352, 2348);
+}
+
+TEST(readcd_formless_header_only_fills_the_whole_sector)
+{
+    std::vector<u8> raw = ReadRawFixture();
+    if (raw.empty()) {
+        return;
+    }
+    CCueBinFileDevice *disc = OpenXaDisc();
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // The second command Windows XP sends for the same file, taken off the
+    // wire: byte 1 = 0x0C (expected type 3, Mode 2 formless), byte 9 = 0xB0.
+    // XP issues it even when the Form 2 request above succeeds, so it is part
+    // of the sequence rather than a fallback and it has to be answered.
+    //
+    // Byte 9 bits 6..5 are one two-bit Header Codes value, not two flags:
+    // 00 none, 01 header only, 10 subheader only, 11 both. 0xB0 is 01, so it
+    // asks for the 4-byte header, not the subheader. A formless Mode 2 sector
+    // has no subheader anyway, so this is sync + header + 2336 bytes of data:
+    // the whole 2352-byte sector, which is exactly what XP allocates for it.
+    //
+    // Reading those two bits in bit order rather than as a value makes this
+    // look like it skips the header and lands in the non-contiguous branch.
+    const u32 lba = kForm1Sectors;
+    u8 cdb[12];
+    MakeReadCdCdb(cdb, 3, lba, 1, 0xB0);
+
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2352);
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    CHECK_EQ(r.data.size(), (size_t)2352);
+    CHECK_EQ(r.csw.dCSWDataResidue, 0u);
+    if (r.data.size() != 2352) {
+        return;
+    }
+    CHECK_EQ(r.data[0], 0x00);
+    CHECK_EQ(r.data[1], 0xFF);
+    CHECK_BYTES(r.data.data(), r.data.size(), raw.data() + (size_t)lba * 2352, 2352);
+}
+
+// ---------------------------------------------------------------------------
+// The field selection itself
+// ---------------------------------------------------------------------------
+
+TEST(readcd_user_data_only_returns_user_data_not_ecc)
+{
+    std::vector<u8> raw = ReadRawFixture();
+    if (raw.empty()) {
+        return;
+    }
+    CCueBinFileDevice *disc = OpenXaDisc();
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Byte 9 = 0x10 is "user data only", the most ordinary request there is.
+    // It becomes selection 0x02, which the old mapping read as EDC/ECC: the
+    // reply was 288 bytes of error-correction data with a residue of 2064.
+    //
+    // Both expected sector types matter and they failed differently. Type 0
+    // (unspecified) is the one that went through the mis-mapped selection and
+    // returned the ECC. Type 4 took a branch that ignored byte 9 entirely and
+    // happened to hardcode the right answer, so it passed for the wrong reason
+    // - worth pinning so it cannot regress when the hardcoding is gone.
+    const u32 lba = 16; // Form 1, and the Video CD's volume descriptor
+    for (u8 sectorType : {(u8)0, (u8)4}) {
+        u8 cdb[12];
+        MakeReadCdCdb(cdb, sectorType, lba, 1, 0x10);
+
+        auto r = bench.SendCommand(cdb, sizeof(cdb), 2048);
+        CHECK_EQ(r.csw.bmCSWStatus, 0);
+        CHECK_EQ(r.data.size(), (size_t)2048);
+        CHECK_EQ(r.csw.dCSWDataResidue, 0u);
+        if (r.data.size() != 2048) {
+            continue;
+        }
+
+        // Independent oracle: user data of LBA 16 on this disc is the ISO 9660
+        // primary volume descriptor, so it begins 0x01 "CD001".
+        CHECK_EQ(r.data[0], 0x01);
+        CHECK(memcmp(r.data.data() + 1, "CD001", 5) == 0);
+        CHECK_BYTES(r.data.data(), r.data.size(), raw.data() + (size_t)lba * 2352 + 24, 2048);
+    }
+}
+
+TEST(readcd_form2_user_data_only_is_2324_bytes)
+{
+    std::vector<u8> raw = ReadRawFixture();
+    if (raw.empty()) {
+        return;
+    }
+    CCueBinFileDevice *disc = OpenXaDisc();
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // The whole point of READ CD for these files: a Form 2 sector's user data
+    // is 2324 bytes, not 2048. Serving 2048 silently drops 276 bytes of real
+    // payload from every sector.
+    const u32 lba = kForm1Sectors;
+    u8 cdb[12];
+    MakeReadCdCdb(cdb, 5, lba, 1, 0x10);
+
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2352);
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    CHECK_EQ(r.data.size(), (size_t)2324);
+    if (r.data.size() != 2324) {
+        return;
+    }
+    CHECK_BYTES(r.data.data(), r.data.size(), raw.data() + (size_t)lba * 2352 + 24, 2324);
+}
+
+TEST(readcd_raw_all_fields_is_unchanged)
+{
+    std::vector<u8> raw = ReadRawFixture();
+    if (raw.empty()) {
+        return;
+    }
+    CCueBinFileDevice *disc = OpenXaDisc();
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Selection 0xF8 sets every bit, so it always summed to 2352 even with the
+    // fields mis-mapped. It is the mode Windows 98 uses for Mode 2 files and
+    // the only one that ever worked, so it is the regression that matters most:
+    // whatever else changes, this reply must not.
+    for (u32 lba : {(u32)16, kForm1Sectors}) {
+        u8 cdb[12];
+        MakeReadCdCdb(cdb, 0, lba, 1, 0xF8);
+        auto r = bench.SendCommand(cdb, sizeof(cdb), 2352);
+        CHECK_EQ(r.csw.bmCSWStatus, 0);
+        CHECK_EQ(r.data.size(), (size_t)2352);
+        CHECK_EQ(r.csw.dCSWDataResidue, 0u);
+        if (r.data.size() == 2352) {
+            CHECK_BYTES(r.data.data(), r.data.size(), raw.data() + (size_t)lba * 2352, 2352);
+        }
+    }
+}
+
+TEST(readcd_multiple_blocks_keep_the_selected_layout)
+{
+    std::vector<u8> raw = ReadRawFixture();
+    if (raw.empty()) {
+        return;
+    }
+    CCueBinFileDevice *disc = OpenXaDisc();
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // XP asks for one sector and then five more in a single command. The
+    // per-sector stride has to stay at the selected length, not the 2352 the
+    // sector occupies in the image.
+    const u32 lba = kForm1Sectors + 1;
+    const u32 blocks = 5;
+    u8 cdb[12];
+    MakeReadCdCdb(cdb, 5, lba, blocks, 0xF0);
+
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2348 * blocks);
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    CHECK_EQ(r.data.size(), (size_t)2348 * blocks);
+    if (r.data.size() != (size_t)2348 * blocks) {
+        return;
+    }
+    for (u32 i = 0; i < blocks; i++) {
+        CHECK_BYTES(r.data.data() + (size_t)i * 2348, 2348,
+                    raw.data() + (size_t)(lba + i) * 2352, 2348);
+    }
+}
+
+TEST(readcd_non_contiguous_selection_is_rejected)
+{
+    CCueBinFileDevice *disc = OpenXaDisc();
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Sync and user data but not the header and subheader between them. That
+    // is not one slice of the sector, and answering with the bytes in between
+    // would be worse than refusing.
+    u8 cdb[12];
+    MakeReadCdCdb(cdb, 4, kForm1Sectors, 1, 0x90);
+
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2352);
+    CHECK_EQ(r.csw.bmCSWStatus, 1);
+
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.csw.bmCSWStatus, 0);
+    if (sense.data.size() >= 14) {
+        CHECK_EQ(sense.data[2] & 0x0F, 0x05); // ILLEGAL REQUEST
+        CHECK_EQ(sense.data[12], 0x24);       // INVALID FIELD IN CDB
+    }
+}
+
+TEST(readcd_empty_selection_is_rejected)
+{
+    CCueBinFileDevice *disc = OpenXaDisc();
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // No fields at all. The block count divides by the transfer size, so this
+    // has to be refused rather than allowed to divide by zero.
+    u8 cdb[12];
+    MakeReadCdCdb(cdb, 4, 16, 1, 0x00);
+
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2352);
+    CHECK_EQ(r.csw.bmCSWStatus, 1);
+
+    auto sense = bench.RequestSense();
+    if (sense.data.size() >= 14) {
+        CHECK_EQ(sense.data[2] & 0x0F, 0x05);
+        CHECK_EQ(sense.data[12], 0x24);
+    }
+}

--- a/integration-tests/test-suite/test_readtoc.cpp
+++ b/integration-tests/test-suite/test_readtoc.cpp
@@ -94,7 +94,7 @@ TEST(read_toc_legacy_cdb9_session_info)
     const u8 expected[12] = {
         0x00, 0x0A, // length 10
         0x01, 0x01, // first/last session
-        0x00, 0x14, 0x01, 0x00,
+        0x00, 0x10, 0x01, 0x00, // control 0x10: this disc is all audio
         0x00, 0x00, 0x00, 0x00, // first track of session at LBA 0
     };
     CHECK_BYTES(r.data.data(), r.data.size(), expected, sizeof(expected));


### PR DESCRIPTION
Fixes for issue #91 ("mixed-disc only shows up as an Audio CD"), plus one
further defect the reporter found while verifying it. Every change came out of a
device trace against real hardware, and each has a regression test that was
control-arm verified: the test was confirmed failing with the fix stashed, not
merely passing with it applied.

**CD Extra / multisession**

1. `toc: describe CD Extra discs as the two sessions they are` — the full TOC,
   READ DISC INFORMATION and the format 0x01 session reply were all hardcoded
   single-session, leaving a host with nowhere to look for a filesystem.
2. `toc: stop reporting session 1's lead-out on top of session 2` — now derived
   from `REM LEAD-OUT` when present, otherwise the next session's start minus
   the 11250-frame Orange Book gap.
3. `read: take sector layout from the track being read, not track 1` — the one
   that fixed Windows XP. READ(10)/READ(12) used a block size and skip count
   filled once from track 1; on a CD Extra track 1 is audio, so every data
   sector arrived shifted by 24 bytes and "CD001" was never where the host
   looked.
4. `toc: encode track numbers in BCD when the reply is BCD` — the full TOC POINT
   field stayed binary in BCD replies, so track 31 went out as 0x1F. Only
   visible on a disc with 10 or more tracks, and only on hosts using the legacy
   CDB byte-9 encoding, which macOS does.
5. `bot: report the sense bytes REQUEST SENSE actually sent` — not CD Extra
   specific. REQUEST SENSE never adjusted `dCSWDataResidue`, so every sense
   reply in the product's history claimed 0 of 18 bytes transferred. Hosts that
   trust the residue cannot distinguish a permanent failure from a transient
   one; macOS retried a single out-of-range sector 42 times because of it.

**READ CD field selection**

6. `readcd: return the sector fields the host asked for` — the reporter came
   back saying the CD Extra fixes worked but copying a folder of Mode 2 Form 2
   files gave I/O errors on every file except the first. That was ours. READ CD
   picked its reply from a `switch` on the expected sector type in CDB byte 1
   and ignored the field selection in byte 9 entirely; where byte 9 was
   consulted, the bits were read one position off, so "user data only" returned
   288 bytes of ECC.

   Worth flagging for review, because it is easy to get backwards: **byte 9 bits
   6-5 are a single two-bit Header Codes value, not two independent flags** (00
   none, 01 header only, 10 subheader only, 11 both). After the shift the low
   bit is the 4-byte header and the high bit the 8-byte subheader, even though
   the header comes first on the disc. Reading those in bit order makes Windows
   XP's bulk-read request look non-contiguous and get refused.

   Layout is now derived from a single sector-shape model shared by the length
   and skip calculations, so the two can no longer disagree.

Confirmed on Windows 98, XP and 11 against real hardware, and the original
reporter has confirmed the fix on his own machine: the whole folder copied, with
file count and total size matching his reference copy exactly.

Integration suite: 139 tests, 0 failed, including 8 new READ CD tests.

Two things deliberately left alone: READ(10) on an audio track still returns
status 0 with garbage rather than sense 05/64/00, and READ(10) on Form 2 sectors
is **not** made CHECK CONDITION. The latter is the MMC-correct answer but would
break Windows 98, which copies those files successfully today.

---

Independent of the other open PRs from this batch. This branch and the eject-insert one both touch `cd_utils.cpp`, `scsi_read.cpp`, `scsi_toc.cpp` and `usbcdgadget.cpp`, but a test merge of the two is clean, so they can be merged in either order.