### PR TITLE
FTP: refuse to delete, rename or overwrite the mounted image

### DIFF
--- a/addon/ftpserver/fatfspath.h
+++ b/addon/ftpserver/fatfspath.h
@@ -1,0 +1,78 @@
+#ifndef _ftpserver_fatfspath_h
+#define _ftpserver_fatfspath_h
+
+#include <stddef.h>
+#include <string.h>
+
+//
+// Comparing two FatFs paths for "same file".
+//
+// This lives in its own header, separate from the FTP worker, because the
+// worker needs a socket stack and cannot be compiled into the host test suite -
+// and the guard that stops a client deleting, renaming or overwriting the
+// mounted image failed TWICE in a row purely on path spelling, with no test
+// able to see it:
+//
+//   "1://Alien.cue"  RealPath() formats "%s/%s" onto m_CurrentPath, which is
+//                    "1:/" for the whole session when the worker auto-enters
+//                    the images partition on connect.
+//   "1:Alien.cue"    FTPPathToFatFsPath() consumes the slash that follows the
+//                    volume when it turns an absolute FTP path into a FatFs
+//                    one, and never puts it back.
+//   "1:/Alien.cue"   what SCSITBService::GetCurrentCDPath() always reports.
+//
+// FatFs resolves all three to the same file - a drive-relative path is taken
+// against that volume's current directory, which is its root here - so every
+// spelling works for f_open/f_unlink/f_rename and only a string comparison can
+// tell them apart. That is exactly the comparison the guard is.
+//
+
+// Canonical form: separators collapsed, no trailing separator, and always a
+// separator directly after the volume colon.
+static inline void NormalizeFatFsPath(const char *pIn, char *pOut, size_t nOutSize)
+{
+    size_t nOut = 0;
+    bool bVolumeSeen = false;
+
+    // Two spare bytes: one for a separator this may insert after the volume,
+    // one for the terminator.
+    for (size_t i = 0; pIn[i] != '\0' && nOut + 2 < nOutSize; i++)
+    {
+        if (pIn[i] == '/' && nOut > 0 && pOut[nOut - 1] == '/')
+            continue; // collapse repeated separators
+
+        pOut[nOut++] = pIn[i];
+
+        if (pIn[i] == ':' && !bVolumeSeen)
+        {
+            bVolumeSeen = true;
+            if (pIn[i + 1] != '/' && pIn[i + 1] != '\0')
+                pOut[nOut++] = '/'; // "1:name" -> "1:/name"
+        }
+    }
+
+    while (nOut > 1 && pOut[nOut - 1] == '/')
+        nOut--;
+
+    pOut[nOut] = '\0';
+}
+
+// Whether two FatFs paths name the same file. Case-insensitive, because FAT is.
+static inline bool FatFsPathsEqual(const char *pA, const char *pB, size_t nMax)
+{
+    if (pA == nullptr || pB == nullptr)
+        return false;
+
+    // 520 covers MAX_PATH_LEN (512) plus the inserted separator and terminator.
+    char NormA[520];
+    char NormB[520];
+    if (nMax > sizeof(NormA))
+        nMax = sizeof(NormA);
+
+    NormalizeFatFsPath(pA, NormA, nMax);
+    NormalizeFatFsPath(pB, NormB, nMax);
+
+    return strcasecmp(NormA, NormB) == 0;
+}
+
+#endif

--- a/addon/ftpserver/ftpworker.cpp
+++ b/addon/ftpserver/ftpworker.cpp
@@ -32,6 +32,7 @@
 #include <discimage/util.h>
 #include "ftpworker.h"
 #include "utility.h"
+#include "fatfspath.h"
 
 // Use a per-instance name for the log macros
 #define From m_LogName
@@ -395,6 +396,38 @@ CString CFTPWorker::RealPath(const char* pInBuffer) const {
     return Path;
 }
 
