### PR TITLE
MDS: track the read position instead of inferring it from the file pointer

### DIFF
--- a/addon/discimage/mdsfile.cpp
+++ b/addon/discimage/mdsfile.cpp
@@ -295,6 +295,35 @@ bool CMDSFileDevice::Init() {
                 m_nTotalFrames);
     }
 
+    // Does the disc have frames the MDF does not store? Alcohol omits the
+    // pregap before a track by default, so a typical multi-track image has a
+    // 150-frame hole; a single-track one has none. Reads have to walk frame by
+    // frame when there is a hole, and that is expensive enough to be worth
+    // settling here rather than per read.
+    //
+    // Summing the track lengths answers it for every well-formed image:
+    // covered short of the total means a hole, equal means every frame is
+    // stored. A malformed table whose tracks overlap sums high and also lands
+    // on "walk it". The one case this misses is an overlap that exactly
+    // cancels a hole, which no imaging tool produces and which costs
+    // correctness only on an image that is already self-contradictory.
+    u32 covered = 0;
+    for (int i = 0; i < m_parser->getNumSessions(); i++) {
+        MDS_SessionBlock* session = m_parser->getSession(i);
+        for (int j = 0; j < session->num_all_blocks; j++) {
+            MDS_TrackBlock* track = m_parser->getTrack(i, j);
+            if (track->point == 0 || track->point >= 0xA0) {
+                continue;
+            }
+            MDS_TrackExtraBlock* extra = m_parser->getTrackExtra(i, j);
+            covered += extra ? extra->length : 0;
+        }
+    }
+    m_bHasUnstoredGaps = (covered != m_nTotalFrames);
+    if (m_bHasUnstoredGaps) {
+        LOGNOTE("=== MDF is sparse: %u of %u frames stored ===", covered, m_nTotalFrames);
+    }
+
     LOGNOTE("=== Image has subchannel data: %s ===",
             m_hasSubchannels ? "YES (SafeDisc compatible)" : "NO");
     LOGNOTE("=== Disc length: %u frames ===", m_nTotalFrames);
