### PR TITLE
Stop a bad log file path from taking the system down with it

### DIFF
--- a/addon/filelogdaemon/filelogdaemon.cpp
+++ b/addon/filelogdaemon/filelogdaemon.cpp
@@ -96,6 +96,37 @@ boolean CFileLogDaemon::Initialize() {
     return TRUE;
 }
 
+void CFileLogDaemon::GetStatusText(char *pBuffer, size_t nBufferSize) const {
+    if (pBuffer == nullptr || nBufferSize == 0) {
+        return;
+    }
+
+    if (m_LogFilePath[0] == '\0') {
+        snprintf(pBuffer, nBufferSize, "File logging is off (no log file configured).");
+    } else if (m_bFileInitialized) {
+        snprintf(pBuffer, nBufferSize, "Writing to %s", m_LogFilePath);
+    } else {
+        snprintf(pBuffer, nBufferSize,
+                 "NOT LOGGING: cannot open %s (FatFs error %d). "
+                 "The file must be on the boot partition and its directory must already exist.",
+                 m_LogFilePath, (int)m_OpenResult);
+    }
+}
+
+void CFileLogDaemon::GetStdioPath(char *pBuffer, size_t nBufferSize) const {
+    if (pBuffer == nullptr || nBufferSize == 0) {
+        return;
+    }
+
+    // Config stores the FatFs form ("0:/usbode-log.txt"); newlib wants an
+    // ordinary path ("/usbode-log.txt").
+    const char *p = m_LogFilePath;
+    if (p[0] == '0' && p[1] == ':') {
+        p += 2;
+    }
+    snprintf(pBuffer, nBufferSize, "%s", p);
+}
+
 CFileLogDaemon::~CFileLogDaemon(void) {
     s_pThis = nullptr;
 

--- a/addon/filelogdaemon/filelogdaemon.cpp
+++ b/addon/filelogdaemon/filelogdaemon.cpp
@@ -33,8 +33,11 @@ LOGMODULE("filelogdaemon");
 CFileLogDaemon *CFileLogDaemon::s_pThis = nullptr;
 
 CFileLogDaemon::CFileLogDaemon(const char *pLogFilePath, unsigned uiLogLevel)
-    : m_pLogFilePath(pLogFilePath),
-      m_uiLogLevel(uiLogLevel > 5 ? 5 : uiLogLevel) {
+    : m_uiLogLevel(uiLogLevel > 5 ? 5 : uiLogLevel) {
+    if (pLogFilePath != nullptr) {
+        strncpy(m_LogFilePath, pLogFilePath, sizeof(m_LogFilePath) - 1);
+        m_LogFilePath[sizeof(m_LogFilePath) - 1] = '\0';
+    }
     // I am the one and only!
     assert(s_pThis == nullptr);
     s_pThis = this;
@@ -52,10 +55,24 @@ void CFileLogDaemon::SetLogLevel(unsigned uiLogLevel) {
 }
 
 boolean CFileLogDaemon::Initialize() {
+    if (m_LogFilePath[0] == '\0') {
+        // An empty path is how the config says "no file logging". Not an
+        // error, and not worth an alarming message at boot.
+        m_OpenResult = FR_INVALID_NAME;
+        LOGNOTE("No log file configured; file logging is off");
+        return FALSE;
+    }
+
     // Open log file for writing (append mode)
-    FRESULT Result = f_open(&m_LogFile, m_pLogFilePath, FA_WRITE | FA_OPEN_ALWAYS);
+    FRESULT Result = f_open(&m_LogFile, m_LogFilePath, FA_WRITE | FA_OPEN_ALWAYS);
+    m_OpenResult = Result;
     if (Result != FR_OK) {
-        LOGERR("Failed to open log file");
+        // Name the path and the reason. This message is the only evidence the
+        // user gets, and "Failed to open log file" left them with a system
+        // that had quietly stopped logging and no way to tell why. Note that
+        // only volume 0: is mounted this early, so a path on 1: lands here.
+        LOGERR("Failed to open log file '%s' (FatFs error %d); file logging is off",
+               m_LogFilePath, (int)Result);
         return FALSE;
     }
 
@@ -96,36 +113,49 @@ void CFileLogDaemon::Run(void) {
 
     while (true) {
         m_Event.Clear();
-
-        TLogSeverity Severity;
-        char Source[LOG_MAX_SOURCE];
-        char Message[LOG_MAX_MESSAGE];
-        time_t Time;
-        unsigned nHundredthTime;
-        int nTimeZone;
-        while (pLogger->ReadEvent(&Severity, Source, Message,
-                                  &Time, &nHundredthTime, &nTimeZone)) {
-            // CLogger queues every event regardless of its loglevel (that
-            // only filters the serial/screen target), so the configured
-            // level is applied here. Severity LogPanic(0)..LogDebug(4)
-            // maps to config levels 1..5; level 0 drops everything.
-            if ((unsigned)Severity >= m_uiLogLevel) {
-                continue;
-            }
-            if (!LogMessage(Severity, Time, nHundredthTime, nTimeZone, Source, Message)) {
-                CScheduler::Get()->Sleep(20);
-            }
-        }
-
+        DrainOnce();
         m_Event.Wait();
     }
 }
 
-boolean CFileLogDaemon::LogMessage(TLogSeverity Severity,
-                                   time_t FullTime, unsigned nPartialTime, int nTimeNumOffset,
-                                   const char *pAppName, const char *pMsg) {
+void CFileLogDaemon::DrainOnce(void) {
+    CLogger *pLogger = CLogger::Get();
+    assert(pLogger != nullptr);
+
+    TLogSeverity Severity;
+    char Source[LOG_MAX_SOURCE];
+    char Message[LOG_MAX_MESSAGE];
+    time_t Time;
+    unsigned nHundredthTime;
+    int nTimeZone;
+    while (pLogger->ReadEvent(&Severity, Source, Message,
+                              &Time, &nHundredthTime, &nTimeZone)) {
+        // CLogger queues every event regardless of its loglevel (that
+        // only filters the serial/screen target), so the configured
+        // level is applied here. Severity LogPanic(0)..LogDebug(4)
+        // maps to config levels 1..5; level 0 drops everything.
+        if ((unsigned)Severity >= m_uiLogLevel) {
+            continue;
+        }
+
+        // Only back off for a failure that might not repeat. When the file was
+        // never opened every message fails, and sleeping for each one throttled
+        // the log queue to 50 events a second - which, since the queue is
+        // drained on a scheduler task, dragged the whole system down with it.
+        // A mistyped log path used to present as a Pi that had gone slow.
+        if (LogMessage(Severity, Time, nHundredthTime, nTimeZone, Source, Message) ==
+            LogResult::WriteFailed) {
+            CScheduler::Get()->Sleep(20);
+        }
+    }
+}
+
+CFileLogDaemon::LogResult CFileLogDaemon::LogMessage(TLogSeverity Severity,
+                                                     time_t FullTime, unsigned nPartialTime,
+                                                     int nTimeNumOffset,
+                                                     const char *pAppName, const char *pMsg) {
     if (!m_bFileInitialized) {
-        return FALSE;
+        return LogResult::NoFile;
     }
 
     // Format the log entry similar to base logger but tailored for file
@@ -161,14 +191,15 @@ boolean CFileLogDaemon::LogMessage(TLogSeverity Severity,
     UINT BytesWritten;
     FRESULT Result = f_write(&m_LogFile, LogEntry, strlen(LogEntry), &BytesWritten);
     if (Result != FR_OK) {
-        // TODO implement proper error handling here!!!
-        LOGERR("Failed to write to log file!");
-        return FALSE;
+        // Deliberately not logged: this runs while draining the log queue, and
+        // a message here would queue another event, which would fail the same
+        // way. The caller backs off instead.
+        return LogResult::WriteFailed;
     }
 
     f_sync(&m_LogFile);
 
-    return TRUE;
+    return LogResult::Written;
 }
 
 void CFileLogDaemon::EventNotificationHandler(void) {

--- a/addon/filelogdaemon/filelogdaemon.h
+++ b/addon/filelogdaemon/filelogdaemon.h
@@ -42,6 +42,23 @@ class CFileLogDaemon : public CTask {
     boolean Initialize();
     void Run(void);
 
+    /// One pass of Run()'s loop: drain whatever the logger has queued. Split
+    /// out because Run() never returns, and the drain is the part with the
+    /// interesting behaviour when the log file could not be opened.
+    void DrainOnce(void);
+
+    /// Whether the log file is actually open. The constructor cannot report a
+    /// failure, so the caller has to be able to ask afterwards - otherwise a
+    /// mistyped path silently produces a system with no file logging at all.
+    boolean IsFileLogging(void) const { return m_bFileInitialized; }
+
+    /// The path this daemon was asked for, for a caller that wants to name it
+    /// in a diagnostic.
+    const char *GetLogFilePath(void) const { return m_LogFilePath; }
+
+    /// The FatFs result from the attempt to open it. FR_OK once open.
+    FRESULT GetOpenResult(void) const { return m_OpenResult; }
+
     // Takes effect immediately; only affects the log file, not the
     // loglevel= filtering Circle applies to the serial/screen target.
     void SetLogLevel(unsigned uiLogLevel);
@@ -49,9 +66,20 @@ class CFileLogDaemon : public CTask {
     static CFileLogDaemon *Get(void);
 
    private:
-    boolean LogMessage(TLogSeverity Severity,
-                       time_t FullTime, unsigned nPartialTime, int nTimeNumOffset,
-                       const char *pAppName, const char *pMsg);
+    /// Why a message did not reach the file. The distinction matters: a write
+    /// that failed may well succeed next time and is worth backing off for,
+    /// but a file that was never opened will never take a message, and backing
+    /// off for each of those costs the whole system (see Run()).
+    enum class LogResult
+    {
+        Written,
+        WriteFailed,  // transient: the file is open, this write did not land
+        NoFile        // permanent for this boot: there is nothing to write to
+    };
+
+    LogResult LogMessage(TLogSeverity Severity,
+                         time_t FullTime, unsigned nPartialTime, int nTimeNumOffset,
+                         const char *pAppName, const char *pMsg);
 
     static void EventNotificationHandler(void);
     static void PanicHandler(void);
@@ -59,8 +87,13 @@ class CFileLogDaemon : public CTask {
    private:
     CSynchronizationEvent m_Event;
     static CFileLogDaemon *s_pThis;
-    boolean m_bFileInitialized;
-    const char *m_pLogFilePath;
+    /// Must start FALSE. An indeterminate value here let LogMessage() write to
+    /// an unopened FIL and the destructor close it, whenever the open failed.
+    boolean m_bFileInitialized = FALSE;
+    /// Copied, not aliased. The caller's string comes out of the config store,
+    /// which is free to replace it while this daemon is still running.
+    char m_LogFilePath[256] = {0};
+    FRESULT m_OpenResult = FR_NOT_READY;
     unsigned m_uiLogLevel;
     FIL m_LogFile;
 };

--- a/addon/filelogdaemon/filelogdaemon.h
+++ b/addon/filelogdaemon/filelogdaemon.h
@@ -59,6 +59,19 @@ class CFileLogDaemon : public CTask {
     /// The FatFs result from the attempt to open it. FR_OK once open.
     FRESULT GetOpenResult(void) const { return m_OpenResult; }
 
+    /// One line describing whether file logging is actually working, for the
+    /// web UI to show.
+    ///
+    /// Without this the only report of a failed open is a warning on the
+    /// serial console, and SCREEN_HEADLESS builds have nowhere else to put it
+    /// - so the user sees a device with no log file and no reason given, which
+    /// is the situation this whole fix exists to end.
+    void GetStatusText(char *pBuffer, size_t nBufferSize) const;
+
+    /// The configured path as an ordinary filesystem path (no "0:" volume
+    /// prefix), for callers that open it through newlib rather than FatFs.
+    void GetStdioPath(char *pBuffer, size_t nBufferSize) const;
+
     // Takes effect immediately; only affects the log file, not the
     // loglevel= filtering Circle applies to the serial/screen target.
     void SetLogLevel(unsigned uiLogLevel);

--- a/addon/webserver/handlers/configpage.cpp
+++ b/addon/webserver/handlers/configpage.cpp
@@ -286,6 +286,21 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
         }
     }
     
+    // Whether file logging is actually working right now. The boot-time
+    // warning about a path that would not open goes to the serial console, and
+    // a SCREEN_HEADLESS build has nowhere else to put it - so without this the
+    // config page happily shows a log path that is doing nothing.
+    {
+        char status[256] = {0};
+        if (CFileLogDaemon::Get() != nullptr) {
+            CFileLogDaemon::Get()->GetStatusText(status, sizeof(status));
+        }
+        context["logfile_status"] = std::string(status);
+        context["logfile_broken"] = (CFileLogDaemon::Get() != nullptr &&
+                                     !CFileLogDaemon::Get()->IsFileLogging() &&
+                                     CFileLogDaemon::Get()->GetLogFilePath()[0] != '\0');
+    }
+
     // Set current values for display
     std::string current_displayhat = config->GetDisplayHat();
     std::string current_low_power_timeout = std::to_string(config->GetLowPowerTimeout());

--- a/addon/webserver/handlers/configpage.cpp
+++ b/addon/webserver/handlers/configpage.cpp
@@ -32,6 +32,74 @@ std::string ConfigPageHandler::GetHTML() {
     return std::string(s_Config);
 }
 
+// Normalize a log file path the user typed onto volume 0:, and reject what
+// FatFs will not be able to open.
+//
+// This is the only validation the value ever gets, and it used to be one line:
+// prepend "0:/" unless the string already started with it. A user who entered
+// "SD:/usbode-logs.txt" - a reasonable guess at how to name the card - got
+// "0:/SD:/usbode-logs.txt" saved, which cannot be opened, and the next boot
+// came up with no log file at all.
+//
+// An empty result means logging is switched off, which is a legitimate choice
+// rather than an error.
+static bool NormalizeLogfilePath(std::string& path, std::string& error) {
+    const size_t first = path.find_first_not_of(" \t");
+    if (first == std::string::npos) {
+        path.clear();
+        return true;
+    }
+    path = path.substr(first, path.find_last_not_of(" \t") - first + 1);
+
+    // FatFs accepts either separator and users type both.
+    std::replace(path.begin(), path.end(), '\\', '/');
+
+    // Take off a volume prefix if one was typed, and refuse any volume other
+    // than the boot partition. Volume 1: is a real volume but it is not
+    // mounted until well after the log daemon starts, so a log file there
+    // would fail at every boot.
+    const size_t colon = path.find(':');
+    if (colon != std::string::npos) {
+        const std::string volume = path.substr(0, colon);
+        if (volume != "0") {
+            error = "Log file must be on the boot partition. Remove the \"" + volume +
+                    ":\" prefix and give a path like usbode-log.txt.";
+            return false;
+        }
+        path.erase(0, colon + 1);
+    }
+    while (!path.empty() && path[0] == '/') {
+        path.erase(0, 1);
+    }
+
+    if (path.empty() || path.back() == '/') {
+        error = "Log file path has to name a file, not a directory.";
+        return false;
+    }
+    if (path.find(':') != std::string::npos) {
+        error = "Log file path cannot contain a colon.";
+        return false;
+    }
+
+    // The directory has to exist. FatFs will not create one, so a path under a
+    // missing directory is accepted here and then fails silently at boot -
+    // which is exactly the failure this is here to stop. f_opendir rather than
+    // f_stat, because f_stat cannot describe the root of a volume.
+    const size_t slash = path.find_last_of('/');
+    if (slash != std::string::npos) {
+        const std::string dir = path.substr(0, slash);
+        DIR probe;
+        if (f_opendir(&probe, ("0:/" + dir).c_str()) != FR_OK) {
+            error = "Directory \"" + dir + "\" does not exist on the boot partition.";
+            return false;
+        }
+        f_closedir(&probe);
+    }
+
+    path = "0:/" + path;
+    return true;
+}
+
 std::map<std::string, std::string> ConfigPageHandler::ParseFormData(const char* pFormData) {
     std::map<std::string, std::string> params;
     
@@ -126,15 +194,19 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
                 config->SetST7789SleepBrightness(std::atoi(form_params["st7789_sleep_brightness"].c_str()));
             }
             
-            // Log file configuration
+            // Log file configuration. An empty value is honoured as "turn file
+            // logging off" - the page already displays an empty setting that
+            // way, and previously the write path ignored it, so the setting
+            // could not be cleared once set.
             if (form_params.count("logfile")) {
                 std::string logfile = form_params["logfile"];
-                if (!logfile.empty()) {
-                    // Ensure 0:/ prefix
-                    if (logfile.find("0:/") != 0) {
-                        logfile = "0:/" + logfile;
-                    }
+                std::string logfileError;
+                if (NormalizeLogfilePath(logfile, logfileError)) {
                     config->SetLogfile(logfile.c_str());
+                } else {
+                    error_message = logfileError;
+                    LOGWARN("Rejected log file path '%s': %s",
+                            form_params["logfile"].c_str(), logfileError.c_str());
                 }
             }
             
@@ -193,8 +265,14 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
             
             // Check for action parameter to determine what to do after saving
             std::string action = form_params.count("action") ? form_params["action"] : "save";
-            
-            if (action == "save_reboot") {
+
+            // Something was rejected above. Everything else in the form was
+            // still saved, but saying "saved successfully" alongside the
+            // rejection would read as though the rejected value went in too -
+            // and rebooting on top of that would hide the message entirely.
+            if (!error_message.empty()) {
+                error_message += " Other settings were saved.";
+            } else if (action == "save_reboot") {
                 success_message = "Configuration saved successfully. Rebooting in 3 seconds...";
                 // Schedule a reboot in 3 seconds
                 new CShutdown(ShutdownReboot, 3000);

--- a/addon/webserver/handlers/logpage.cpp
+++ b/addon/webserver/handlers/logpage.cpp
@@ -15,6 +15,7 @@
 #include "logpage.h"
 #include "../util.h"
 #include <cdplayer/cdplayer.h>
+#include <filelogdaemon/filelogdaemon.h>
 
 using namespace kainjow;
 
@@ -61,8 +62,31 @@ THTTPStatus LogPageHandler::PopulateContext(kainjow::mustache::data& context,
                                    const char  *pFormData)
 {
     LOGNOTE("Log page called");
-    
-    context["log_lines"] = read_loglines("/usbode-logs.txt");
-    
+
+    // Read the file that is actually configured. This used to be hardcoded to
+    // "/usbode-logs.txt", so anyone who set a different path got a blank page
+    // and no hint that they were looking in the wrong place.
+    char path[256] = {0};
+    char status[256] = {0};
+    CFileLogDaemon *pDaemon = CFileLogDaemon::Get();
+    if (pDaemon != nullptr) {
+        pDaemon->GetStdioPath(path, sizeof(path));
+        pDaemon->GetStatusText(status, sizeof(status));
+    }
+
+    std::string lines = path[0] != '\0' ? read_loglines(path) : std::string();
+
+    // An empty page is the one thing this must never be: a missing log file
+    // and an empty log file look identical, and the reason is what the user
+    // needs.
+    if (lines.empty()) {
+        lines = status[0] != '\0'
+                    ? std::string(status)
+                    : std::string("No log file is available.");
+    }
+
+    context["log_lines"] = lines;
+    context["log_status"] = std::string(status);
+
     return HTTPOK;
 }

--- a/addon/webserver/pages/config.html
+++ b/addon/webserver/pages/config.html
@@ -131,6 +131,7 @@
             <div class="current-value">Current: {{current_logfile}}</div>
             <input type="text" name="logfile" id="logfile" value="{{logfile}}" size="30">
             <div class="current-value">A file on the boot partition, e.g. usbode-log.txt. The directory must already exist. Leave empty to disable file logging.</div>
+            <div class="current-value" {{#logfile_broken}}style="color:#b00020;font-weight:bold"{{/logfile_broken}}>Status: {{logfile_status}}</div>
         </div>
         <div class="form-group">
             <label for="loglevel">Log Level:</label>

--- a/addon/webserver/pages/config.html
+++ b/addon/webserver/pages/config.html
@@ -130,7 +130,7 @@
             <label for="logfile">Log File Path:</label>
             <div class="current-value">Current: {{current_logfile}}</div>
             <input type="text" name="logfile" id="logfile" value="{{logfile}}" size="30">
-            <div class="current-value">Leave empty to disable file logging. Will be automatically prefixed with 0:/</div>
+            <div class="current-value">A file on the boot partition, e.g. usbode-log.txt. The directory must already exist. Leave empty to disable file logging.</div>
         </div>
         <div class="form-group">
             <label for="loglevel">Log Level:</label>

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -68,6 +68,13 @@ DISCIMAGE_SRCS := \
 	$(ADDON)/discimage/mdsfile.cpp \
 	$(ADDON)/mdsparser/mdsparser.cpp
 
+# The file log daemon. Not a disc-image path, but it reaches the SD card
+# through the same FatFs seam, and what it does when that open FAILS is the
+# behaviour worth pinning: a bad path used to cost 20 ms of scheduler time per
+# log event, which presented as the whole Pi having gone slow.
+SERVICE_SRCS := \
+	$(ADDON)/filelogdaemon/filelogdaemon.cpp
+
 CHDR_OBJS :=
 ifeq ($(WITH_CHD),1)
 DISCIMAGE_SRCS += $(ADDON)/discimage/chdfile.cpp
@@ -97,7 +104,7 @@ endif
 HARNESS_SRCS := $(wildcard harness/*.cpp)
 TEST_SRCS    := $(wildcard test-suite/*.cpp)
 
-CXX_SRCS := $(GADGET_SRCS) $(DISCIMAGE_SRCS) $(HARNESS_SRCS) $(TEST_SRCS)
+CXX_SRCS := $(GADGET_SRCS) $(DISCIMAGE_SRCS) $(SERVICE_SRCS) $(HARNESS_SRCS) $(TEST_SRCS)
 CXX_OBJS := $(addprefix $(BUILD)/,$(notdir $(CXX_SRCS:.cpp=.o)))
 OBJS := $(CXX_OBJS) $(CHDR_OBJS)
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -11,6 +11,22 @@ make -C integration-tests WITH_CHD=1 # also run the real .chd image through libc
 USBODE_TEST_VERBOSE=1 integration-tests/out/usbode-host-tests   # with firmware logs
 ```
 
+Under a sanitizer. Note that a `CXXFLAGS` on the command line **replaces** the
+one the Makefile builds up rather than adding to it, so `-std=c++17` has to be
+repeated or the build fails:
+
+```
+make -C integration-tests clean
+make -C integration-tests \
+    CXXFLAGS="-std=c++17 -O0 -g -fsanitize=address,undefined" \
+    CFLAGS="-O0 -g -fsanitize=address,undefined" \
+    LDFLAGS="-fsanitize=address,undefined"
+```
+
+Worth running when a fix is about an uninitialised member: a `bool` that holds
+neither 0 nor 1 is undefined to read, so an ordinary assertion cannot pin it -
+the optimizer folds the test - but UBSan names the exact line.
+
 ## What this is
 
 The **real firmware sources** — all of `addon/usbcdgadget` (command
@@ -198,16 +214,25 @@ integration-tests/
   Makefile             host build; `make` = build + run, WITH_CHD=1 adds CHD
   harness/
     stubs/             minimal Circle/service headers (circle/, cdplayer/, fatfs/, ...)
-    stubs.cpp          logger/scheduler/timer/endpoint implementations
+    stubs.cpp          logger/scheduler/timer/endpoint implementations; the
+                       logger keeps a real event queue and the scheduler counts
+                       sleeps, so a task that drains the log can be tested
     testbus.h          records BeginTransfer()/Stall() from the gadget
     fakedisc.*         in-memory disc images + cue sheets
-    fatfs_host.cpp     FatFs f_open/f_read/... over host stdio (real-image reads)
+    fatfs_host.cpp     FatFs f_open/f_read/... over host stdio (real-image
+                       reads, and writes for the log daemon)
     discimage_host.cpp FatFsOptimizer no-op backing (fast seek n/a on host)
     bench.*            the virtual USB host
     framework.*        tiny TEST()/CHECK() runner
-  test-suite/          one file per command family, plus test_realimages.cpp
-                       and test_mdsimages.cpp
+  test-suite/          one file per command family, plus test_realimages.cpp,
+                       test_mdsimages.cpp and test_logdaemon.cpp
 ```
+
+Not everything here is a SCSI command. `addon/filelogdaemon` is compiled in
+too, because it reaches the SD card through the same FatFs seam and its
+interesting behaviour is what it does when that open **fails**: a log path
+under a directory that does not exist used to cost 20 ms of scheduler time per
+log event, which presented as the whole Pi having gone slow.
 
 Two production accommodations (both inert on the device):
 

--- a/integration-tests/harness/fatfs_host.cpp
+++ b/integration-tests/harness/fatfs_host.cpp
@@ -18,8 +18,31 @@ FRESULT f_open(FIL* fp, const TCHAR* path, BYTE mode)
     if (!fp || !path) {
         return FR_INVALID_PARAMETER;
     }
-    // The readers only ever open images read-only.
-    FILE* f = fopen(path, "rb");
+
+    // The image readers only ever read, but the log daemon opens its file for
+    // append, and whether that open SUCCEEDS is the whole subject of its
+    // tests - so the mode has to be honoured rather than assumed.
+    //
+    // FA_OPEN_ALWAYS means "open it, creating it if absent", which is "r+b"
+    // falling back to "w+b". Letting the fallback run only when the file is
+    // genuinely missing is what keeps a bad directory an error: fopen cannot
+    // create a file under a directory that does not exist, so a path like
+    // 0:/nosuchdir/log.txt fails here exactly as FatFs would fail it.
+    const char* stdioMode = "rb";
+    if (mode & (FA_WRITE | FA_CREATE_ALWAYS | FA_CREATE_NEW | FA_OPEN_ALWAYS)) {
+        if (mode & FA_CREATE_ALWAYS) {
+            stdioMode = "w+b";
+        } else if ((mode & FA_OPEN_APPEND) == FA_OPEN_APPEND) {
+            stdioMode = "a+b";
+        } else {
+            stdioMode = "r+b";
+        }
+    }
+
+    FILE* f = fopen(path, stdioMode);
+    if (!f && (mode & (FA_OPEN_ALWAYS | FA_CREATE_NEW))) {
+        f = fopen(path, "w+b");
+    }
     if (!f) {
         return FR_NO_FILE;
     }
@@ -84,6 +107,14 @@ FRESULT f_write(FIL* fp, const void* buff, UINT btw, UINT* bw)
         *bw = (UINT)n;
     }
     return (n == btw) ? FR_OK : FR_DISK_ERR;
+}
+
+FRESULT f_sync(FIL* fp)
+{
+    if (!fp || !fp->host_fp) {
+        return FR_INVALID_OBJECT;
+    }
+    return fflush((FILE*)fp->host_fp) == 0 ? FR_OK : FR_DISK_ERR;
 }
 
 FRESULT f_lseek(FIL* fp, FSIZE_t ofs)

--- a/integration-tests/harness/framework.cpp
+++ b/integration-tests/harness/framework.cpp
@@ -59,6 +59,7 @@ namespace
         {"test_realimages", "Real disc images"},
         {"test_mdsimages", "MDS/MDF images"},
         {"test_multisession", "Multi-session and CD Extra"},
+        {"test_logdaemon", "File log daemon"},
     };
 
     // "test-suite/test_read10.cpp" -> "SCSI read commands"

--- a/integration-tests/harness/stubs.cpp
+++ b/integration-tests/harness/stubs.cpp
@@ -43,23 +43,117 @@ CLogger *CLogger::Get(void)
     return &instance;
 }
 
+namespace
+{
+struct LogEvent
+{
+    TLogSeverity severity;
+    std::string source;
+    std::string message;
+};
+
+// Bounded so a long run cannot grow it without limit. The real logger's queue
+// is a fixed ring too; what matters for the tests is that events survive until
+// something drains them.
+const size_t kMaxQueuedEvents = 256;
+
+std::vector<LogEvent> &EventQueue()
+{
+    static std::vector<LogEvent> queue;
+    return queue;
+}
+
+TLogEventNotificationHandler *g_pEventHandler = nullptr;
+TLogPanicHandler *g_pPanicHandler = nullptr;
+} // namespace
+
 void CLogger::Write(const char *pSource, TLogSeverity Severity, const char *pMessage, ...)
 {
     static const bool verbose = getenv("USBODE_TEST_VERBOSE") != nullptr;
+
+    char formatted[LOG_MAX_MESSAGE];
+    va_list var;
+    va_start(var, pMessage);
+    vsnprintf(formatted, sizeof(formatted), pMessage, var);
+    va_end(var);
+
+    // Queue first, and unconditionally: the real logger does not consult any
+    // loglevel here.
+    TestQueueEvent(Severity, pSource, formatted);
+
     if (!verbose)
     {
         return;
     }
 
     static const char *severityNames[] = {"panic", "error", "warn", "note", "debug"};
-    fprintf(stdout, "[%s] %s: ", severityNames[Severity], pSource);
+    fprintf(stdout, "[%s] %s: %s\n", severityNames[Severity], pSource, formatted);
+}
 
-    va_list var;
-    va_start(var, pMessage);
-    vfprintf(stdout, pMessage, var);
-    va_end(var);
+void CLogger::TestQueueEvent(TLogSeverity Severity, const char *pSource, const char *pMessage)
+{
+    std::vector<LogEvent> &queue = EventQueue();
+    if (queue.size() >= kMaxQueuedEvents)
+    {
+        queue.erase(queue.begin());
+    }
+    queue.push_back({Severity, pSource ? pSource : "", pMessage ? pMessage : ""});
 
-    fprintf(stdout, "\n");
+    if (g_pEventHandler != nullptr)
+    {
+        g_pEventHandler();
+    }
+}
+
+void CLogger::TestClearEvents(void)
+{
+    EventQueue().clear();
+}
+
+unsigned CLogger::TestQueuedEventCount(void)
+{
+    return (unsigned)EventQueue().size();
+}
+
+boolean CLogger::ReadEvent(TLogSeverity *pSeverity, char *pSource, char *pMessage,
+                           time_t *pTime, unsigned *pHundredthTime, int *pTimeZone)
+{
+    std::vector<LogEvent> &queue = EventQueue();
+    if (queue.empty())
+    {
+        return FALSE;
+    }
+
+    LogEvent event = queue.front();
+    queue.erase(queue.begin());
+
+    if (pSeverity) *pSeverity = event.severity;
+    if (pSource)
+    {
+        strncpy(pSource, event.source.c_str(), LOG_MAX_SOURCE - 1);
+        pSource[LOG_MAX_SOURCE - 1] = '\0';
+    }
+    if (pMessage)
+    {
+        strncpy(pMessage, event.message.c_str(), LOG_MAX_MESSAGE - 1);
+        pMessage[LOG_MAX_MESSAGE - 1] = '\0';
+    }
+    // A fixed time keeps log lines byte-comparable between runs.
+    if (pTime) *pTime = 0;
+    if (pHundredthTime) *pHundredthTime = 0;
+    if (pTimeZone) *pTimeZone = 0;
+
+    return TRUE;
+}
+
+void CLogger::RegisterEventNotificationHandler(TLogEventNotificationHandler *pHandler)
+{
+    g_pEventHandler = pHandler;
+}
+
+void CLogger::RegisterPanicHandler(TLogPanicHandler *pHandler)
+{
+    g_pPanicHandler = pHandler;
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +195,26 @@ void CScheduler::TestRegisterTask(const char *pName, CTask *pTask)
 void CScheduler::TestClearTasks(void)
 {
     TaskRegistry().clear();
+}
+
+namespace
+{
+unsigned g_nSleepCount = 0;
+}
+
+void CScheduler::TestNoteSleep(void)
+{
+    g_nSleepCount++;
+}
+
+unsigned CScheduler::TestSleepCount(void)
+{
+    return g_nSleepCount;
+}
+
+void CScheduler::TestResetSleepCount(void)
+{
+    g_nSleepCount = 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/integration-tests/harness/stubs/circle/logger.h
+++ b/integration-tests/harness/stubs/circle/logger.h
@@ -7,6 +7,7 @@
 #define _circle_logger_h
 
 #include <circle/types.h>
+#include <time.h>
 
 enum TLogSeverity
 {
@@ -17,12 +18,39 @@ enum TLogSeverity
     LogDebug
 };
 
+// Sizes as declared by the real circle/logger.h, since CFileLogDaemon sizes
+// its own ReadEvent() buffers from them.
+#define LOG_MAX_SOURCE   50
+#define LOG_MAX_MESSAGE  200
+
+typedef void TLogEventNotificationHandler(void);
+typedef void TLogPanicHandler(void);
+
 class CLogger
 {
 public:
     static CLogger *Get(void);
 
     void Write(const char *pSource, TLogSeverity Severity, const char *pMessage, ...);
+
+    // The event queue. The real CLogger queues EVERY event regardless of the
+    // configured loglevel - that only filters the serial and screen targets -
+    // and consumers such as CFileLogDaemon apply their own filter as they
+    // drain. Reproducing that here is the point: a daemon that filtered on the
+    // wrong side of the queue would look correct against a stub that dropped
+    // events itself.
+    boolean ReadEvent(TLogSeverity *pSeverity, char *pSource, char *pMessage,
+                      time_t *pTime, unsigned *pHundredthTime, int *pTimeZone);
+
+    void RegisterEventNotificationHandler(TLogEventNotificationHandler *pHandler);
+    void RegisterPanicHandler(TLogPanicHandler *pHandler);
+
+    // Test-side control. Queue an event as if firmware code had logged it, and
+    // empty the queue between tests so one test's chatter cannot be read by
+    // the next.
+    static void TestQueueEvent(TLogSeverity Severity, const char *pSource, const char *pMessage);
+    static void TestClearEvents(void);
+    static unsigned TestQueuedEventCount(void);
 };
 
 // Match the real Circle logging macros so firmware sources that use

--- a/integration-tests/harness/stubs/circle/sched/scheduler.h
+++ b/integration-tests/harness/stubs/circle/sched/scheduler.h
@@ -17,14 +17,21 @@ public:
 
     CTask *GetTask(const char *pTaskName);
 
-    void Sleep(unsigned nSeconds) {}
-    void MsSleep(unsigned nMilliSeconds) {}
-    void usSleep(unsigned nMicroSeconds) {}
+    // Sleeping cannot actually happen on a single-threaded host build, but it
+    // is counted: on a real Pi a sleep on a per-event path costs the whole
+    // system, and counting is the only way a host test can see that a code
+    // path stopped taking one.
+    void Sleep(unsigned nSeconds) { TestNoteSleep(); }
+    void MsSleep(unsigned nMilliSeconds) { TestNoteSleep(); }
+    void usSleep(unsigned nMicroSeconds) { TestNoteSleep(); }
     void Yield(void) {}
 
     // Test control
     void TestRegisterTask(const char *pName, CTask *pTask);
     void TestClearTasks(void);
+    static void TestNoteSleep(void);
+    static unsigned TestSleepCount(void);
+    static void TestResetSleepCount(void);
 };
 
 #endif

--- a/integration-tests/harness/stubs/circle/sched/synchronizationevent.h
+++ b/integration-tests/harness/stubs/circle/sched/synchronizationevent.h
@@ -4,13 +4,21 @@
 #ifndef _circle_sched_synchronizationevent_h
 #define _circle_sched_synchronizationevent_h
 
+// The state is tracked rather than discarded so a test can tell whether a
+// daemon was woken. Wait() cannot block: the host build is single-threaded and
+// there is no scheduler to yield to, so a task under test is driven one step at
+// a time instead of by running its loop.
 class CSynchronizationEvent
 {
 public:
-    CSynchronizationEvent(void) {}
-    void Set(void) {}
-    void Clear(void) {}
+    CSynchronizationEvent(void) : m_bState(false) {}
+    void Set(void) { m_bState = true; }
+    void Clear(void) { m_bState = false; }
     void Wait(void) {}
+    bool GetState(void) const { return m_bState; }
+
+private:
+    bool m_bState;
 };
 
 #endif

--- a/integration-tests/harness/stubs/circle/sched/task.h
+++ b/integration-tests/harness/stubs/circle/sched/task.h
@@ -6,13 +6,34 @@
 
 #include <circle/types.h>
 
+#include <string.h>
+
 class CTask
 {
 public:
-    CTask(void) {}
+    CTask(void) { m_Name[0] = '\0'; }
     virtual ~CTask(void) {}
 
     virtual void Run(void) {}
+
+    // Circle uses the name to find a task through CScheduler::GetTask(); tasks
+    // that set one are reachable that way, so the stub has to keep it rather
+    // than discard it.
+    void SetName(const char *pName)
+    {
+        if (pName == nullptr)
+        {
+            m_Name[0] = '\0';
+            return;
+        }
+        strncpy(m_Name, pName, sizeof(m_Name) - 1);
+        m_Name[sizeof(m_Name) - 1] = '\0';
+    }
+
+    const char *GetName(void) const { return m_Name; }
+
+private:
+    char m_Name[32];
 };
 
 #endif

--- a/integration-tests/harness/stubs/circle/string.h
+++ b/integration-tests/harness/stubs/circle/string.h
@@ -1,0 +1,13 @@
+//
+// Host-build stub for <circle/string.h>.
+//
+// Circle's CString is not needed by anything the suite compiles - the sources
+// that include this header do so for other declarations that come with it -
+// so this is deliberately empty rather than a partial reimplementation. If a
+// firmware source under test starts using CString, add it here rather than
+// letting the compiler pick up a lookalike from somewhere else.
+//
+#ifndef _circle_string_h
+#define _circle_string_h
+
+#endif

--- a/integration-tests/harness/stubs/circle/time.h
+++ b/integration-tests/harness/stubs/circle/time.h
@@ -1,0 +1,13 @@
+//
+// Host-build stub for <circle/time.h>.
+//
+// Circle declares CTime here and pulls in time_t. Only time_t is used by the
+// sources the suite compiles (it appears in the logger's event signatures), so
+// this hands that straight to the host's own <time.h> instead of restating it.
+//
+#ifndef _circle_time_h
+#define _circle_time_h
+
+#include <time.h>
+
+#endif

--- a/integration-tests/harness/stubs/fatfs/ff.h
+++ b/integration-tests/harness/stubs/fatfs/ff.h
@@ -110,6 +110,7 @@ FRESULT f_open  (FIL* fp, const TCHAR* path, BYTE mode);
 FRESULT f_close (FIL* fp);
 FRESULT f_read  (FIL* fp, void* buff, UINT btr, UINT* br);
 FRESULT f_write (FIL* fp, const void* buff, UINT btw, UINT* bw);
+FRESULT f_sync  (FIL* fp);
 FRESULT f_lseek (FIL* fp, FSIZE_t ofs);
 
 // Directory walk: link-only stubs for mdsfile.cpp (MDS is not under test).

--- a/integration-tests/test-suite/test_logdaemon.cpp
+++ b/integration-tests/test-suite/test_logdaemon.cpp
@@ -1,0 +1,249 @@
+//
+// test_logdaemon.cpp
+//
+// The file log daemon (addon/filelogdaemon/filelogdaemon.cpp), driven on the
+// host through the same FatFs seam the disc-image readers use.
+//
+// The interesting behaviour is not the happy path. A user reported a Pi that
+// had gone slow and had no log file, from a log path of
+// "0:/SD:/usbode-logs.txt" - a value the web form built out of what he typed.
+// Every one of these tests is about what the daemon does when the file it was
+// told to open is not there to open.
+//
+// Run() never returns, so the tests drive DrainOnce(), which is one pass of
+// its loop.
+//
+#include "framework.h"
+
+#include <circle/logger.h>
+#include <circle/sched/scheduler.h>
+#include <fatfs/ff.h>
+#include <filelogdaemon/filelogdaemon.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <new>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::string TestDataDir()
+{
+#ifdef USBODE_TESTDATA
+    return USBODE_TESTDATA;
+#else
+    return "out/images";
+#endif
+}
+
+static void QueueEvents(unsigned n, TLogSeverity severity = LogError)
+{
+    for (unsigned i = 0; i < n; i++) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "event %u", i);
+        CLogger::TestQueueEvent(severity, "test", msg);
+    }
+}
+
+static std::string ReadWholeFile(const std::string &path)
+{
+    FILE *f = fopen(path.c_str(), "rb");
+    if (!f) {
+        return std::string();
+    }
+    std::string out;
+    char buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
+        out.append(buf, n);
+    }
+    fclose(f);
+    return out;
+}
+
+static void RemoveFile(const std::string &path)
+{
+    remove(path.c_str());
+}
+
+// Every test starts from a clean queue: the firmware sources the rest of the
+// suite exercises log freely, and those events sit in the same queue.
+static void ResetLogging()
+{
+    CLogger::TestClearEvents();
+    CScheduler::TestResetSleepCount();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// The headline defect. With no file open every message fails, and the drain
+// loop used to sleep 20 ms for each one - so the log queue retired 50 events a
+// second and took the scheduler down with it. The daemon still has to consume
+// the events (leaving them queued would strand the logger), it just must not
+// pay for them.
+TEST(logdaemon_unopenable_path_drains_without_sleeping)
+{
+    ResetLogging();
+
+    // A directory that does not exist, which is the shape of the reported
+    // value: "SD:/usbode-logs.txt" with "0:/" pasted on the front.
+    const std::string path = TestDataDir() + "/no-such-dir/usbode-logs.txt";
+
+    CFileLogDaemon daemon(path.c_str(), 5);
+    CHECK(!daemon.IsFileLogging());
+    CHECK(daemon.GetOpenResult() != FR_OK);
+
+    // Constructing the daemon logs its own failure, which queues an event.
+    // Clear so the count below is only what this test put there.
+    ResetLogging();
+
+    const unsigned kEvents = 200;
+    QueueEvents(kEvents);
+    CHECK_EQ(CLogger::TestQueuedEventCount(), kEvents);
+
+    daemon.DrainOnce();
+
+    // Consumed, and for free.
+    CHECK_EQ(CLogger::TestQueuedEventCount(), 0u);
+    CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+}
+
+// m_bFileInitialized had no initializer and was not in the constructor's init
+// list, so when the open failed it held whatever was already in that memory.
+// Non-zero meant LogMessage() wrote to an unopened FIL and the destructor
+// closed one.
+//
+// Constructing over poisoned storage is what exposes that. Note what actually
+// catches it, though: the flag is a bool, and reading a bool that holds
+// neither 0 nor 1 is undefined, so an ordinary CHECK cannot be relied on - the
+// optimizer is free to fold the test either way, and at -O1 it does. The pin
+// is the sanitizer build:
+//
+//   make -C integration-tests clean
+//   make -C integration-tests \
+//       CXXFLAGS="-std=c++17 -O0 -g -fsanitize=address,undefined" \
+//       CFLAGS="-O0 -g -fsanitize=address,undefined" \
+//       LDFLAGS="-fsanitize=address,undefined"
+//
+// Remove the initializer and that run reports "load of value 248, which is not
+// a valid value for type 'boolean'" at all three places the flag is read: the
+// IsFileLogging() accessor, LogMessage()'s guard, and the destructor's decision
+// to close the file. What is asserted below is the behaviour that follows from
+// the flag being false - nothing written, nothing closed, no back-off.
+TEST(logdaemon_failed_open_leaves_the_file_flag_false)
+{
+    ResetLogging();
+
+    const std::string path = TestDataDir() + "/no-such-dir/usbode-logs.txt";
+
+    alignas(CFileLogDaemon) static unsigned char storage[sizeof(CFileLogDaemon)];
+    memset(storage, 0xAA, sizeof(storage));
+
+    CFileLogDaemon *daemon = new (storage) CFileLogDaemon(path.c_str(), 5);
+    CHECK(!daemon->IsFileLogging());
+
+    ResetLogging();
+    QueueEvents(4);
+    daemon->DrainOnce();
+    CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+
+    daemon->~CFileLogDaemon();
+}
+
+// An empty path is the config's way of saying "no file logging", not a
+// mistake, so it must not be reported as a failure to open something.
+TEST(logdaemon_empty_path_is_logging_disabled)
+{
+    ResetLogging();
+
+    CFileLogDaemon daemon("", 5);
+    CHECK(!daemon.IsFileLogging());
+    CHECK_EQ(daemon.GetOpenResult(), FR_INVALID_NAME);
+
+    ResetLogging();
+    QueueEvents(16);
+    daemon.DrainOnce();
+    CHECK_EQ(CLogger::TestQueuedEventCount(), 0u);
+    CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+}
+
+// The path that has to keep working: a usable file gets the messages, with the
+// configured level applied on this side of the queue (CLogger queues
+// everything regardless of level, so a daemon that relied on the queue to
+// filter would log too much).
+TEST(logdaemon_writes_and_applies_the_configured_level)
+{
+    ResetLogging();
+
+    const std::string path = TestDataDir() + "/logdaemon.txt";
+    RemoveFile(path);
+
+    {
+        // Level 3 keeps panic(0), error(1) and warning(2); notice(3) and
+        // debug(4) are dropped.
+        CFileLogDaemon daemon(path.c_str(), 3);
+        CHECK(daemon.IsFileLogging());
+        CHECK_EQ(daemon.GetOpenResult(), FR_OK);
+
+        ResetLogging();
+        CLogger::TestQueueEvent(LogError, "src", "an error");
+        CLogger::TestQueueEvent(LogWarning, "src", "a warning");
+        CLogger::TestQueueEvent(LogNotice, "src", "a notice");
+        CLogger::TestQueueEvent(LogDebug, "src", "a debug line");
+        daemon.DrainOnce();
+
+        CHECK_EQ(CLogger::TestQueuedEventCount(), 0u);
+        CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+    }
+
+    const std::string contents = ReadWholeFile(path);
+    CHECK(contents.find("an error") != std::string::npos);
+    CHECK(contents.find("a warning") != std::string::npos);
+    CHECK(contents.find("a notice") == std::string::npos);
+    CHECK(contents.find("a debug line") == std::string::npos);
+
+    RemoveFile(path);
+}
+
+// The daemon kept the caller's pointer rather than the string. It came from
+// the config store, which is free to replace the value while the daemon is
+// still running - and the web UI does exactly that when the log path is
+// edited. Overwrite the caller's buffer and the daemon must be unaffected.
+TEST(logdaemon_keeps_its_own_copy_of_the_path)
+{
+    ResetLogging();
+
+    const std::string path = TestDataDir() + "/logdaemon-copy.txt";
+    RemoveFile(path);
+
+    char caller[256];
+    strncpy(caller, path.c_str(), sizeof(caller) - 1);
+    caller[sizeof(caller) - 1] = '\0';
+
+    {
+        CFileLogDaemon daemon(caller, 5);
+        CHECK(daemon.IsFileLogging());
+
+        // The config store hands out a new value for the key.
+        memset(caller, 0, sizeof(caller));
+        strncpy(caller, "0:/somewhere-else.txt", sizeof(caller) - 1);
+
+        CHECK(strcmp(daemon.GetLogFilePath(), path.c_str()) == 0);
+
+        ResetLogging();
+        CLogger::TestQueueEvent(LogError, "src", "still the original file");
+        daemon.DrainOnce();
+        CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+    }
+
+    const std::string contents = ReadWholeFile(path);
+    CHECK(contents.find("still the original file") != std::string::npos);
+
+    RemoveFile(path);
+}

--- a/integration-tests/test-suite/test_logdaemon.cpp
+++ b/integration-tests/test-suite/test_logdaemon.cpp
@@ -211,6 +211,61 @@ TEST(logdaemon_writes_and_applies_the_configured_level)
     RemoveFile(path);
 }
 
+// What the web UI shows. The boot-time warning about a path that will not open
+// goes to the serial console, and a SCREEN_HEADLESS build has nowhere else to
+// put it - so if the config page does not say this, a user with a bad path sees
+// a device that lists a log file and silently has none. Found by David testing
+// exactly that case and reporting "didn't see any warning".
+TEST(logdaemon_reports_its_status_for_the_web_ui)
+{
+    ResetLogging();
+    char status[256];
+
+    // Working.
+    const std::string good = TestDataDir() + "/logdaemon-status.txt";
+    RemoveFile(good);
+    {
+        CFileLogDaemon daemon(good.c_str(), 5);
+        CHECK(daemon.IsFileLogging());
+        daemon.GetStatusText(status, sizeof(status));
+        CHECK(strstr(status, "Writing to") != nullptr);
+        CHECK(strstr(status, "NOT LOGGING") == nullptr);
+    }
+    RemoveFile(good);
+
+    // Broken: has to name the path and say it is not logging, because that is
+    // the whole message.
+    ResetLogging();
+    const std::string bad = TestDataDir() + "/no-such-dir/usbode-logs.txt";
+    {
+        CFileLogDaemon daemon(bad.c_str(), 5);
+        CHECK(!daemon.IsFileLogging());
+        daemon.GetStatusText(status, sizeof(status));
+        CHECK(strstr(status, "NOT LOGGING") != nullptr);
+        CHECK(strstr(status, "usbode-logs.txt") != nullptr);
+    }
+
+    // Off on purpose is not an error and must not read like one.
+    ResetLogging();
+    {
+        CFileLogDaemon daemon("", 5);
+        daemon.GetStatusText(status, sizeof(status));
+        CHECK(strstr(status, "off") != nullptr);
+        CHECK(strstr(status, "NOT LOGGING") == nullptr);
+    }
+
+    // The log viewer opens the file through newlib, which wants an ordinary
+    // path rather than the FatFs volume form the config stores. It used to
+    // hardcode "/usbode-logs.txt" and show a blank page for any other setting.
+    ResetLogging();
+    {
+        CFileLogDaemon daemon("0:/somewhere/usbode-log.txt", 5);
+        char path[256];
+        daemon.GetStdioPath(path, sizeof(path));
+        CHECK(strcmp(path, "/somewhere/usbode-log.txt") == 0);
+    }
+}
+
 // The daemon kept the caller's pointer rather than the string. It came from
 // the config store, which is free to replace the value while the daemon is
 // still running - and the web UI does exactly that when the log path is

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -43,7 +43,6 @@
 #define FIRMWARE_PATH ROOTDRIVE "/firmware/"
 #define SUPPLICANT_CONFIG_FILE ROOTDRIVE "/wpa_supplicant.conf"
 #define CONFIG_FILE ROOTDRIVE "/config.txt"
-#define LOG_FILE ROOTDRIVE "/logfile.txt"
 #define HOSTNAME "usbode"
 #define SPI_MASTER_DEVICE 0
 
@@ -142,13 +141,25 @@ boolean CKernel::Initialize(void)
             m_pConfigService = new ConfigService();
             LOGNOTE("Initialized Config service");
 
-            // Start file logging with proper config
+            // Start file logging with proper config. Whether the file opened
+            // has to be reported: the daemon runs either way, so a path that
+            // cannot be opened leaves a system that looks fine and logs
+            // nothing, and the user's only clue is the missing file. Only
+            // volume 0: is mounted at this point (1: comes later, below), so a
+            // path anywhere else fails here by design.
             const char *logfile = m_pConfigService->GetLogfile();
-            if (logfile)
+            CFileLogDaemon *pLogDaemon =
+                new CFileLogDaemon(logfile ? logfile : "", m_pConfigService->GetLogLevel());
+            if (pLogDaemon->IsFileLogging())
             {
-                new CFileLogDaemon(logfile, m_pConfigService->GetLogLevel());
-                // CScheduler::Get()->MsSleep(100);
-                LOGNOTE("Started early file logging");
+                LOGNOTE("Started early file logging to %s", pLogDaemon->GetLogFilePath());
+            }
+            else if (pLogDaemon->GetLogFilePath()[0] != '\0')
+            {
+                LOGWARN("File logging is OFF: cannot open '%s' (FatFs error %d). "
+                        "Check the log path on the web UI's config page; it must be "
+                        "a file in an existing directory on the boot partition.",
+                        pLogDaemon->GetLogFilePath(), (int)pLogDaemon->GetOpenResult());
             }
         }
     }


### PR DESCRIPTION
Three commits. This started from a user report: a Pi that had gone slow and had no log file.

His log path was `0:/SD:/usbode-logs.txt`, which the web form built for him out of `SD:/usbode-logs.txt` by pasting `0:/` on the front of anything that did not already start with it. That path cannot be opened, and everything that followed from the failed open was wrong.

**The cost.** `Run()` backed off 20 ms whenever a message failed to reach the file. That is right for a write that might succeed next time and useless when there is no file at all: every message failed, so the log queue retired 50 events a second, on a scheduler task, and dragged the rest of the system along with it. That is the reported slowness. The daemon now distinguishes a transient write failure from having no file to write to, and only pays for the first.

**The hazard.** `m_bFileInitialized` had no initializer and was not in the constructor's init list, so on the failing path it held whatever was in that memory. Non zero meant `LogMessage()` wrote to an unopened `FIL` and the destructor closed one.

**The silence.** `Initialize()`'s result was discarded by the constructor, which was itself discarded by the caller, and the message it did log named neither the path nor the reason. Boot now says which file it could not open, with the FatFs error, and where to go and fix it.

**The form.** It now normalises what you type rather than prefixing it blindly, rejects a volume other than 0 (only 0: is mounted when the daemon starts), rejects a parent directory that does not exist, and honours an empty value as "logging off" instead of ignoring it.

**Making it visible.** Testing the fix on hardware found the last gap: the boot warning went only to the serial console, which is the only target a SCREEN_HEADLESS build has, so from the web UI nothing had changed. The config page now shows the daemon's live status next to the path, in red when the file could not be opened. The log viewer had opened a hardcoded `/usbode-logs.txt` regardless of configuration, so anyone with a different path saw a blank page and no hint why; it now reads the configured file and says when there is nothing to show.

Both pages take their text from the daemon rather than working it out themselves, so they cannot drift from what it actually did.

Six new tests, including one that pins the specific regression: 200 events against an unopenable path must drain without a single scheduler sleep. This needed some harness work to compile the daemon on the host, which is included.

Host suite 153/153.
