### PR TITLE
Stop logging on every SCSI read

### DIFF
--- a/addon/usbcdgadget/cd_utils.cpp
+++ b/addon/usbcdgadget/cd_utils.cpp
@@ -418,19 +418,28 @@ int CDUtils::GetBlocksizeForTrack(CUSBCDGadget* gadget, CUETrackInfo trackInfo)
     //     return 2352;
     // }
 
+    // Gated, not bare NOTICE. This runs once per READ(10) and once per READ CD
+    // (scsi_read.cpp:129 and :436) - so, in IRQ context, on the hottest path in
+    // the device. A device log pulled on 2026-07-28 had 13,069 of these lines,
+    // peaking at 929 in a single second.
+    //
+    // The cost is not the log file. CLogger::WriteV() builds a CString and
+    // queues the event BEFORE it consults the log level, so every one of these
+    // heap-allocates inside an IRQ - and lowering loglevel does not avoid any
+    // of it. m_bDebugLogging does.
     switch (trackInfo.track_mode)
     {
     case CUETrack_MODE1_2048:
-        MLOGNOTE("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE1_2048");
+        CDROM_DEBUG_LOG("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE1_2048");
         return 2048;
     case CUETrack_MODE1_2352:
-        MLOGNOTE("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE1_2352");
+        CDROM_DEBUG_LOG("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE1_2352");
         return 2352;
     case CUETrack_MODE2_2352:
-        MLOGNOTE("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE2_2352");
+        CDROM_DEBUG_LOG("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE2_2352");
         return 2352;
     case CUETrack_AUDIO:
-        MLOGNOTE("CDUtils::GetBlocksizeForTrack", "CUETrack_AUDIO");
+        CDROM_DEBUG_LOG("CDUtils::GetBlocksizeForTrack", "CUETrack_AUDIO");
         return 2352;
     default:
         MLOGERR("CDUtils::GetBlocksizeForTrack", "Track mode %d not handled", trackInfo.track_mode);


### PR DESCRIPTION
One commit. This came out of a device log I pulled off my Zero 2 W while chasing a heat and lockup complaint.

`CDUtils::GetBlocksizeForTrack` logged its result at NOTICE on every branch, using a bare `MLOGNOTE` rather than the `CDROM_DEBUG_LOG` macro its neighbours in the same file use. It is called once per READ(10) and once per READ CD (scsi_read.cpp:129 and :436), in IRQ context, which makes it the hottest path in the device.

The log had 13,069 of those lines in it, peaking at 929 in a single second.

The cost is not the log file, and it is not avoidable by configuration. `CLogger::WriteV` builds a `CString` and queues the event before it consults the log level, so every one of these heap allocates inside an interrupt no matter what `loglevel` is set to. Downstream it compounds: the file log daemon f_writes and f_syncs each line, `CEMMCDevice` pulses the ACT LED around every SD transfer, and on a Zero 2 W that LED is a `CVirtualGPIOPin` driven through the VideoCore mailbox, whose spinlock is TASK_LEVEL and does not hold off IRQs. One log line per sector read turns into SD writes and mailbox round trips at kilohertz rates.

Observable on hardware. With this applied the device runs noticeably cooler, and the ACT LED tracks real disc access instead of blinking frantically through a game install.

It is also my leading suspect for the random hard lockups I have been seeing, which present as a completely unresponsive device with a solid green ACT LED. Mailbox contention is what locked up this same board once before, and a mailbox wedged mid operation would leave the LED stuck exactly like that. I am not claiming that as proven, and I would rather this land on its own merit: a per sector NOTICE has no business being unconditional.

Now gated behind `m_bDebugLogging` like every other diagnostic in the file. The `MLOGERR` for an unhandled track mode stays, since it is rare and it matters.

Host suite 147/147.