@@ -325,7 +354,7 @@ CMDSFileDevice::~CMDSFileDevice(void) {
 }
 
 bool CMDSFileDevice::TouchesUnstoredGap(u32 firstLBA, size_t nSectors) const {
-    if (!m_parser) {
+    if (!m_parser || !m_bHasUnstoredGaps) {
         return false;
     }
     for (size_t i = 0; i < nSectors; i++) {
@@ -343,17 +372,23 @@ bool CMDSFileDevice::TouchesUnstoredGap(u32 firstLBA, size_t nSectors) const {
 
 int CMDSFileDevice::ReadAcrossGaps(void *pBuffer, size_t nSize) {
     u8* dest = (u8*)pBuffer;
-    const size_t sectors = nSize / 2352;
     size_t total_read = 0;
 
-    for (size_t i = 0; i < sectors; i++) {
+    while (total_read < nSize) {
+        // A transfer that is not a whole number of frames ends on a partial
+        // one. Serving it short instead would report fewer bytes than the
+        // caller asked for, which reads as an I/O error rather than as the
+        // hole it is.
+        const size_t remaining = nSize - total_read;
+        const size_t chunk = remaining < 2352 ? remaining : 2352;
+
         int session, trackIdx;
         MDS_TrackBlock* track = FindTrackForLBA(m_nCurrentLBA, &session, &trackIdx);
 
         if (!track) {
             // Unstored pregap. Zeros are what the pregap of a data track holds
             // anyway, and they keep the transfer whole instead of failing it.
-            memset(dest, 0, 2352);
+            memset(dest, 0, chunk);
         } else {
             // Seek per frame rather than trusting the file pointer: a gap
             // consumed no file position, so it is stale after one.
@@ -365,17 +400,21 @@ int CMDSFileDevice::ReadAcrossGaps(void *pBuffer, size_t nSize) {
                 return total_read > 0 ? (int)total_read : -1;
             }
             UINT bytes_read = 0;
-            FRESULT result = f_read(m_pFile, dest, 2352, &bytes_read);
-            if (result != FR_OK || bytes_read != 2352) {
+            FRESULT result = f_read(m_pFile, dest, chunk, &bytes_read);
+            if (result != FR_OK || bytes_read != chunk) {
                 LOGERR("Gap-aware read: LBA %u returned %u bytes (err %d)",
                        m_nCurrentLBA, bytes_read, result);
                 return total_read > 0 ? (int)total_read : -1;
             }
         }
 
-        dest += 2352;
-        total_read += 2352;
-        m_nCurrentLBA++;
+        dest += chunk;
+        total_read += chunk;
+        // Only a whole frame moves the reader on to the next one; a partial
+        // tail leaves the position inside the frame it stopped in.
+        if (chunk == 2352) {
+            m_nCurrentLBA++;
+        }
     }
 
     return (int)total_read;
@@ -390,8 +429,16 @@ int CMDSFileDevice::Read(void *pBuffer, size_t nSize) {
     // A transfer that crosses a pregap the MDF does not store cannot be one
     // f_read, because part of it has no bytes behind it. That is rare enough
     // to be worth detecting rather than paying for frame-by-frame reads on
-    // every transfer, so the paths below are left as they were.
-    if (nSize >= 2352 && TouchesUnstoredGap(m_nCurrentLBA, nSize / 2352)) {
+    // every transfer, so the paths below are left as they were. On an image
+    // with no hole at all TouchesUnstoredGap() answers from a flag worked out
+    // at Init() and costs nothing.
+    //
+    // A transfer shorter than a frame still has to be checked: the frame it
+    // lands in can be a hole just as easily as a whole-frame read can, and
+    // gating this on nSize let such a read fall through to the raw path and
+    // return whatever the file pointer was resting on.
+    const size_t framesTouched = (nSize + 2351) / 2352;
+    if (framesTouched > 0 && TouchesUnstoredGap(m_nCurrentLBA, framesTouched)) {
         return ReadAcrossGaps(pBuffer, nSize);
     }
 
@@ -452,6 +499,13 @@ int CMDSFileDevice::Read(void *pBuffer, size_t nSize) {
         LOGERR("Failed to read %d bytes into memory, err %d", nSize, result);
         return -1;
     }
+
+    // Move the reader on by what was consumed, the same way the two paths
+    // above do. Leaving it behind here was the other half of the stale-frame
+    // problem: a caller reading straight on without an intervening Seek had
+    // every frame after the first judged against the first one's address.
+    m_nCurrentLBA += nBytesRead / 2352;
+
     return nBytesRead;
 }
 
@@ -475,18 +529,20 @@ u64 CMDSFileDevice::Seek(u64 nOffset) {
         return static_cast<u64>(-1);
     }
 
-    // Don't seek if we're already there
-    if (Tell() == nOffset)
-        return nOffset;
-
     // Calculate which LBA is being requested
     u32 lba = nOffset / 2352;  // Assuming 2352 bytes per sector
     u32 offset_in_sector = nOffset % 2352;
-    
+
+    // Record the frame first, before any early exit can skip it. Read() takes
+    // both its gap detection and its subchannel stride from m_nCurrentLBA, so
+    // a Seek() that returns without setting it leaves the reader working on
+    // whichever frame it happened to be on last - and still reporting success.
+    m_nCurrentLBA = lba;
+
     // Find which track contains this LBA
     int session, trackIdx;
     MDS_TrackBlock* track = FindTrackForLBA(lba, &session, &trackIdx);
-    
+
     if (!track) {
         // An LBA inside the disc but outside every track is a pregap the
         // imaging tool chose not to store - Alcohol omits them by default, so
@@ -495,7 +551,6 @@ u64 CMDSFileDevice::Seek(u64 nOffset) {
         // track lands here legitimately, and a real drive answers rather than
         // failing. There is no file position to take up; Read() serves zeros.
         if (lba < m_nTotalFrames) {
-            m_nCurrentLBA = lba;
             return nOffset;
         }
         LOGERR("Seek: LBA %u not found in any track", lba);
@@ -504,22 +559,29 @@ u64 CMDSFileDevice::Seek(u64 nOffset) {
 
     // Calculate offset into MDF file
     u32 sectors_from_track_start = lba - track->start_sector;
-    u64 actual_file_offset = track->start_offset + 
-                             (sectors_from_track_start * track->sector_size) + 
+    u64 actual_file_offset = track->start_offset +
+                             ((u64)sectors_from_track_start * track->sector_size) +
                              offset_in_sector;
-    
-    // LOGDBG("Seek: LBA %u (offset %llu) -> track %d, file offset %llu", 
+
+    // LOGDBG("Seek: LBA %u (offset %llu) -> track %d, file offset %llu",
     //        lba, nOffset, track->point, actual_file_offset);
-    
+
+    // Don't seek if we're already there. The comparison has to be against the
+    // FILE offset just computed, not against nOffset: nOffset is a disc
+    // address and Tell() is a file address, and the two are different numbers
+    // on any image with 2448-byte sectors or an unstored gap. They do still
+    // coincide - on a contiguous 2352-byte image at every frame, and on a
+    // 2448-byte one every 49th frame, since 49 * 2448 == 51 * 2352 - which is
+    // how comparing them used to skip a seek that was genuinely needed.
+    if (Tell() == actual_file_offset) {
+        return nOffset;
+    }
+
     FRESULT result = f_lseek(m_pFile, actual_file_offset);
     if (result != FR_OK) {
         LOGERR("Seek to file offset %llu failed, err %d", actual_file_offset, result);
         return static_cast<u64>(-1);
     }
-
-    // Remember which frame this was: Read() cannot recover it from the file
-    // position once subchannel data makes the physical stride 2448 bytes.
-    m_nCurrentLBA = lba;
 
     // Return the logical offset that was requested (not the physical file offset)
     return nOffset;
@@ -651,20 +713,28 @@ int CMDSFileDevice::ReadSubchannel(u32 lba, u8* subchannel) {
     
     int session, trackIdx;
     MDS_TrackBlock* track = FindTrackForLBA(lba, &session, &trackIdx);
-    
+
     if (!track) {
+        // Inside the disc but in a pregap the MDF does not store, which is the
+        // same situation Seek() and Read() answer with zeros. Failing here
+        // instead would make a subchannel request across a track boundary the
+        // one operation that still errors on a hole.
+        if (lba < m_nTotalFrames) {
+            memset(subchannel, 0, 96);
+            return 96;
+        }
         LOGERR("LBA %u not found in any track", lba);
         return -1;
     }
-    
+
     // Check if this track has subchannel data
     if (track->subchannel == 0) {
         return -1;
     }
-    
+
     // Calculate offset into the MDF file
     u32 sectors_from_track_start = lba - track->start_sector;
-    u64 sector_offset = track->start_offset + (sectors_from_track_start * track->sector_size);
+    u64 sector_offset = track->start_offset + ((u64)sectors_from_track_start * track->sector_size);
     
     // Subchannel data is stored in the last 96 bytes of each raw sector
     // Raw sector format: 2352 bytes user data + 96 bytes subchannel

--- a/addon/discimage/mdsfile.h
+++ b/addon/discimage/mdsfile.h
@@ -82,10 +82,20 @@ class CMDSFileDevice : public IMDSDevice {
     /// bytes, so its length divided by 2352 over-reports the disc.
     u32 m_nTotalFrames = 0;
 
-    /// The LBA Seek() last resolved. Read() needs it because Tell() reports
-    /// a PHYSICAL offset in the MDF, which on a 2448-byte-per-sector track
-    /// is not lba * 2352.
+    /// The LBA Seek() last resolved, advanced by Read() as it consumes frames.
+    /// This is the reader's position, and it cannot be recovered from the file
+    /// pointer: Tell() reports a PHYSICAL offset in the MDF, which is not
+    /// lba * 2352 on a 2448-byte-per-sector track and not even monotonic in
+    /// the LBA once an unstored pregap moves the disc address without moving
+    /// the file. Everything that has to know which frame is being served -
+    /// gap detection, the subchannel stride - reads it from here.
     u32 m_nCurrentLBA = 0;
+
+    /// True if the disc has at least one frame the MDF does not store. Worked
+    /// out once, because the alternative is a per-frame track lookup on every
+    /// read: TouchesUnstoredGap() is O(frames x tracks), and the overwhelming
+    /// majority of images have no hole at all.
+    bool m_bHasUnstoredGaps = false;
 
     // Helper to find track containing an LBA
     MDS_TrackBlock* FindTrackForLBA(u32 lba, int* sessionOut, int* trackOut) const;

--- a/integration-tests/test-suite/test_mdsimages.cpp
+++ b/integration-tests/test-suite/test_mdsimages.cpp
@@ -1015,6 +1015,235 @@ TEST(mds_unstored_pregap_reads_as_zeros)
     delete disc;
 }
 
+// The gap handling above can only work if the reader knows which frame it is
+// on, and it did not always know. Seek() decided it was already in position by
+// comparing Tell() - a PHYSICAL offset into the MDF - against the LOGICAL disc
+// offset it was asked for, and took an early exit without recording the LBA.
+// Read() then keyed its gap check off whatever LBA was left over from before.
+//
+// The two tests below are the same defect reached from opposite directions,
+// and neither is exotic: each one is what an ordinary host produces when it
+// reads a file that happens to end on a frame boundary.
+//
+// The fixture above does not catch this because every read in it jumps to a
+// new address, so the physical and logical offsets never coincide.
+TEST(mds_gap_reached_by_a_sequential_read_still_reads_as_zeros)
+{
+    // On a contiguous 2352-byte image the physical and logical offsets are the
+    // same number for every frame, so reading the last stored frame of a track
+    // leaves the file pointer exactly at the logical offset of the first frame
+    // of the hole - and the early exit fires on the very next read.
+    const u32 kTrack1Len = 16;  // LBA 0..15; the file's next frame is the ISO PVD
+    const u32 kGap = 150;
+    const u32 kTrack2LBA = kTrack1Len + kGap;
+    const u32 kTrack2Len = 16;
+
+    std::vector<u8> raw = RawMode1Sectors(kIso, 0, kTrack1Len + kTrack2Len);
+    CHECK_EQ(raw.size(), (size_t)(kTrack1Len + kTrack2Len) * 2352);
+    if (raw.size() != (size_t)(kTrack1Len + kTrack2Len) * 2352) {
+        return;
+    }
+
+    const std::string mds = TestDataDir() + "/mdsgapseq.mds";
+    const std::string mdf = TestDataDir() + "/mdsgapseq.mdf";
+    WriteBytes(mdf, raw);
+
+    MdsTrackSpec t1;
+    t1.mode = 0xAA;
+    t1.point = 1;
+    t1.sectorSize = 2352;
+    t1.startSector = 0;
+    t1.startOffset = 0;
+    t1.length = kTrack1Len;
+
+    MdsTrackSpec t2;
+    t2.mode = 0xAA;
+    t2.point = 2;
+    t2.sectorSize = 2352;
+    t2.startSector = kTrack2LBA;                 // 150 frames later on the disc
+    t2.startOffset = (u64)kTrack1Len * 2352;     // but straight after in the file
+    t2.pregap = kGap;
+    t2.length = kTrack2Len;
+
+    WriteMdsFile(mds, {t1, t2}, "mdsgapseq.mdf");
+
+    CMDSFileDevice *disc = OpenMds(mds);
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    auto read = [&bench](u32 lba, u32 blocks) {
+        const u8 cdb[10] = {0x28, 0, (u8)(lba >> 24), (u8)(lba >> 16), (u8)(lba >> 8), (u8)lba,
+                            0, (u8)(blocks >> 8), (u8)blocks, 0};
+        return bench.SendCommand(cdb, sizeof(cdb), blocks * 2048);
+    };
+
+    // Walk up to the last stored frame of track 1. This read is the setup: it
+    // is what parks the file pointer on the boundary.
+    auto last = read(kTrack1Len - 1, 1);
+    CHECK_EQ(last.csw.bmCSWStatus, 0);
+
+    // The next frame is the hole, and it has to read as zeros. Serving the
+    // file pointer instead is unmistakable here: the bytes sitting there are
+    // track 2's primary volume descriptor.
+    auto gap = read(kTrack1Len, 1);
+    CHECK_EQ(gap.csw.bmCSWStatus, 0);
+    CHECK_EQ(gap.data.size(), (size_t)2048);
+    if (gap.data.size() == 2048) {
+        CHECK(memcmp(gap.data.data() + 1, "CD001", 5) != 0);
+        for (size_t i = 0; i < 2048; i++) {
+            if (gap.data[i] != 0) {
+                char msg[128];
+                snprintf(msg, sizeof(msg),
+                         "gap frame LBA %u: byte %zu is 0x%02x, expected the hole to read as zeros",
+                         kTrack1Len, i, gap.data[i]);
+                ReportFailure(__FILE__, __LINE__, msg);
+                break;
+            }
+        }
+    }
+
+    // Track 2 itself still resolves, so the fix cannot have been to stop
+    // trusting start_offset.
+    auto t2read = read(kTrack2LBA, 1);
+    CHECK_EQ(t2read.csw.bmCSWStatus, 0);
+    if (t2read.data.size() == 2048) {
+        CHECK(memcmp(t2read.data.data() + 1, "CD001", 5) == 0);
+    }
+
+    // The same defect without a Seek() to trigger it. Reading on from where
+    // the last read finished is a caller the gadget does not currently
+    // produce - it seeks before every batch - but it is what the reader now
+    // says it supports, and the plain path is the only one of the three that
+    // used to leave the position behind. Two frames of track 1, then straight
+    // on into the hole.
+    CHECK_EQ(disc->Seek((u64)(kTrack1Len - 2) * 2352), (u64)(kTrack1Len - 2) * 2352);
+    std::vector<u8> twoFrames(2 * 2352);
+    CHECK_EQ(disc->Read(twoFrames.data(), twoFrames.size()), (int)twoFrames.size());
+
+    std::vector<u8> nextFrame(2352, 0xAA);
+    CHECK_EQ(disc->Read(nextFrame.data(), nextFrame.size()), (int)nextFrame.size());
+    for (size_t i = 0; i < nextFrame.size(); i++) {
+        if (nextFrame[i] != 0) {
+            char msg[128];
+            snprintf(msg, sizeof(msg),
+                     "read on into the hole: byte %zu is 0x%02x, expected zeros",
+                     i, nextFrame[i]);
+            ReportFailure(__FILE__, __LINE__, msg);
+            break;
+        }
+    }
+
+    delete disc;
+}
+
+// The two operations that reach a hole by a route other than a whole-frame
+// READ(10), driven against the reader directly because no host command
+// produces them on this geometry.
+//
+// Both used to be the odd one out. A read shorter than a frame skipped the gap
+// check on its size alone and returned whatever the file pointer was resting
+// on, and ReadSubchannel() failed outright on a frame that Seek() and Read()
+// were both willing to answer with zeros - so a subchannel request spanning a
+// track boundary was the one operation a sparse image still could not serve.
+TEST(mds_gap_answers_short_reads_and_subchannel_requests_too)
+{
+    const u32 kTrack1Len = 16;
+    const u32 kGap = 150;
+    const u32 kTrack2LBA = kTrack1Len + kGap;
+    const u32 kTrack2Len = 16;
+    const u32 kTotal = kTrack2LBA + kTrack2Len;
+
+    std::vector<u8> raw = RawMode1Sectors(kIso, 0, kTrack1Len + kTrack2Len);
+    if (raw.empty()) {
+        CHECK(false);
+        return;
+    }
+    // Subchannel bytes on both stored tracks, so the hole is the only place a
+    // request can come back empty.
+    std::vector<u8> image((size_t)(kTrack1Len + kTrack2Len) * 2448);
+    for (u32 i = 0; i < kTrack1Len + kTrack2Len; i++) {
+        memcpy(image.data() + (size_t)i * 2448, raw.data() + (size_t)i * 2352, 2352);
+        for (u32 j = 0; j < 96; j++) {
+            image[(size_t)i * 2448 + 2352 + j] = SubchannelByte(i, j);
+        }
+    }
+
+    const std::string mds = TestDataDir() + "/mdsgapsub.mds";
+    const std::string mdf = TestDataDir() + "/mdsgapsub.mdf";
+    WriteBytes(mdf, image);
+
+    MdsTrackSpec t1;
+    t1.mode = 0xAA;
+    t1.subchannel = 0x08;
+    t1.point = 1;
+    t1.sectorSize = 2448;
+    t1.startSector = 0;
+    t1.startOffset = 0;
+    t1.length = kTrack1Len;
+
+    MdsTrackSpec t2;
+    t2.mode = 0xAA;
+    t2.subchannel = 0x08;
+    t2.point = 2;
+    t2.sectorSize = 2448;
+    t2.startSector = kTrack2LBA;
+    t2.startOffset = (u64)kTrack1Len * 2448;
+    t2.pregap = kGap;
+    t2.length = kTrack2Len;
+
+    WriteMdsFile(mds, {t1, t2}, "mdsgapsub.mdf");
+
+    CMDSFileDevice *disc = OpenMds(mds);
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    // A stored frame's subchannel still comes back as itself.
+    u8 sub[96];
+    memset(sub, 0xAA, sizeof(sub));
+    CHECK_EQ(disc->ReadSubchannel(kTrack1Len - 1, sub), 96);
+    u8 expected[96];
+    for (u32 i = 0; i < 96; i++) {
+        expected[i] = SubchannelByte(kTrack1Len - 1, i);
+    }
+    CHECK_BYTES(sub, sizeof(sub), expected, sizeof(expected));
+
+    // A frame in the hole answers with zeros rather than failing.
+    memset(sub, 0xAA, sizeof(sub));
+    CHECK_EQ(disc->ReadSubchannel(kTrack1Len, sub), 96);
+    u8 zeros[96];
+    memset(zeros, 0, sizeof(zeros));
+    CHECK_BYTES(sub, sizeof(sub), zeros, sizeof(zeros));
+
+    // Past the disc is still an error, not another hole.
+    CHECK_EQ(disc->ReadSubchannel(kTotal + 4, sub), -1);
+
+    // A read of less than one frame, landing in the hole.
+    u8 partial[2048];
+    memset(partial, 0xAA, sizeof(partial));
+    CHECK_EQ(disc->Seek((u64)kTrack1Len * 2352), (u64)kTrack1Len * 2352);
+    CHECK_EQ(disc->Read(partial, sizeof(partial)), (int)sizeof(partial));
+    for (size_t i = 0; i < sizeof(partial); i++) {
+        if (partial[i] != 0) {
+            char msg[128];
+            snprintf(msg, sizeof(msg),
+                     "short read in the hole: byte %zu is 0x%02x, expected zeros",
+                     i, partial[i]);
+            ReportFailure(__FILE__, __LINE__, msg);
+            break;
+        }
+    }
+
+    delete disc;
+}
+
 // ---------------------------------------------------------------------------
 // Subchannel images (2448-byte sectors)
 // ---------------------------------------------------------------------------
@@ -1136,6 +1365,96 @@ TEST(mds_subchannel_image_strips_and_exposes_subchannel_data)
         }
         CHECK_BYTES(batch.data.data(), batch.data.size(), expected.data(), expected.size());
     }
+}
+
+// The other direction onto the same defect, and the reason it survived the
+// gap fix: on a 2448-byte image the physical and logical offsets advance at
+// different rates, so they are equal only at frames where lba * 2448 is
+// divisible by 2352 - every 49th frame, since 2448/48 = 51 and 2352/48 = 49.
+// Read up to frame 48 and the file pointer sits at 49 * 2448 = 119952, which
+// is also 51 * 2352. A host that then reads LBA 51 hits the early exit, the
+// LBA stays at 49, and the reader serves frame 49 while reporting success.
+//
+// Nothing about that read order is unusual - it is one ordinary seek after one
+// ordinary sequential run - and there is such a coincidence point every 49
+// frames across the whole disc.
+TEST(mds_subchannel_seek_after_a_read_does_not_serve_a_stale_frame)
+{
+    const u32 nSectors = 64;
+    const u32 kSetupLBA = 48;   // leaves the file pointer at 49 * 2448
+    const u32 kTargetLBA = 51;  // whose logical offset is the same 119952
+    static_assert(kSetupLBA + 1 == 49 && 49 * 2448 == 51 * 2352,
+                  "the coincidence this test relies on");
+
+    const std::string mds = TestDataDir() + "/mdsstale.mds";
+    const std::string mdf = TestDataDir() + "/mdsstale.mdf";
+
+    std::vector<u8> raw = RawMode1Sectors(kIso, 0, nSectors);
+    if (raw.empty()) {
+        CHECK(false);
+        return;
+    }
+    std::vector<u8> image((size_t)nSectors * 2448);
+    for (u32 lba = 0; lba < nSectors; lba++) {
+        memcpy(image.data() + (size_t)lba * 2448, raw.data() + (size_t)lba * 2352, 2352);
+        for (u32 i = 0; i < 96; i++) {
+            image[(size_t)lba * 2448 + 2352 + i] = SubchannelByte(lba, i);
+        }
+    }
+    // Past the ISO's system area every frame here would otherwise be zeros,
+    // which cannot tell a stale frame from the right one. Stamp each frame's
+    // user data with its own LBA so a misread names the frame it came from.
+    for (u32 lba = 0; lba < nSectors; lba++) {
+        u8 *user = image.data() + (size_t)lba * 2448 + 16;
+        for (u32 i = 0; i < 2048; i++) {
+            user[i] = (u8)(lba * 7u + i * 3u + 11u);
+        }
+        memcpy(raw.data() + (size_t)lba * 2352 + 16, user, 2048);
+    }
+    WriteBytes(mdf, image);
+
+    MdsTrackSpec track;
+    track.mode = 0xAA;
+    track.subchannel = 0x08;
+    track.point = 1;
+    track.sectorSize = 2448;
+    track.length = nSectors;
+    WriteMdsFile(mds, {track}, "mdsstale.mdf");
+
+    CMDSFileDevice *disc = OpenMds(mds);
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    auto read = [&bench](u32 lba) {
+        const u8 cdb[10] = {0x28, 0, (u8)(lba >> 24), (u8)(lba >> 16), (u8)(lba >> 8), (u8)lba,
+                            0, 0, 1, 0};
+        return bench.SendCommand(cdb, sizeof(cdb), 2048);
+    };
+    auto expectFrame = [&raw](const std::vector<u8> &d, u32 lba) {
+        if (d.size() != 2048) {
+            return;
+        }
+        u8 expected[2048];
+        memcpy(expected, raw.data() + (size_t)lba * 2352 + 16, 2048);
+        CHECK_BYTES(d.data(), d.size(), expected, sizeof(expected));
+    };
+
+    auto setup = read(kSetupLBA);
+    CHECK_EQ(setup.csw.bmCSWStatus, 0);
+    expectFrame(setup.data, kSetupLBA);
+
+    auto target = read(kTargetLBA);
+    CHECK_EQ(target.csw.bmCSWStatus, 0);
+    CHECK_EQ(target.data.size(), (size_t)2048);
+    expectFrame(target.data, kTargetLBA);
+
+    delete disc;
 }
 
 // READ CD (0xBE) asking for the subchannel data alongside the user data.


### PR DESCRIPTION
One commit, with three new tests, all confirmed red before the fix.

`Seek()` decided it was already in position by comparing `Tell()` against the offset it was asked for. Those are not the same kind of number. `Tell()` is a byte offset into the MDF, the argument is an address on the disc. On an image with 2448 byte sectors they run at different rates, and on one with an unstored pregap the disc address moves where the file offset does not.

When they did coincide the function returned early, and the early return skipped recording the LBA. `Read()` takes both its gap detection and its subchannel stride from that LBA, so it went on serving whichever frame the reader was last on, and reported success doing it.

Two ways in, both ordinary:

* A contiguous 2352 byte image makes the two offsets equal at every frame, so reading a track to its end and then reading on lands in the pregap with a stale LBA, the hole goes undetected, and the next track's bytes come back where zeros belong. This is the Video CD case: on a real Alcohol image here, LBA 526 returned track 2's volume descriptor.
* A 2448 byte image makes them equal every 49th frame, since 49 * 2448 is 51 * 2352. Ending a read at frame 48 and then reading frame 51 served frame 49.

The fix compares against the file offset actually computed, and sets the LBA before any early exit can skip it. The plain read path now advances the position like the other two already did, so the class keeps one definition of where it is.

The fixtures use the exact geometry of real Alcohol images rather than invented numbers. Parsing three of my own discs confirmed the convention the reader assumes: `length` excludes the pregap, and `start_offset` accounts only for stored frames.

Hardware tested on a Pi Zero 2 W: Descent II, audio track 13 played end to end and the game installed, on Win98 and XP.

Host suite 150/150.