+// Deleting, renaming or overwriting the mounted image leaves the gadget reading
+// a file that no longer has the contents it opened - the host keeps issuing
+// READ(10) against storage that has been unlinked or truncated under it, which
+// is one reported way of hanging the device. The web UI has always refused this
+// (deleteapi.cpp:43); FTP did not, so the same card could be broken over FTP in
+// a way the browser would not allow.
+bool CFTPWorker::IsMountedImage(const char* pPath) const {
+    assert(pPath != nullptr);
+
+    SCSITBService* svc =
+        static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
+    if (svc == nullptr)
+        return false;
+
+    const char* current = svc->GetCurrentCDPath();
+    if (current == nullptr || current[0] == '\0')
+        return false;
+
+    // Not a plain strcmp: the same file reaches here spelled three different
+    // ways depending on how the client addressed it. See fatfspath.h.
+    return FatFsPathsEqual(pPath, current, MAX_PATH_LEN);
+}
+
+// The service is a task looked up by name; every caller here treated it as
+// guaranteed and dereferenced it blind.
+void CFTPWorker::RefreshImageCache() const {
+    SCSITBService* svc =
+        static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
+    if (svc != nullptr)
+        svc->RefreshCache();
+}
+
 const TDirectoryListEntry* CFTPWorker::BuildDirectoryList(size_t& nOutEntries) const {
     DIR Dir;
     FILINFO FileInfo;
@@ -708,6 +741,20 @@ bool CFTPWorker::Store(const char* pArgs) {
 
     FIL File;
     CString Path = RealPath(pArgs);
+
+    // FA_CREATE_ALWAYS truncates, so uploading over the mounted image empties
+    // the file the host is reading from - worse than deleting it, because the
+    // directory entry survives and nothing looks wrong until a read fails.
+    if (IsMountedImage(Path)) {
+        // Log BEFORE replying: SendStatus() formats into m_CommandBuffer, and
+        // pArgs points into that same buffer, so the reply overwrites the
+        // argument being logged.
+        LOGERR("Refused to overwrite the mounted image %s", pArgs);
+        SendStatus(TFTPStatus::FileActionNotTaken,
+                   "That image is mounted. Mount another one first.");
+        return false;
+    }
+
     if (f_open(&File, Path, FA_CREATE_ALWAYS | FA_WRITE) != FR_OK) {
         SendStatus(TFTPStatus::FileActionNotTaken, "Could not open file for writing.");
         return false;
@@ -816,9 +863,7 @@ bool CFTPWorker::Store(const char* pArgs) {
 
     f_close(&File);
 
-    SCSITBService* svc = static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
-    if (svc != nullptr)
-        svc->RefreshCache();
+    RefreshImageCache();
 
     return true;
 }
@@ -829,6 +874,14 @@ bool CFTPWorker::Delete(const char* pArgs) {
 
     CString Path = RealPath(pArgs);
 
+    if (IsMountedImage(Path)) {
+        // Before the reply - SendStatus() overwrites the buffer pArgs is in.
+        LOGERR("Refused to delete the mounted image %s", pArgs);
+        SendStatus(TFTPStatus::FileActionNotTaken,
+                   "That image is mounted. Mount another one first.");
+        return true;
+    }
+
     if (f_unlink(Path) != FR_OK) {
         SendStatus(TFTPStatus::FileActionNotTaken, "File was not deleted.");
 	LOGERR("Couldn't delete %s", pArgs);
@@ -836,8 +889,7 @@ bool CFTPWorker::Delete(const char* pArgs) {
     else
         SendStatus(TFTPStatus::FileActionOk, "File deleted.");
 
-    SCSITBService* svc = static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
-    svc->RefreshCache();
+    RefreshImageCache();
 
     return true;
 }
@@ -1092,6 +1144,20 @@ bool CFTPWorker::RenameTo(const char* pArgs) {
     CString SourcePath = RealPath(m_RenameFrom);
     CString DestPath = RealPath(pArgs);
 
+    // Renaming the mounted image moves it out from under the live mount just as
+    // surely as deleting it; renaming something else ONTO it destroys it.
+    if (IsMountedImage(SourcePath) || IsMountedImage(DestPath)) {
+        // Before the reply - SendStatus() overwrites the buffer pArgs is in.
+        // This one proved it: the log line read "... -> hat image is mounted.
+        // Mount another one first." - the reply itself, offset by five bytes.
+        LOGERR("Refused to rename the mounted image (%s -> %s)",
+               static_cast<const char*>(m_RenameFrom), pArgs);
+        SendStatus(TFTPStatus::FileNameNotAllowed,
+                   "That image is mounted. Mount another one first.");
+        m_RenameFrom = "";
+        return true;
+    }
+
     if (f_rename(SourcePath, DestPath) != FR_OK)
         SendStatus(TFTPStatus::FileNameNotAllowed, "File name not allowed.");
     else
@@ -1099,8 +1165,7 @@ bool CFTPWorker::RenameTo(const char* pArgs) {
 
     m_RenameFrom = "";
 
-    SCSITBService* svc = static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
-    svc->RefreshCache();
+    RefreshImageCache();
 
     return true;
 }

--- a/addon/ftpserver/ftpworker.h
+++ b/addon/ftpserver/ftpworker.h
@@ -104,6 +104,11 @@ class CFTPWorker : protected CTask {
     CString RealPath(const char* pInBuffer) const;
     const TDirectoryListEntry* BuildDirectoryList(size_t& nOutEntries) const;
 
+    // True if the path names the image the host currently has mounted.
+    bool IsMountedImage(const char* pPath) const;
+    // Rescan the image catalogue, tolerating the service not being there.
+    void RefreshImageCache() const;
+
     // FTP command handlers
     bool System(const char* pArgs);
     bool Username(const char* pArgs);

--- a/integration-tests/harness/framework.cpp
+++ b/integration-tests/harness/framework.cpp
@@ -59,6 +59,7 @@ namespace
         {"test_realimages", "Real disc images"},
         {"test_mdsimages", "MDS/MDF images"},
         {"test_multisession", "Multi-session and CD Extra"},
+        {"test_ftppaths", "FTP path matching"},
     };
 
     // "test-suite/test_read10.cpp" -> "SCSI read commands"

--- a/integration-tests/test-suite/test_ftppaths.cpp
+++ b/integration-tests/test-suite/test_ftppaths.cpp
@@ -1,0 +1,94 @@
+//
+// The FTP mounted-image guard is a path comparison, and it has now been wrong
+// twice in a row for the same underlying reason: the same file arrives spelled
+// differently depending on how the client addressed it, and every spelling
+// works for FatFs, so nothing except the comparison itself can notice.
+//
+// ftpworker.cpp cannot be compiled here (it needs the socket stack), so the
+// comparison lives in its own header and is pinned directly.
+//
+#include "framework.h"
+
+#include <ftpserver/fatfspath.h>
+
+// What SCSITBService::GetCurrentCDPath() always reports.
+static const char *kMounted = "1:/Alien Trilogy.cue";
+
+// Every spelling below is a real one produced by the FTP worker, not an
+// invented variation:
+//
+//   "1://x"  RealPath() formats "%s/%s" and m_CurrentPath is "1:/" for the
+//            whole session when the worker auto-enters the images partition
+//            on connect. This is what a plain "DELE x" produces.
+//   "1:x"    FTPPathToFatFsPath() eats the separator after the volume when it
+//            converts an absolute FTP path, and never restores it. This is
+//            what a client sending "/1/x" produces - and it is what defeated
+//            the first fix, which only collapsed duplicate separators.
+TEST(ftp_guard_matches_every_spelling_of_the_mounted_image)
+{
+    CHECK(FatFsPathsEqual("1:/Alien Trilogy.cue", kMounted, 512));
+    CHECK(FatFsPathsEqual("1://Alien Trilogy.cue", kMounted, 512));
+    CHECK(FatFsPathsEqual("1:Alien Trilogy.cue", kMounted, 512));
+    CHECK(FatFsPathsEqual("1:///Alien Trilogy.cue", kMounted, 512));
+
+    // FAT is case-insensitive, so a differently-cased name is the same file
+    // and must not slip past the guard.
+    CHECK(FatFsPathsEqual("1:/ALIEN TRILOGY.CUE", kMounted, 512));
+    CHECK(FatFsPathsEqual("1:alien trilogy.cue", kMounted, 512));
+}
+
+// The guard must not over-reach either: refusing to delete files that are not
+// mounted would be its own bug, and a prefix match would do exactly that.
+TEST(ftp_guard_does_not_match_other_files)
+{
+    CHECK(!FatFsPathsEqual("1:/Alien Trilogy.bin", kMounted, 512));
+    CHECK(!FatFsPathsEqual("1:/Alien Trilogy.cue.bak", kMounted, 512));
+    CHECK(!FatFsPathsEqual("1:/Alien", kMounted, 512));
+    CHECK(!FatFsPathsEqual("1:/Games/Alien Trilogy.cue", kMounted, 512));
+
+    // Same name, different volume: 0: is the boot partition, not images.
+    CHECK(!FatFsPathsEqual("0:/Alien Trilogy.cue", kMounted, 512));
+
+    CHECK(!FatFsPathsEqual(nullptr, kMounted, 512));
+    CHECK(!FatFsPathsEqual("1:/x.cue", nullptr, 512));
+}
+
+// Subfolders are the common case for anyone who organises their images, and
+// the CWD path builds them by a different route than the root case.
+TEST(ftp_guard_handles_paths_in_subfolders)
+{
+    const char *mounted = "1:/Games/RPG/game.cue";
+
+    CHECK(FatFsPathsEqual("1:/Games/RPG/game.cue", mounted, 512));
+    CHECK(FatFsPathsEqual("1://Games/RPG/game.cue", mounted, 512));
+    CHECK(FatFsPathsEqual("1:Games/RPG/game.cue", mounted, 512));
+    CHECK(FatFsPathsEqual("1:/Games//RPG/game.cue", mounted, 512));
+
+    CHECK(!FatFsPathsEqual("1:/Games/RPG2/game.cue", mounted, 512));
+    CHECK(!FatFsPathsEqual("1:/Games/game.cue", mounted, 512));
+}
+
+// Normalization details worth stating outright, since the guard rests on them.
+TEST(fatfs_path_normalization_is_canonical)
+{
+    char out[520];
+
+    NormalizeFatFsPath("1://a//b///c.cue", out, sizeof(out));
+    CHECK(strcmp(out, "1:/a/b/c.cue") == 0);
+
+    NormalizeFatFsPath("1:a/b.cue", out, sizeof(out));
+    CHECK(strcmp(out, "1:/a/b.cue") == 0);
+
+    // A trailing separator names the same directory as none.
+    NormalizeFatFsPath("1:/Games/", out, sizeof(out));
+    CHECK(strcmp(out, "1:/Games") == 0);
+
+    // A bare volume is left alone rather than growing a separator.
+    NormalizeFatFsPath("1:", out, sizeof(out));
+    CHECK(strcmp(out, "1:") == 0);
+
+    // Truncation must still terminate, never run off the buffer.
+    char small[8];
+    NormalizeFatFsPath("1:/averylongname.cue", small, sizeof(small));
+    CHECK(strlen(small) < sizeof(small));
+}


### PR DESCRIPTION
One commit. The web UI has always refused to delete the image the host has mounted. FTP had no such guard, so the same card could be broken over FTP in a way the browser would not allow, and a user reported the device locking up after the image file stopped existing.

Three FTP paths could do it:

* `DELE` unlinks the mounted image, leaving the gadget reading storage with no directory entry while the host keeps issuing READ(10).
* `RNTO` moves it out from under the mount just as effectively, and renaming something else onto it destroys it.
* `STOR` opens `FA_CREATE_ALWAYS`, which truncates. Uploading over the mounted image is the worst of the three, because the directory entry survives and nothing looks wrong until a read comes back short.

The comparison is the whole difficulty here, and it is not obvious. The same file reaches the guard spelled three different ways:

* `1:/x.cue` is what `SCSITBService::GetCurrentCDPath()` always reports.
* `1://x.cue` is what `RealPath()` produces, because it formats `"%s/%s"` onto `m_CurrentPath`, and that is `"1:/"` for the whole session whenever the worker auto enters the images partition on connect, which it does for every client that does not CWD somewhere first.
* `1:x.cue` is what `FTPPathToFatFsPath()` produces, because it consumes the separator after the volume when converting an absolute FTP path and never restores it.

FatFs resolves all three to the same file, since a drive relative path is taken against that volume's current directory, which is its root. So every spelling works for `f_open`, `f_unlink` and `f_rename`, and only a string comparison can tell them apart. A guard that compares them naively is silently inert for the most ordinary case there is, and appears to work the moment the client happens to CWD first. I know because mine was, twice.

Paths are now normalised before comparing, case insensitively because FAT is.

That comparison lives in its own header rather than in the worker because ftpworker.cpp cannot be compiled into the host suite, it needs the socket stack, and a guard nothing can test is a guard that quietly stops working. `test_ftppaths.cpp` asserts every spelling the worker actually produces, and the negative cases too: a prefix, a deeper path, or a same named file on `0:` must not match, because a guard that over refuses is its own bug.

Hardware tested: delete, rename and upload over the mounted image are all refused over FTP, and the same operations on any other image still work.

Host suite 151/151.
