### PR TITLE
Mount reliability, logging, FTP and MDS fixes

### DIFF
--- a/addon/cdromservice/cdromservice.cpp
+++ b/addon/cdromservice/cdromservice.cpp
@@ -56,7 +56,21 @@ void CDROMService::SetDevice(IImageDevice *pDevice)
         LOGNOTE("Device has subchannel data");
     }
 
-    // We defer initialization of the CD Gadget until the first CD image is loaded
+    // We defer initialization of the CD Gadget until the first CD image is loaded.
+    //
+    // LOAD-BEARING, not just an optimization. This is the only path that brings
+    // the USB gadget up, so with no image there are no endpoints at all - and
+    // the QEMU boot test depends on exactly that, because QEMU cannot emulate
+    // dwc2 device mode. It keeps the images partition empty so this moment
+    // never arrives, and validate_boot_log.py lists the symptoms of the
+    // hardware path running - "does not support USB gadget mode", "dwgadget:
+    // Unknown vendor", "Failed to initialize CD Gadget" - as FORBIDDEN_ANYWHERE.
+    // See tests/qemu-boot/README.md.
+    //
+    // So: do not move initialization earlier, and do not make it unconditional.
+    // Note that ejected=1 does NOT avoid it either - the boot path still
+    // pre-loads the remembered image, and ArmBootEject() only hides the medium
+    // from the host after the gadget is already up.
     if (!isInitialized)
     {
         bool ok = m_CDGadget->Initialize();

--- a/addon/cdromservice/cdromservice.cpp
+++ b/addon/cdromservice/cdromservice.cpp
@@ -57,20 +57,9 @@ void CDROMService::SetDevice(IImageDevice *pDevice)
     }
 
     // We defer initialization of the CD Gadget until the first CD image is loaded.
-    //
-    // LOAD-BEARING, not just an optimization. This is the only path that brings
-    // the USB gadget up, so with no image there are no endpoints at all - and
-    // the QEMU boot test depends on exactly that, because QEMU cannot emulate
-    // dwc2 device mode. It keeps the images partition empty so this moment
-    // never arrives, and validate_boot_log.py lists the symptoms of the
-    // hardware path running - "does not support USB gadget mode", "dwgadget:
-    // Unknown vendor", "Failed to initialize CD Gadget" - as FORBIDDEN_ANYWHERE.
+    // Do not move this earlier or make it unconditional: the QEMU boot test relies
+    // on no image meaning no gadget, since QEMU cannot emulate dwc2 device mode.
     // See tests/qemu-boot/README.md.
-    //
-    // So: do not move initialization earlier, and do not make it unconditional.
-    // Note that ejected=1 does NOT avoid it either - the boot path still
-    // pre-loads the remembered image, and ArmBootEject() only hides the medium
-    // from the host after the gadget is already up.
     if (!isInitialized)
     {
         bool ok = m_CDGadget->Initialize();

--- a/addon/cdromservice/cdromservice.h
+++ b/addon/cdromservice/cdromservice.h
@@ -46,6 +46,13 @@ public:
     // was last powered off. Must be armed before the first SetDevice().
     void ArmBootEject(void);
     void DisarmBootEject(void);
+
+    // Whether the USB gadget has been brought up yet. It is created lazily by
+    // the first SetDevice(), so "false" means the host currently sees no device
+    // at all - which callers deciding whether to adopt an image need to know,
+    // since an empty drive and an absent drive look nothing alike to a PC.
+    bool IsGadgetInitialized(void) const { return isInitialized; }
+
     void Run(void);
 
 private:

--- a/addon/cueparser/cueutil.cpp
+++ b/addon/cueparser/cueutil.cpp
@@ -28,6 +28,25 @@ bool CueFindTrackForLBA(const char *cue_sheet, uint32_t lba, CUETrackInfo *out) 
     return found;
 }
 
+bool CueHasMultipleFiles(const char *cue_sheet) {
+    if (cue_sheet == nullptr) {
+        return false;
+    }
+
+    CUEParser parser(cue_sheet);
+    const CUETrackInfo *trackInfo;
+
+    while ((trackInfo = parser.next_track()) != nullptr) {
+        // file_index counts FILE lines as the parser walks them, so any track
+        // reporting the second or later file means the sheet is split.
+        if (trackInfo->file_index > 1) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 uint64_t CueLBAToByteOffset(const char *cue_sheet, uint32_t lba) {
     CUETrackInfo track;
     if (!CueFindTrackForLBA(cue_sheet, lba, &track)) {

--- a/addon/cueparser/cueutil.h
+++ b/addon/cueparser/cueutil.h
@@ -26,16 +26,7 @@ bool CueFindTrackForLBA(const char *cue_sheet, uint32_t lba, CUETrackInfo *out);
 // start. Falls back to lba * 2352 if the cue sheet is null or has no tracks.
 uint64_t CueLBAToByteOffset(const char *cue_sheet, uint32_t lba);
 
-// True if the cue sheet references more than one data file - a "split track"
-// rip, where each track is its own .bin.
-//
-// USBODE cannot mount one. The loader opens the single file named after the
-// cue and never looks at the FILE lines, and the parser cannot place tracks
-// from a later file without knowing how long the earlier ones are. The result
-// is a disc whose TOC is wrong rather than a disc that fails to load, so this
-// exists to let the loader refuse the image outright.
-//
-// Uses the real parser rather than scanning for the word FILE, so quoting,
-// comments and REM lines are treated exactly as they will be when the sheet is
-// actually read.
+// True if the cue sheet references more than one data file (a "split track" rip).
+// USBODE cannot mount one: the loader only opens the file named after the cue, so
+// the disc comes up with a wrong TOC rather than failing, and callers refuse it.
 bool CueHasMultipleFiles(const char *cue_sheet);

--- a/addon/cueparser/cueutil.h
+++ b/addon/cueparser/cueutil.h
@@ -25,3 +25,17 @@ bool CueFindTrackForLBA(const char *cue_sheet, uint32_t lba, CUETrackInfo *out);
 // unstored PREGAP have no bytes in the file and clamp to the track's data
 // start. Falls back to lba * 2352 if the cue sheet is null or has no tracks.
 uint64_t CueLBAToByteOffset(const char *cue_sheet, uint32_t lba);
+
+// True if the cue sheet references more than one data file - a "split track"
+// rip, where each track is its own .bin.
+//
+// USBODE cannot mount one. The loader opens the single file named after the
+// cue and never looks at the FILE lines, and the parser cannot place tracks
+// from a later file without knowing how long the earlier ones are. The result
+// is a disc whose TOC is wrong rather than a disc that fails to load, so this
+// exists to let the loader refuse the image outright.
+//
+// Uses the real parser rather than scanning for the word FILE, so quoting,
+// comments and REM lines are treated exactly as they will be when the sheet is
+// actually read.
+bool CueHasMultipleFiles(const char *cue_sheet);

--- a/addon/discimage/mdsfile.cpp
+++ b/addon/discimage/mdsfile.cpp
@@ -295,18 +295,11 @@ bool CMDSFileDevice::Init() {
                 m_nTotalFrames);
     }
 
-    // Does the disc have frames the MDF does not store? Alcohol omits the
-    // pregap before a track by default, so a typical multi-track image has a
-    // 150-frame hole; a single-track one has none. Reads have to walk frame by
-    // frame when there is a hole, and that is expensive enough to be worth
-    // settling here rather than per read.
-    //
-    // Summing the track lengths answers it for every well-formed image:
-    // covered short of the total means a hole, equal means every frame is
-    // stored. A malformed table whose tracks overlap sums high and also lands
-    // on "walk it". The one case this misses is an overlap that exactly
-    // cancels a hole, which no imaging tool produces and which costs
-    // correctness only on an image that is already self-contradictory.
+    // Does the MDF omit any frames? Alcohol drops the pregap before a track by
+    // default, so most multi-track images have a 150-frame hole. Reads have to
+    // walk frame by frame when there is one, so settle it here instead.
+    // Track lengths summing short of the total means a hole; overlapping tracks
+    // sum high and also walk it, which is the safe answer for a malformed table.
     u32 covered = 0;
     for (int i = 0; i < m_parser->getNumSessions(); i++) {
         MDS_SessionBlock* session = m_parser->getSession(i);
@@ -375,10 +368,8 @@ int CMDSFileDevice::ReadAcrossGaps(void *pBuffer, size_t nSize) {
     size_t total_read = 0;
 
     while (total_read < nSize) {
-        // A transfer that is not a whole number of frames ends on a partial
-        // one. Serving it short instead would report fewer bytes than the
-        // caller asked for, which reads as an I/O error rather than as the
-        // hole it is.
+        // A short read would look like an I/O error rather than the hole it is,
+        // so a partial trailing frame is still served in full.
         const size_t remaining = nSize - total_read;
         const size_t chunk = remaining < 2352 ? remaining : 2352;
 
@@ -429,14 +420,9 @@ int CMDSFileDevice::Read(void *pBuffer, size_t nSize) {
     // A transfer that crosses a pregap the MDF does not store cannot be one
     // f_read, because part of it has no bytes behind it. That is rare enough
     // to be worth detecting rather than paying for frame-by-frame reads on
-    // every transfer, so the paths below are left as they were. On an image
-    // with no hole at all TouchesUnstoredGap() answers from a flag worked out
-    // at Init() and costs nothing.
-    //
-    // A transfer shorter than a frame still has to be checked: the frame it
-    // lands in can be a hole just as easily as a whole-frame read can, and
-    // gating this on nSize let such a read fall through to the raw path and
-    // return whatever the file pointer was resting on.
+    // every transfer, so the paths below are left as they were. A sub-frame
+    // transfer still has to be checked: gating this on nSize let it fall through
+    // to the raw path and return whatever the file pointer was resting on.
     const size_t framesTouched = (nSize + 2351) / 2352;
     if (framesTouched > 0 && TouchesUnstoredGap(m_nCurrentLBA, framesTouched)) {
         return ReadAcrossGaps(pBuffer, nSize);
@@ -500,10 +486,9 @@ int CMDSFileDevice::Read(void *pBuffer, size_t nSize) {
         return -1;
     }
 
-    // Move the reader on by what was consumed, the same way the two paths
-    // above do. Leaving it behind here was the other half of the stale-frame
-    // problem: a caller reading straight on without an intervening Seek had
-    // every frame after the first judged against the first one's address.
+    // Advance by what was consumed, as the two paths above do. Without this a
+    // caller reading on without an intervening Seek judges every later frame
+    // against the first one's address.
     m_nCurrentLBA += nBytesRead / 2352;
 
     return nBytesRead;
@@ -533,10 +518,8 @@ u64 CMDSFileDevice::Seek(u64 nOffset) {
     u32 lba = nOffset / 2352;  // Assuming 2352 bytes per sector
     u32 offset_in_sector = nOffset % 2352;
 
-    // Record the frame first, before any early exit can skip it. Read() takes
-    // both its gap detection and its subchannel stride from m_nCurrentLBA, so
-    // a Seek() that returns without setting it leaves the reader working on
-    // whichever frame it happened to be on last - and still reporting success.
+    // Record the frame before any early exit can skip it: Read() takes its gap
+    // detection and subchannel stride from m_nCurrentLBA.
     m_nCurrentLBA = lba;
 
     // Find which track contains this LBA
@@ -566,13 +549,9 @@ u64 CMDSFileDevice::Seek(u64 nOffset) {
     // LOGDBG("Seek: LBA %u (offset %llu) -> track %d, file offset %llu",
     //        lba, nOffset, track->point, actual_file_offset);
 
-    // Don't seek if we're already there. The comparison has to be against the
-    // FILE offset just computed, not against nOffset: nOffset is a disc
-    // address and Tell() is a file address, and the two are different numbers
-    // on any image with 2448-byte sectors or an unstored gap. They do still
-    // coincide - on a contiguous 2352-byte image at every frame, and on a
-    // 2448-byte one every 49th frame, since 49 * 2448 == 51 * 2352 - which is
-    // how comparing them used to skip a seek that was genuinely needed.
+    // Don't seek if we're already there. Compare against the FILE offset just
+    // computed, not nOffset, which is a disc address: the two coincide often
+    // enough (every 49th frame at 2448 bytes) to skip a seek that was needed.
     if (Tell() == actual_file_offset) {
         return nOffset;
     }
@@ -715,10 +694,8 @@ int CMDSFileDevice::ReadSubchannel(u32 lba, u8* subchannel) {
     MDS_TrackBlock* track = FindTrackForLBA(lba, &session, &trackIdx);
 
     if (!track) {
-        // Inside the disc but in a pregap the MDF does not store, which is the
-        // same situation Seek() and Read() answer with zeros. Failing here
-        // instead would make a subchannel request across a track boundary the
-        // one operation that still errors on a hole.
+        // In an unstored pregap, which Seek() and Read() answer with zeros.
+        // Failing here would make this the one operation that errors on a hole.
         if (lba < m_nTotalFrames) {
             memset(subchannel, 0, 96);
             return 96;

--- a/addon/discimage/mdsfile.cpp
+++ b/addon/discimage/mdsfile.cpp
@@ -295,6 +295,35 @@ bool CMDSFileDevice::Init() {
                 m_nTotalFrames);
     }
 
+    // Does the disc have frames the MDF does not store? Alcohol omits the
+    // pregap before a track by default, so a typical multi-track image has a
+    // 150-frame hole; a single-track one has none. Reads have to walk frame by
+    // frame when there is a hole, and that is expensive enough to be worth
+    // settling here rather than per read.
+    //
+    // Summing the track lengths answers it for every well-formed image:
+    // covered short of the total means a hole, equal means every frame is
+    // stored. A malformed table whose tracks overlap sums high and also lands
+    // on "walk it". The one case this misses is an overlap that exactly
+    // cancels a hole, which no imaging tool produces and which costs
+    // correctness only on an image that is already self-contradictory.
+    u32 covered = 0;
+    for (int i = 0; i < m_parser->getNumSessions(); i++) {
+        MDS_SessionBlock* session = m_parser->getSession(i);
+        for (int j = 0; j < session->num_all_blocks; j++) {
+            MDS_TrackBlock* track = m_parser->getTrack(i, j);
+            if (track->point == 0 || track->point >= 0xA0) {
+                continue;
+            }
+            MDS_TrackExtraBlock* extra = m_parser->getTrackExtra(i, j);
+            covered += extra ? extra->length : 0;
+        }
+    }
+    m_bHasUnstoredGaps = (covered != m_nTotalFrames);
+    if (m_bHasUnstoredGaps) {
+        LOGNOTE("=== MDF is sparse: %u of %u frames stored ===", covered, m_nTotalFrames);
+    }
+
     LOGNOTE("=== Image has subchannel data: %s ===",
             m_hasSubchannels ? "YES (SafeDisc compatible)" : "NO");
     LOGNOTE("=== Disc length: %u frames ===", m_nTotalFrames);
@@ -325,7 +354,7 @@ CMDSFileDevice::~CMDSFileDevice(void) {
 }
 
 bool CMDSFileDevice::TouchesUnstoredGap(u32 firstLBA, size_t nSectors) const {
-    if (!m_parser) {
+    if (!m_parser || !m_bHasUnstoredGaps) {
         return false;
     }
     for (size_t i = 0; i < nSectors; i++) {
@@ -343,17 +372,23 @@ bool CMDSFileDevice::TouchesUnstoredGap(u32 firstLBA, size_t nSectors) const {
 
 int CMDSFileDevice::ReadAcrossGaps(void *pBuffer, size_t nSize) {
     u8* dest = (u8*)pBuffer;
-    const size_t sectors = nSize / 2352;
     size_t total_read = 0;
 
-    for (size_t i = 0; i < sectors; i++) {
+    while (total_read < nSize) {
+        // A transfer that is not a whole number of frames ends on a partial
+        // one. Serving it short instead would report fewer bytes than the
+        // caller asked for, which reads as an I/O error rather than as the
+        // hole it is.
+        const size_t remaining = nSize - total_read;
+        const size_t chunk = remaining < 2352 ? remaining : 2352;
+
         int session, trackIdx;
         MDS_TrackBlock* track = FindTrackForLBA(m_nCurrentLBA, &session, &trackIdx);
 
         if (!track) {
             // Unstored pregap. Zeros are what the pregap of a data track holds
             // anyway, and they keep the transfer whole instead of failing it.
-            memset(dest, 0, 2352);
+            memset(dest, 0, chunk);
         } else {
             // Seek per frame rather than trusting the file pointer: a gap
             // consumed no file position, so it is stale after one.
@@ -365,17 +400,21 @@ int CMDSFileDevice::ReadAcrossGaps(void *pBuffer, size_t nSize) {
                 return total_read > 0 ? (int)total_read : -1;
             }
             UINT bytes_read = 0;
-            FRESULT result = f_read(m_pFile, dest, 2352, &bytes_read);
-            if (result != FR_OK || bytes_read != 2352) {
+            FRESULT result = f_read(m_pFile, dest, chunk, &bytes_read);
+            if (result != FR_OK || bytes_read != chunk) {
                 LOGERR("Gap-aware read: LBA %u returned %u bytes (err %d)",
                        m_nCurrentLBA, bytes_read, result);
                 return total_read > 0 ? (int)total_read : -1;
             }
         }
 
-        dest += 2352;
-        total_read += 2352;
-        m_nCurrentLBA++;
+        dest += chunk;
+        total_read += chunk;
+        // Only a whole frame moves the reader on to the next one; a partial
+        // tail leaves the position inside the frame it stopped in.
+        if (chunk == 2352) {
+            m_nCurrentLBA++;
+        }
     }
 
     return (int)total_read;
@@ -390,8 +429,16 @@ int CMDSFileDevice::Read(void *pBuffer, size_t nSize) {
     // A transfer that crosses a pregap the MDF does not store cannot be one
     // f_read, because part of it has no bytes behind it. That is rare enough
     // to be worth detecting rather than paying for frame-by-frame reads on
-    // every transfer, so the paths below are left as they were.
-    if (nSize >= 2352 && TouchesUnstoredGap(m_nCurrentLBA, nSize / 2352)) {
+    // every transfer, so the paths below are left as they were. On an image
+    // with no hole at all TouchesUnstoredGap() answers from a flag worked out
+    // at Init() and costs nothing.
+    //
+    // A transfer shorter than a frame still has to be checked: the frame it
+    // lands in can be a hole just as easily as a whole-frame read can, and
+    // gating this on nSize let such a read fall through to the raw path and
+    // return whatever the file pointer was resting on.
+    const size_t framesTouched = (nSize + 2351) / 2352;
+    if (framesTouched > 0 && TouchesUnstoredGap(m_nCurrentLBA, framesTouched)) {
         return ReadAcrossGaps(pBuffer, nSize);
     }
 
@@ -452,6 +499,13 @@ int CMDSFileDevice::Read(void *pBuffer, size_t nSize) {
         LOGERR("Failed to read %d bytes into memory, err %d", nSize, result);
         return -1;
     }
+
+    // Move the reader on by what was consumed, the same way the two paths
+    // above do. Leaving it behind here was the other half of the stale-frame
+    // problem: a caller reading straight on without an intervening Seek had
+    // every frame after the first judged against the first one's address.
+    m_nCurrentLBA += nBytesRead / 2352;
+
     return nBytesRead;
 }
 
@@ -475,18 +529,20 @@ u64 CMDSFileDevice::Seek(u64 nOffset) {
         return static_cast<u64>(-1);
     }
 
-    // Don't seek if we're already there
-    if (Tell() == nOffset)
-        return nOffset;
-
     // Calculate which LBA is being requested
     u32 lba = nOffset / 2352;  // Assuming 2352 bytes per sector
     u32 offset_in_sector = nOffset % 2352;
-    
+
+    // Record the frame first, before any early exit can skip it. Read() takes
+    // both its gap detection and its subchannel stride from m_nCurrentLBA, so
+    // a Seek() that returns without setting it leaves the reader working on
+    // whichever frame it happened to be on last - and still reporting success.
+    m_nCurrentLBA = lba;
+
     // Find which track contains this LBA
     int session, trackIdx;
     MDS_TrackBlock* track = FindTrackForLBA(lba, &session, &trackIdx);
-    
+
     if (!track) {
         // An LBA inside the disc but outside every track is a pregap the
         // imaging tool chose not to store - Alcohol omits them by default, so
@@ -495,7 +551,6 @@ u64 CMDSFileDevice::Seek(u64 nOffset) {
         // track lands here legitimately, and a real drive answers rather than
         // failing. There is no file position to take up; Read() serves zeros.
         if (lba < m_nTotalFrames) {
-            m_nCurrentLBA = lba;
             return nOffset;
         }
         LOGERR("Seek: LBA %u not found in any track", lba);
@@ -504,22 +559,29 @@ u64 CMDSFileDevice::Seek(u64 nOffset) {
 
     // Calculate offset into MDF file
     u32 sectors_from_track_start = lba - track->start_sector;
-    u64 actual_file_offset = track->start_offset + 
-                             (sectors_from_track_start * track->sector_size) + 
+    u64 actual_file_offset = track->start_offset +
+                             ((u64)sectors_from_track_start * track->sector_size) +
                              offset_in_sector;
-    
-    // LOGDBG("Seek: LBA %u (offset %llu) -> track %d, file offset %llu", 
+
+    // LOGDBG("Seek: LBA %u (offset %llu) -> track %d, file offset %llu",
     //        lba, nOffset, track->point, actual_file_offset);
-    
+
+    // Don't seek if we're already there. The comparison has to be against the
+    // FILE offset just computed, not against nOffset: nOffset is a disc
+    // address and Tell() is a file address, and the two are different numbers
+    // on any image with 2448-byte sectors or an unstored gap. They do still
+    // coincide - on a contiguous 2352-byte image at every frame, and on a
+    // 2448-byte one every 49th frame, since 49 * 2448 == 51 * 2352 - which is
+    // how comparing them used to skip a seek that was genuinely needed.
+    if (Tell() == actual_file_offset) {
+        return nOffset;
+    }
+
     FRESULT result = f_lseek(m_pFile, actual_file_offset);
     if (result != FR_OK) {
         LOGERR("Seek to file offset %llu failed, err %d", actual_file_offset, result);
         return static_cast<u64>(-1);
     }
-
-    // Remember which frame this was: Read() cannot recover it from the file
-    // position once subchannel data makes the physical stride 2448 bytes.
-    m_nCurrentLBA = lba;
 
     // Return the logical offset that was requested (not the physical file offset)
     return nOffset;
@@ -651,20 +713,28 @@ int CMDSFileDevice::ReadSubchannel(u32 lba, u8* subchannel) {
     
     int session, trackIdx;
     MDS_TrackBlock* track = FindTrackForLBA(lba, &session, &trackIdx);
-    
+
     if (!track) {
+        // Inside the disc but in a pregap the MDF does not store, which is the
+        // same situation Seek() and Read() answer with zeros. Failing here
+        // instead would make a subchannel request across a track boundary the
+        // one operation that still errors on a hole.
+        if (lba < m_nTotalFrames) {
+            memset(subchannel, 0, 96);
+            return 96;
+        }
         LOGERR("LBA %u not found in any track", lba);
         return -1;
     }
-    
+
     // Check if this track has subchannel data
     if (track->subchannel == 0) {
         return -1;
     }
-    
+
     // Calculate offset into the MDF file
     u32 sectors_from_track_start = lba - track->start_sector;
-    u64 sector_offset = track->start_offset + (sectors_from_track_start * track->sector_size);
+    u64 sector_offset = track->start_offset + ((u64)sectors_from_track_start * track->sector_size);
     
     // Subchannel data is stored in the last 96 bytes of each raw sector
     // Raw sector format: 2352 bytes user data + 96 bytes subchannel

--- a/addon/discimage/mdsfile.h
+++ b/addon/discimage/mdsfile.h
@@ -82,10 +82,20 @@ class CMDSFileDevice : public IMDSDevice {
     /// bytes, so its length divided by 2352 over-reports the disc.
     u32 m_nTotalFrames = 0;
 
-    /// The LBA Seek() last resolved. Read() needs it because Tell() reports
-    /// a PHYSICAL offset in the MDF, which on a 2448-byte-per-sector track
-    /// is not lba * 2352.
+    /// The LBA Seek() last resolved, advanced by Read() as it consumes frames.
+    /// This is the reader's position, and it cannot be recovered from the file
+    /// pointer: Tell() reports a PHYSICAL offset in the MDF, which is not
+    /// lba * 2352 on a 2448-byte-per-sector track and not even monotonic in
+    /// the LBA once an unstored pregap moves the disc address without moving
+    /// the file. Everything that has to know which frame is being served -
+    /// gap detection, the subchannel stride - reads it from here.
     u32 m_nCurrentLBA = 0;
+
+    /// True if the disc has at least one frame the MDF does not store. Worked
+    /// out once, because the alternative is a per-frame track lookup on every
+    /// read: TouchesUnstoredGap() is O(frames x tracks), and the overwhelming
+    /// majority of images have no hole at all.
+    bool m_bHasUnstoredGaps = false;
 
     // Helper to find track containing an LBA
     MDS_TrackBlock* FindTrackForLBA(u32 lba, int* sessionOut, int* trackOut) const;

--- a/addon/discimage/mdsfile.h
+++ b/addon/discimage/mdsfile.h
@@ -82,19 +82,14 @@ class CMDSFileDevice : public IMDSDevice {
     /// bytes, so its length divided by 2352 over-reports the disc.
     u32 m_nTotalFrames = 0;
 
-    /// The LBA Seek() last resolved, advanced by Read() as it consumes frames.
-    /// This is the reader's position, and it cannot be recovered from the file
-    /// pointer: Tell() reports a PHYSICAL offset in the MDF, which is not
-    /// lba * 2352 on a 2448-byte-per-sector track and not even monotonic in
-    /// the LBA once an unstored pregap moves the disc address without moving
-    /// the file. Everything that has to know which frame is being served -
-    /// gap detection, the subchannel stride - reads it from here.
+    /// The reader's position: set by Seek(), advanced by Read(). Cannot be
+    /// recovered from the file pointer, since Tell() reports a PHYSICAL offset
+    /// in the MDF that is neither lba * 2352 on a 2448-byte-per-sector track
+    /// nor monotonic in the LBA across an unstored pregap.
     u32 m_nCurrentLBA = 0;
 
-    /// True if the disc has at least one frame the MDF does not store. Worked
-    /// out once, because the alternative is a per-frame track lookup on every
-    /// read: TouchesUnstoredGap() is O(frames x tracks), and the overwhelming
-    /// majority of images have no hole at all.
+    /// True if the MDF omits at least one frame. Cached because the alternative
+    /// is an O(frames x tracks) lookup per read, and most images have no hole.
     bool m_bHasUnstoredGaps = false;
 
     // Helper to find track containing an LBA

--- a/addon/discimage/util.cpp
+++ b/addon/discimage/util.cpp
@@ -26,8 +26,29 @@
 #include "chdfile.h"
 
 #include <cueparser/cueutil.h>
+#include <stdarg.h>
 
 LOGMODULE("discimage-util");
+
+// Reason the last load failed. Every loader here reports failure the same way
+// - by returning nullptr - so without somewhere to put the reason it only ever
+// reached the log.
+static char s_LastImageLoadError[192] = {0};
+
+const char* GetLastImageLoadError() {
+    return s_LastImageLoadError;
+}
+
+static void ClearImageLoadError() {
+    s_LastImageLoadError[0] = '\0';
+}
+
+static void SetImageLoadError(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    vsnprintf(s_LastImageLoadError, sizeof(s_LastImageLoadError), format, args);
+    va_end(args);
+}
 
 char tolower(char c) {
     if (c >= 'A' && c <= 'Z')
@@ -202,6 +223,7 @@ IImageDevice* loadMDSFileDevice(const char* imagePath) {
     size_t mds_size = 0;
     if (!ReadFileToString(fullPath, &mds_str, &mds_size)) {
         LOGERR("Failed to read MDS file: %s", fullPath);
+        SetImageLoadError("Could not read the .mds file. It may be unreadable or too large.");
         return nullptr;
     }
 
@@ -209,6 +231,7 @@ IImageDevice* loadMDSFileDevice(const char* imagePath) {
     CMDSFileDevice* mdsDevice = new CMDSFileDevice(fullPath, mds_str, mds_size, mediaType);
     if (!mdsDevice->Init()) {
         LOGERR("Failed to initialize MDS device: %s", imagePath);
+        SetImageLoadError("Not a valid Alcohol 120%% image, or its .mdf data file is missing.");
         delete mdsDevice;
         return nullptr;
     }
@@ -248,6 +271,7 @@ IImageDevice* loadCueBinIsoFileDevice(const char* imagePath) {
         LOGNOTE("Loading CUE sheet from: %s", fullPath);
         if (!ReadFileToString(fullPath, &cue_str)) {
             LOGERR("Failed to read CUE file: %s", fullPath);
+            SetImageLoadError("Could not read the cue sheet for this image.");
             delete imageFile;
             return nullptr;
         }
@@ -264,6 +288,9 @@ IImageDevice* loadCueBinIsoFileDevice(const char* imagePath) {
                    "file (a split-track rip). USBODE needs a single .bin; "
                    "re-rip the disc as one image or merge the tracks.",
                    fullPath);
+            SetImageLoadError("This is a split-track rip: the cue sheet points at one .bin "
+                              "per track. USBODE needs a single .bin, so re-rip the disc as "
+                              "one image or merge the tracks.");
             delete imageFile;
             delete[] cue_str;
             return nullptr;
@@ -278,6 +305,7 @@ IImageDevice* loadCueBinIsoFileDevice(const char* imagePath) {
     FRESULT result = f_open(imageFile, fullPath, FA_READ);
     if (result != FR_OK) {
         LOGERR("Cannot open data file for reading: %s (error %d)", fullPath, result);
+        SetImageLoadError("The data file this image needs is missing: %s", fullPath);
         delete imageFile;
         if (cue_str) delete[] cue_str;
         return nullptr;
@@ -311,6 +339,7 @@ IImageDevice* loadCHDFileDevice(const char* imagePath) {
     CCHDFileDevice* chdDevice = new CCHDFileDevice(fullPath, mediaType);
     if (!chdDevice->Init()) {
         LOGERR("Failed to initialize CHD device: %s", imagePath);
+        SetImageLoadError("Not a valid CHD image, or it uses an unsupported compression.");
         delete chdDevice;
         return nullptr;
     }
@@ -396,6 +425,8 @@ IImageDevice* loadImageDevice(const char* imagePath) {
     // imagePath is a full path like "1:/Games/game.iso"
     LOGNOTE("loadImageDevice called for: %s", imagePath);
 
+    ClearImageLoadError();
+
     if (hasMdsExtension(imagePath)) {
         LOGNOTE("Detected MDS format - using MDS plugin");
         return loadMDSFileDevice(imagePath);
@@ -410,6 +441,7 @@ IImageDevice* loadImageDevice(const char* imagePath) {
     }
     else {
         LOGERR("Unknown file format: %s", imagePath);
+        SetImageLoadError("Unsupported file type. USBODE mounts .iso, .cue/.bin, .chd, .mds and .toast images.");
         return nullptr;
     }
 }

--- a/addon/discimage/util.cpp
+++ b/addon/discimage/util.cpp
@@ -25,6 +25,8 @@
 #include "mdsfile.h"
 #include "chdfile.h"
 
+#include <cueparser/cueutil.h>
+
 LOGMODULE("discimage-util");
 
 char tolower(char c) {
@@ -250,6 +252,22 @@ IImageDevice* loadCueBinIsoFileDevice(const char* imagePath) {
             return nullptr;
         }
         LOGNOTE("Loaded CUE sheet");
+
+        // A split-track rip names one .bin per track. Nothing below can honour
+        // that: the data file is chosen by rewriting the cue's own extension,
+        // so only the first file would ever be opened, and the parser cannot
+        // place the later tracks without knowing how long the earlier files
+        // are. The disc would mount with a TOC that is simply wrong, which is
+        // worse than not mounting - so refuse it and say why.
+        if (CueHasMultipleFiles(cue_str)) {
+            LOGERR("Cannot mount %s: the cue sheet references more than one data "
+                   "file (a split-track rip). USBODE needs a single .bin; "
+                   "re-rip the disc as one image or merge the tracks.",
+                   fullPath);
+            delete imageFile;
+            delete[] cue_str;
+            return nullptr;
+        }
 
         // Switch to BIN file for data
         change_extension_to_bin(fullPath);

--- a/addon/discimage/util.h
+++ b/addon/discimage/util.h
@@ -24,14 +24,8 @@ bool hasDvdHint(const char* imageName);
 // Image loading - returns base IImageDevice interface
 IImageDevice* loadImageDevice(const char* imageName);
 
-/// Why the last loadImageDevice() call returned nullptr, in words a user can
-/// act on, or "" if the last one succeeded.
-///
-/// The loaders only ever returned nullptr, so the reason existed solely in the
-/// log - which meant a mount that failed for a specific, fixable reason (a
-/// split-track cue, a missing .bin) was reported to the user, if at all, as a
-/// generic failure. Written by the loaders, read by SCSITBService when it
-/// records why a mount did not happen.
+// Why the last loadImageDevice() failed, in words a user can act on, or "" if it
+// succeeded. Written by the loaders, read by SCSITBService when a mount is refused.
 const char* GetLastImageLoadError();
 
 // Format-specific loaders

--- a/addon/discimage/util.h
+++ b/addon/discimage/util.h
@@ -24,6 +24,16 @@ bool hasDvdHint(const char* imageName);
 // Image loading - returns base IImageDevice interface
 IImageDevice* loadImageDevice(const char* imageName);
 
+/// Why the last loadImageDevice() call returned nullptr, in words a user can
+/// act on, or "" if the last one succeeded.
+///
+/// The loaders only ever returned nullptr, so the reason existed solely in the
+/// log - which meant a mount that failed for a specific, fixable reason (a
+/// split-track cue, a missing .bin) was reported to the user, if at all, as a
+/// generic failure. Written by the loaders, read by SCSITBService when it
+/// records why a mount did not happen.
+const char* GetLastImageLoadError();
+
 // Format-specific loaders
 IImageDevice* loadMDSFileDevice(const char* imageName);
 IImageDevice* loadCueBinIsoFileDevice(const char* imageName);

--- a/addon/displayservice/sh1106/imagespage.cpp
+++ b/addon/displayservice/sh1106/imagespage.cpp
@@ -28,6 +28,10 @@ void SH1106ImagesPage::OnEnter() {
     ConfigService* config = ConfigService::Get();
     bool flatFileList = config ? config->GetFlatFileList() : false;
 
+    // A mount request does not survive leaving and re-entering the page.
+    m_MountPending = false;
+    m_MountFailed = false;
+
     const char* currentPath = m_Service->GetCurrentCDPath();
     m_CurrentPath[0] = '\0';
 
@@ -125,10 +129,23 @@ void SH1106ImagesPage::OnButtonPress(Button button) {
                     NavigateToFolder(relativePath);
                 } else {
                     const char* relativePath = m_Service->GetRelativePath(cacheIdx);
-                    m_Service->SetNextCDByName(relativePath);
-                    m_MountedIndex = m_SelectedIndex;
-                    m_NextPageName = "homepage";
-                    m_ShouldChangePage = true;
+                    // Queue the mount; do NOT wait for it here. This runs in
+                    // the GPIO interrupt handler, and waiting means sleeping on
+                    // the scheduler, which from IRQ context freezes the Pi hard
+                    // enough to need a power cycle - on every mount, whatever
+                    // the image. ResolvePendingMount() collects the outcome
+                    // from Refresh(), which is task context.
+                    m_MountRequestSeq = m_Service->GetMountSeq();
+                    if (m_Service->SetNextCDByName(relativePath)) {
+                        m_MountRequestIndex = m_SelectedIndex;
+                        m_MountPending = true;
+                        m_MountWaitTicks = 0;
+                        m_MountFailed = false;
+                    } else {
+                        m_MountPending = false;
+                        m_MountFailed = true;
+                    }
+                    dirty = true;
                 }
             }
             break;
@@ -389,7 +406,47 @@ void SH1106ImagesPage::RefreshScroll() {
     }
 }
 
+// Refresh() ticks every 50ms (displayservice.cpp), so this is roughly ten
+// seconds - comfortably longer than a slow card needs, and longer than the
+// service's own mount timeout.
+static const unsigned MountWaitTickLimit = 200;
+
+// Collect the result of a mount the button handler queued. Runs in task
+// context, because OnButtonPress cannot: it is a GPIO interrupt handler on this
+// display, where sleeping would lock the machine up.
+void SH1106ImagesPage::ResolvePendingMount() {
+    if (!m_MountPending || !m_Service)
+        return;
+
+    if (m_Service->GetMountSeq() == m_MountRequestSeq) {
+        // Still queued. Give up eventually rather than sitting pending forever
+        // if the request never reaches the service task at all.
+        if (++m_MountWaitTicks > MountWaitTickLimit) {
+            m_MountPending = false;
+            m_MountFailed = true;
+            dirty = true;
+        }
+        return;
+    }
+
+    m_MountPending = false;
+    dirty = true;
+
+    if (m_Service->GetLastMountError()[0] == '\0') {
+        m_MountFailed = false;
+        m_MountedIndex = m_MountRequestIndex;
+        m_NextPageName = "homepage";
+        m_ShouldChangePage = true;
+    } else {
+        // Stay on the image list. Jumping to the homepage showed the PREVIOUS
+        // image as current with nothing said about the failure.
+        m_MountFailed = true;
+    }
+}
+
 void SH1106ImagesPage::Refresh() {
+    ResolvePendingMount();
+
     if (dirty) {
         Draw();
         return;
@@ -407,7 +464,9 @@ void SH1106ImagesPage::Draw() {
 
     m_Graphics->ClearScreen(COLOR2D(0, 0, 0));
     m_Graphics->DrawRect(0, 0, m_Display->GetWidth(), 10, COLOR2D(255, 255, 255));
-    m_Graphics->DrawText(2, 1, COLOR2D(0, 0, 0), "Images", C2DGraphics::AlignLeft, Font8x8);
+    m_Graphics->DrawText(2, 1, COLOR2D(0, 0, 0),
+                         m_MountFailed ? "Mount FAILED" : "Images",
+                         C2DGraphics::AlignLeft, Font8x8);
 
     if (m_SelectedIndex != m_PreviousSelectedIndex) {
         m_ScrollOffsetPx = 0;

--- a/addon/displayservice/sh1106/imagespage.cpp
+++ b/addon/displayservice/sh1106/imagespage.cpp
@@ -129,12 +129,9 @@ void SH1106ImagesPage::OnButtonPress(Button button) {
                     NavigateToFolder(relativePath);
                 } else {
                     const char* relativePath = m_Service->GetRelativePath(cacheIdx);
-                    // Queue the mount; do NOT wait for it here. This runs in
-                    // the GPIO interrupt handler, and waiting means sleeping on
-                    // the scheduler, which from IRQ context freezes the Pi hard
-                    // enough to need a power cycle - on every mount, whatever
-                    // the image. ResolvePendingMount() collects the outcome
-                    // from Refresh(), which is task context.
+                    // Queue only; do NOT wait. This runs in the GPIO interrupt
+                    // handler, where sleeping on the scheduler hard-locks the Pi.
+                    // ResolvePendingMount() collects the outcome in task context.
                     m_MountRequestSeq = m_Service->GetMountSeq();
                     if (m_Service->SetNextCDByName(relativePath)) {
                         m_MountRequestIndex = m_SelectedIndex;
@@ -411,9 +408,8 @@ void SH1106ImagesPage::RefreshScroll() {
 // service's own mount timeout.
 static const unsigned MountWaitTickLimit = 200;
 
-// Collect the result of a mount the button handler queued. Runs in task
-// context, because OnButtonPress cannot: it is a GPIO interrupt handler on this
-// display, where sleeping would lock the machine up.
+// Collect the result of a mount the button handler queued. Task context, which
+// OnButtonPress is not.
 void SH1106ImagesPage::ResolvePendingMount() {
     if (!m_MountPending || !m_Service)
         return;

--- a/addon/displayservice/sh1106/imagespage.h
+++ b/addon/displayservice/sh1106/imagespage.h
@@ -25,6 +25,7 @@ class SH1106ImagesPage : public IPage {
 
    private:
     void Draw();
+    void ResolvePendingMount();
     void MoveSelection(int delta);
     void NavigateToFolder(const char* path);
     void NavigateUp();
@@ -48,6 +49,22 @@ class SH1106ImagesPage : public IPage {
     CSH1106Display* m_Display;
     C2DGraphics* m_Graphics;
     SCSITBService* m_Service = nullptr;
+    // Set when a mount attempt fails, and shown in place of the page title.
+    // The HAT used to fall silently back to the previously mounted image, so a
+    // disc that refused to load looked exactly like one the user had changed
+    // their mind about. Short by necessity - the full reason is in the web UI
+    // and the log.
+    bool m_MountFailed = false;
+
+    // A mount requested from the button handler and not yet resolved.
+    // OnButtonPress runs in the GPIO interrupt on this display, so it can only
+    // queue the request - m_MountRequestSeq is the service's retired-request
+    // counter as it stood when we asked, and Refresh() watches for it to move.
+    bool m_MountPending = false;
+    unsigned m_MountRequestSeq = 0;
+    size_t m_MountRequestIndex = 0;
+    unsigned m_MountWaitTicks = 0;
+
     size_t m_SelectedIndex = 0;
     size_t m_MountedIndex = 0;
     int charWidth;

--- a/addon/displayservice/sh1106/imagespage.h
+++ b/addon/displayservice/sh1106/imagespage.h
@@ -49,17 +49,13 @@ class SH1106ImagesPage : public IPage {
     CSH1106Display* m_Display;
     C2DGraphics* m_Graphics;
     SCSITBService* m_Service = nullptr;
-    // Set when a mount attempt fails, and shown in place of the page title.
-    // The HAT used to fall silently back to the previously mounted image, so a
-    // disc that refused to load looked exactly like one the user had changed
-    // their mind about. Short by necessity - the full reason is in the web UI
-    // and the log.
+    // Shown in place of the page title when a mount fails. Short by necessity;
+    // the full reason is in the web UI and the log.
     bool m_MountFailed = false;
 
-    // A mount requested from the button handler and not yet resolved.
-    // OnButtonPress runs in the GPIO interrupt on this display, so it can only
-    // queue the request - m_MountRequestSeq is the service's retired-request
-    // counter as it stood when we asked, and Refresh() watches for it to move.
+    // A mount queued by the button handler and not yet resolved.
+    // m_MountRequestSeq is the service's retired-request counter as it stood
+    // when we asked; Refresh() watches for it to move.
     bool m_MountPending = false;
     unsigned m_MountRequestSeq = 0;
     size_t m_MountRequestIndex = 0;

--- a/addon/displayservice/ssd1306/imagespage.cpp
+++ b/addon/displayservice/ssd1306/imagespage.cpp
@@ -28,6 +28,10 @@ void SSD1306ImagesPage::OnEnter() {
     ConfigService* config = ConfigService::Get();
     bool flatFileList = config ? config->GetFlatFileList() : false;
 
+    // A mount request does not survive leaving and re-entering the page.
+    m_MountPending = false;
+    m_MountFailed = false;
+
     const char* currentPath = m_Service->GetCurrentCDPath();
     m_CurrentPath[0] = '\0';
 
@@ -125,10 +129,23 @@ void SSD1306ImagesPage::OnButtonPress(Button button) {
                     NavigateToFolder(relativePath);
                 } else {
                     const char* relativePath = m_Service->GetRelativePath(cacheIdx);
-                    m_Service->SetNextCDByName(relativePath);
-                    m_MountedIndex = m_SelectedIndex;
-                    m_NextPageName = "homepage";
-                    m_ShouldChangePage = true;
+                    // Queue the mount; do NOT wait for it here. This runs in
+                    // the GPIO interrupt handler, and waiting means sleeping on
+                    // the scheduler, which from IRQ context freezes the Pi hard
+                    // enough to need a power cycle - on every mount, whatever
+                    // the image. ResolvePendingMount() collects the outcome
+                    // from Refresh(), which is task context.
+                    m_MountRequestSeq = m_Service->GetMountSeq();
+                    if (m_Service->SetNextCDByName(relativePath)) {
+                        m_MountRequestIndex = m_SelectedIndex;
+                        m_MountPending = true;
+                        m_MountWaitTicks = 0;
+                        m_MountFailed = false;
+                    } else {
+                        m_MountPending = false;
+                        m_MountFailed = true;
+                    }
+                    dirty = true;
                 }
             }
             break;
@@ -389,7 +406,47 @@ void SSD1306ImagesPage::RefreshScroll() {
     }
 }
 
+// Refresh() ticks every 50ms (displayservice.cpp), so this is roughly ten
+// seconds - comfortably longer than a slow card needs, and longer than the
+// service's own mount timeout.
+static const unsigned MountWaitTickLimit = 200;
+
+// Collect the result of a mount the button handler queued. Runs in task
+// context, because OnButtonPress cannot: it is a GPIO interrupt handler on this
+// display, where sleeping would lock the machine up.
+void SSD1306ImagesPage::ResolvePendingMount() {
+    if (!m_MountPending || !m_Service)
+        return;
+
+    if (m_Service->GetMountSeq() == m_MountRequestSeq) {
+        // Still queued. Give up eventually rather than sitting pending forever
+        // if the request never reaches the service task at all.
+        if (++m_MountWaitTicks > MountWaitTickLimit) {
+            m_MountPending = false;
+            m_MountFailed = true;
+            dirty = true;
+        }
+        return;
+    }
+
+    m_MountPending = false;
+    dirty = true;
+
+    if (m_Service->GetLastMountError()[0] == '\0') {
+        m_MountFailed = false;
+        m_MountedIndex = m_MountRequestIndex;
+        m_NextPageName = "homepage";
+        m_ShouldChangePage = true;
+    } else {
+        // Stay on the image list. Jumping to the homepage showed the PREVIOUS
+        // image as current with nothing said about the failure.
+        m_MountFailed = true;
+    }
+}
+
 void SSD1306ImagesPage::Refresh() {
+    ResolvePendingMount();
+
     if (dirty) {
         Draw();
         return;
@@ -407,7 +464,9 @@ void SSD1306ImagesPage::Draw() {
 
     m_Graphics->ClearScreen(COLOR2D(0, 0, 0));
     m_Graphics->DrawRect(0, 0, m_Display->GetWidth(), 10, COLOR2D(255, 255, 255));
-    m_Graphics->DrawText(2, 1, COLOR2D(0, 0, 0), "Images", C2DGraphics::AlignLeft, Font8x8);
+    m_Graphics->DrawText(2, 1, COLOR2D(0, 0, 0),
+                         m_MountFailed ? "Mount FAILED" : "Images",
+                         C2DGraphics::AlignLeft, Font8x8);
 
     if (m_SelectedIndex != m_PreviousSelectedIndex) {
         m_ScrollOffsetPx = 0;

--- a/addon/displayservice/ssd1306/imagespage.cpp
+++ b/addon/displayservice/ssd1306/imagespage.cpp
@@ -129,12 +129,9 @@ void SSD1306ImagesPage::OnButtonPress(Button button) {
                     NavigateToFolder(relativePath);
                 } else {
                     const char* relativePath = m_Service->GetRelativePath(cacheIdx);
-                    // Queue the mount; do NOT wait for it here. This runs in
-                    // the GPIO interrupt handler, and waiting means sleeping on
-                    // the scheduler, which from IRQ context freezes the Pi hard
-                    // enough to need a power cycle - on every mount, whatever
-                    // the image. ResolvePendingMount() collects the outcome
-                    // from Refresh(), which is task context.
+                    // Queue only; do NOT wait. This runs in the GPIO interrupt
+                    // handler, where sleeping on the scheduler hard-locks the Pi.
+                    // ResolvePendingMount() collects the outcome in task context.
                     m_MountRequestSeq = m_Service->GetMountSeq();
                     if (m_Service->SetNextCDByName(relativePath)) {
                         m_MountRequestIndex = m_SelectedIndex;
@@ -411,9 +408,8 @@ void SSD1306ImagesPage::RefreshScroll() {
 // service's own mount timeout.
 static const unsigned MountWaitTickLimit = 200;
 
-// Collect the result of a mount the button handler queued. Runs in task
-// context, because OnButtonPress cannot: it is a GPIO interrupt handler on this
-// display, where sleeping would lock the machine up.
+// Collect the result of a mount the button handler queued. Task context, which
+// OnButtonPress is not.
 void SSD1306ImagesPage::ResolvePendingMount() {
     if (!m_MountPending || !m_Service)
         return;

--- a/addon/displayservice/ssd1306/imagespage.h
+++ b/addon/displayservice/ssd1306/imagespage.h
@@ -25,6 +25,7 @@ class SSD1306ImagesPage : public IPage {
 
    private:
     void Draw();
+    void ResolvePendingMount();
     void MoveSelection(int delta);
     void NavigateToFolder(const char* path);
     void NavigateUp();
@@ -48,6 +49,22 @@ class SSD1306ImagesPage : public IPage {
     CSSD1306GfxDisplay* m_Display;
     C2DGraphics* m_Graphics;
     SCSITBService* m_Service = nullptr;
+    // Set when a mount attempt fails, and shown in place of the page title.
+    // The HAT used to fall silently back to the previously mounted image, so a
+    // disc that refused to load looked exactly like one the user had changed
+    // their mind about. Short by necessity - the full reason is in the web UI
+    // and the log.
+    bool m_MountFailed = false;
+
+    // A mount requested from the button handler and not yet resolved.
+    // OnButtonPress runs in the GPIO interrupt on this display, so it can only
+    // queue the request - m_MountRequestSeq is the service's retired-request
+    // counter as it stood when we asked, and Refresh() watches for it to move.
+    bool m_MountPending = false;
+    unsigned m_MountRequestSeq = 0;
+    size_t m_MountRequestIndex = 0;
+    unsigned m_MountWaitTicks = 0;
+
     size_t m_SelectedIndex = 0;
     size_t m_MountedIndex = 0;
     int charWidth;

--- a/addon/displayservice/ssd1306/imagespage.h
+++ b/addon/displayservice/ssd1306/imagespage.h
@@ -49,17 +49,13 @@ class SSD1306ImagesPage : public IPage {
     CSSD1306GfxDisplay* m_Display;
     C2DGraphics* m_Graphics;
     SCSITBService* m_Service = nullptr;
-    // Set when a mount attempt fails, and shown in place of the page title.
-    // The HAT used to fall silently back to the previously mounted image, so a
-    // disc that refused to load looked exactly like one the user had changed
-    // their mind about. Short by necessity - the full reason is in the web UI
-    // and the log.
+    // Shown in place of the page title when a mount fails. Short by necessity;
+    // the full reason is in the web UI and the log.
     bool m_MountFailed = false;
 
-    // A mount requested from the button handler and not yet resolved.
-    // OnButtonPress runs in the GPIO interrupt on this display, so it can only
-    // queue the request - m_MountRequestSeq is the service's retired-request
-    // counter as it stood when we asked, and Refresh() watches for it to move.
+    // A mount queued by the button handler and not yet resolved.
+    // m_MountRequestSeq is the service's retired-request counter as it stood
+    // when we asked; Refresh() watches for it to move.
     bool m_MountPending = false;
     unsigned m_MountRequestSeq = 0;
     size_t m_MountRequestIndex = 0;

--- a/addon/displayservice/st7789/imagespage.cpp
+++ b/addon/displayservice/st7789/imagespage.cpp
@@ -129,12 +129,9 @@ void ST7789ImagesPage::OnButtonPress(Button button) {
                     NavigateToFolder(relativePath);
                 } else {
                     const char* relativePath = m_Service->GetRelativePath(cacheIdx);
-                    // Queue the mount; do NOT wait for it here. This runs in
-                    // the GPIO interrupt handler, and waiting means sleeping on
-                    // the scheduler, which from IRQ context freezes the Pi hard
-                    // enough to need a power cycle - on every mount, whatever
-                    // the image. ResolvePendingMount() collects the outcome
-                    // from Refresh(), which is task context.
+                    // Queue only; do NOT wait. This runs in the GPIO interrupt
+                    // handler, where sleeping on the scheduler hard-locks the Pi.
+                    // ResolvePendingMount() collects the outcome in task context.
                     m_MountRequestSeq = m_Service->GetMountSeq();
                     if (m_Service->SetNextCDByName(relativePath)) {
                         m_MountRequestIndex = m_SelectedIndex;
@@ -410,9 +407,8 @@ void ST7789ImagesPage::RefreshScroll() {
 // service's own mount timeout.
 static const unsigned MountWaitTickLimit = 200;
 
-// Collect the result of a mount the button handler queued. Runs in task
-// context, because OnButtonPress cannot: it is a GPIO interrupt handler on this
-// display, where sleeping would lock the machine up.
+// Collect the result of a mount the button handler queued. Task context, which
+// OnButtonPress is not.
 void ST7789ImagesPage::ResolvePendingMount() {
     if (!m_MountPending || !m_Service)
         return;

--- a/addon/displayservice/st7789/imagespage.cpp
+++ b/addon/displayservice/st7789/imagespage.cpp
@@ -28,6 +28,10 @@ void ST7789ImagesPage::OnEnter() {
     ConfigService* config = ConfigService::Get();
     bool flatFileList = config ? config->GetFlatFileList() : false;
 
+    // A mount request does not survive leaving and re-entering the page.
+    m_MountPending = false;
+    m_MountFailed = false;
+
     const char* currentPath = m_Service->GetCurrentCDPath();
     m_CurrentPath[0] = '\0';
 
@@ -125,10 +129,23 @@ void ST7789ImagesPage::OnButtonPress(Button button) {
                     NavigateToFolder(relativePath);
                 } else {
                     const char* relativePath = m_Service->GetRelativePath(cacheIdx);
-                    m_Service->SetNextCDByName(relativePath);
-                    m_MountedIndex = m_SelectedIndex;
-                    m_NextPageName = "homepage";
-                    m_ShouldChangePage = true;
+                    // Queue the mount; do NOT wait for it here. This runs in
+                    // the GPIO interrupt handler, and waiting means sleeping on
+                    // the scheduler, which from IRQ context freezes the Pi hard
+                    // enough to need a power cycle - on every mount, whatever
+                    // the image. ResolvePendingMount() collects the outcome
+                    // from Refresh(), which is task context.
+                    m_MountRequestSeq = m_Service->GetMountSeq();
+                    if (m_Service->SetNextCDByName(relativePath)) {
+                        m_MountRequestIndex = m_SelectedIndex;
+                        m_MountPending = true;
+                        m_MountWaitTicks = 0;
+                        m_MountFailed = false;
+                    } else {
+                        m_MountPending = false;
+                        m_MountFailed = true;
+                    }
+                    dirty = true;
                 }
             }
             break;
@@ -388,7 +405,47 @@ void ST7789ImagesPage::RefreshScroll() {
     }
 }
 
+// Refresh() ticks every 50ms (displayservice.cpp), so this is roughly ten
+// seconds - comfortably longer than a slow card needs, and longer than the
+// service's own mount timeout.
+static const unsigned MountWaitTickLimit = 200;
+
+// Collect the result of a mount the button handler queued. Runs in task
+// context, because OnButtonPress cannot: it is a GPIO interrupt handler on this
+// display, where sleeping would lock the machine up.
+void ST7789ImagesPage::ResolvePendingMount() {
+    if (!m_MountPending || !m_Service)
+        return;
+
+    if (m_Service->GetMountSeq() == m_MountRequestSeq) {
+        // Still queued. Give up eventually rather than sitting pending forever
+        // if the request never reaches the service task at all.
+        if (++m_MountWaitTicks > MountWaitTickLimit) {
+            m_MountPending = false;
+            m_MountFailed = true;
+            dirty = true;
+        }
+        return;
+    }
+
+    m_MountPending = false;
+    dirty = true;
+
+    if (m_Service->GetLastMountError()[0] == '\0') {
+        m_MountFailed = false;
+        m_MountedIndex = m_MountRequestIndex;
+        m_NextPageName = "homepage";
+        m_ShouldChangePage = true;
+    } else {
+        // Stay on the image list. Jumping to the homepage showed the PREVIOUS
+        // image as current with nothing said about the failure.
+        m_MountFailed = true;
+    }
+}
+
 void ST7789ImagesPage::Refresh() {
+    ResolvePendingMount();
+
     if (dirty) {
         Draw();
         return;
@@ -406,7 +463,7 @@ void ST7789ImagesPage::Draw() {
 
     m_Graphics->ClearScreen(COLOR2D(255, 255, 255));
 
-    const char* pTitle = "CD Images";
+    const char* pTitle = m_MountFailed ? "Mount FAILED - see web UI" : "CD Images";
 
     // Draw header bar with blue background
     m_Graphics->DrawRect(0, 0, m_Display->GetWidth(), 30, COLOR2D(58, 124, 165));

--- a/addon/displayservice/st7789/imagespage.h
+++ b/addon/displayservice/st7789/imagespage.h
@@ -25,6 +25,7 @@ class ST7789ImagesPage : public IPage {
 
    private:
     void Draw();
+    void ResolvePendingMount();
     void MoveSelection(int delta);
     void NavigateToFolder(const char* path);
     void NavigateUp();
@@ -49,6 +50,22 @@ class ST7789ImagesPage : public IPage {
     SCSITBService* m_Service = nullptr;
     CST7789Display* m_Display;
     C2DGraphics* m_Graphics;
+    // Set when a mount attempt fails, and shown in place of the page title.
+    // The HAT used to fall silently back to the previously mounted image, so a
+    // disc that refused to load looked exactly like one the user had changed
+    // their mind about. Short by necessity - the full reason is in the web UI
+    // and the log.
+    bool m_MountFailed = false;
+
+    // A mount requested from the button handler and not yet resolved.
+    // OnButtonPress runs in the GPIO interrupt on this display, so it can only
+    // queue the request - m_MountRequestSeq is the service's retired-request
+    // counter as it stood when we asked, and Refresh() watches for it to move.
+    bool m_MountPending = false;
+    unsigned m_MountRequestSeq = 0;
+    size_t m_MountRequestIndex = 0;
+    unsigned m_MountWaitTicks = 0;
+
     size_t m_SelectedIndex = 0;
     size_t m_MountedIndex = 0;
     int charWidth;

--- a/addon/displayservice/st7789/imagespage.h
+++ b/addon/displayservice/st7789/imagespage.h
@@ -50,17 +50,13 @@ class ST7789ImagesPage : public IPage {
     SCSITBService* m_Service = nullptr;
     CST7789Display* m_Display;
     C2DGraphics* m_Graphics;
-    // Set when a mount attempt fails, and shown in place of the page title.
-    // The HAT used to fall silently back to the previously mounted image, so a
-    // disc that refused to load looked exactly like one the user had changed
-    // their mind about. Short by necessity - the full reason is in the web UI
-    // and the log.
+    // Shown in place of the page title when a mount fails. Short by necessity;
+    // the full reason is in the web UI and the log.
     bool m_MountFailed = false;
 
-    // A mount requested from the button handler and not yet resolved.
-    // OnButtonPress runs in the GPIO interrupt on this display, so it can only
-    // queue the request - m_MountRequestSeq is the service's retired-request
-    // counter as it stood when we asked, and Refresh() watches for it to move.
+    // A mount queued by the button handler and not yet resolved.
+    // m_MountRequestSeq is the service's retired-request counter as it stood
+    // when we asked; Refresh() watches for it to move.
     bool m_MountPending = false;
     unsigned m_MountRequestSeq = 0;
     size_t m_MountRequestIndex = 0;

--- a/addon/filelogdaemon/filelogdaemon.cpp
+++ b/addon/filelogdaemon/filelogdaemon.cpp
@@ -67,10 +67,8 @@ boolean CFileLogDaemon::Initialize() {
     FRESULT Result = f_open(&m_LogFile, m_LogFilePath, FA_WRITE | FA_OPEN_ALWAYS);
     m_OpenResult = Result;
     if (Result != FR_OK) {
-        // Name the path and the reason. This message is the only evidence the
-        // user gets, and "Failed to open log file" left them with a system
-        // that had quietly stopped logging and no way to tell why. Note that
-        // only volume 0: is mounted this early, so a path on 1: lands here.
+        // Name the path and the reason: this message is the only evidence the
+        // user gets. Only volume 0: is mounted this early, so a path on 1: lands here.
         LOGERR("Failed to open log file '%s' (FatFs error %d); file logging is off",
                m_LogFilePath, (int)Result);
         return FALSE;
@@ -169,11 +167,9 @@ void CFileLogDaemon::DrainOnce(void) {
             continue;
         }
 
-        // Only back off for a failure that might not repeat. When the file was
-        // never opened every message fails, and sleeping for each one throttled
-        // the log queue to 50 events a second - which, since the queue is
-        // drained on a scheduler task, dragged the whole system down with it.
-        // A mistyped log path used to present as a Pi that had gone slow.
+        // Only back off for a failure that might not repeat. With no file open
+        // every message fails, and sleeping for each throttled the queue to 50
+        // events a second, which presented as a Pi that had gone slow.
         if (LogMessage(Severity, Time, nHundredthTime, nTimeZone, Source, Message) ==
             LogResult::WriteFailed) {
             CScheduler::Get()->Sleep(20);
@@ -222,9 +218,8 @@ CFileLogDaemon::LogResult CFileLogDaemon::LogMessage(TLogSeverity Severity,
     UINT BytesWritten;
     FRESULT Result = f_write(&m_LogFile, LogEntry, strlen(LogEntry), &BytesWritten);
     if (Result != FR_OK) {
-        // Deliberately not logged: this runs while draining the log queue, and
-        // a message here would queue another event, which would fail the same
-        // way. The caller backs off instead.
+        // Not logged: this runs while draining the log queue, so a message here
+        // would queue another event that fails the same way.
         return LogResult::WriteFailed;
     }
 

--- a/addon/filelogdaemon/filelogdaemon.cpp
+++ b/addon/filelogdaemon/filelogdaemon.cpp
@@ -96,6 +96,37 @@ boolean CFileLogDaemon::Initialize() {
     return TRUE;
 }
 
+void CFileLogDaemon::GetStatusText(char *pBuffer, size_t nBufferSize) const {
+    if (pBuffer == nullptr || nBufferSize == 0) {
+        return;
+    }
+
+    if (m_LogFilePath[0] == '\0') {
+        snprintf(pBuffer, nBufferSize, "File logging is off (no log file configured).");
+    } else if (m_bFileInitialized) {
+        snprintf(pBuffer, nBufferSize, "Writing to %s", m_LogFilePath);
+    } else {
+        snprintf(pBuffer, nBufferSize,
+                 "NOT LOGGING: cannot open %s (FatFs error %d). "
+                 "The file must be on the boot partition and its directory must already exist.",
+                 m_LogFilePath, (int)m_OpenResult);
+    }
+}
+
+void CFileLogDaemon::GetStdioPath(char *pBuffer, size_t nBufferSize) const {
+    if (pBuffer == nullptr || nBufferSize == 0) {
+        return;
+    }
+
+    // Config stores the FatFs form ("0:/usbode-log.txt"); newlib wants an
+    // ordinary path ("/usbode-log.txt").
+    const char *p = m_LogFilePath;
+    if (p[0] == '0' && p[1] == ':') {
+        p += 2;
+    }
+    snprintf(pBuffer, nBufferSize, "%s", p);
+}
+
 CFileLogDaemon::~CFileLogDaemon(void) {
     s_pThis = nullptr;
 

--- a/addon/filelogdaemon/filelogdaemon.cpp
+++ b/addon/filelogdaemon/filelogdaemon.cpp
@@ -33,8 +33,11 @@ LOGMODULE("filelogdaemon");
 CFileLogDaemon *CFileLogDaemon::s_pThis = nullptr;
 
 CFileLogDaemon::CFileLogDaemon(const char *pLogFilePath, unsigned uiLogLevel)
-    : m_pLogFilePath(pLogFilePath),
-      m_uiLogLevel(uiLogLevel > 5 ? 5 : uiLogLevel) {
+    : m_uiLogLevel(uiLogLevel > 5 ? 5 : uiLogLevel) {
+    if (pLogFilePath != nullptr) {
+        strncpy(m_LogFilePath, pLogFilePath, sizeof(m_LogFilePath) - 1);
+        m_LogFilePath[sizeof(m_LogFilePath) - 1] = '\0';
+    }
     // I am the one and only!
     assert(s_pThis == nullptr);
     s_pThis = this;
@@ -52,10 +55,24 @@ void CFileLogDaemon::SetLogLevel(unsigned uiLogLevel) {
 }
 
 boolean CFileLogDaemon::Initialize() {
+    if (m_LogFilePath[0] == '\0') {
+        // An empty path is how the config says "no file logging". Not an
+        // error, and not worth an alarming message at boot.
+        m_OpenResult = FR_INVALID_NAME;
+        LOGNOTE("No log file configured; file logging is off");
+        return FALSE;
+    }
+
     // Open log file for writing (append mode)
-    FRESULT Result = f_open(&m_LogFile, m_pLogFilePath, FA_WRITE | FA_OPEN_ALWAYS);
+    FRESULT Result = f_open(&m_LogFile, m_LogFilePath, FA_WRITE | FA_OPEN_ALWAYS);
+    m_OpenResult = Result;
     if (Result != FR_OK) {
-        LOGERR("Failed to open log file");
+        // Name the path and the reason. This message is the only evidence the
+        // user gets, and "Failed to open log file" left them with a system
+        // that had quietly stopped logging and no way to tell why. Note that
+        // only volume 0: is mounted this early, so a path on 1: lands here.
+        LOGERR("Failed to open log file '%s' (FatFs error %d); file logging is off",
+               m_LogFilePath, (int)Result);
         return FALSE;
     }
 
@@ -96,36 +113,49 @@ void CFileLogDaemon::Run(void) {
 
     while (true) {
         m_Event.Clear();
-
-        TLogSeverity Severity;
-        char Source[LOG_MAX_SOURCE];
-        char Message[LOG_MAX_MESSAGE];
-        time_t Time;
-        unsigned nHundredthTime;
-        int nTimeZone;
-        while (pLogger->ReadEvent(&Severity, Source, Message,
-                                  &Time, &nHundredthTime, &nTimeZone)) {
-            // CLogger queues every event regardless of its loglevel (that
-            // only filters the serial/screen target), so the configured
-            // level is applied here. Severity LogPanic(0)..LogDebug(4)
-            // maps to config levels 1..5; level 0 drops everything.
-            if ((unsigned)Severity >= m_uiLogLevel) {
-                continue;
-            }
-            if (!LogMessage(Severity, Time, nHundredthTime, nTimeZone, Source, Message)) {
-                CScheduler::Get()->Sleep(20);
-            }
-        }
-
+        DrainOnce();
         m_Event.Wait();
     }
 }
 
-boolean CFileLogDaemon::LogMessage(TLogSeverity Severity,
-                                   time_t FullTime, unsigned nPartialTime, int nTimeNumOffset,
-                                   const char *pAppName, const char *pMsg) {
+void CFileLogDaemon::DrainOnce(void) {
+    CLogger *pLogger = CLogger::Get();
+    assert(pLogger != nullptr);
+
+    TLogSeverity Severity;
+    char Source[LOG_MAX_SOURCE];
+    char Message[LOG_MAX_MESSAGE];
+    time_t Time;
+    unsigned nHundredthTime;
+    int nTimeZone;
+    while (pLogger->ReadEvent(&Severity, Source, Message,
+                              &Time, &nHundredthTime, &nTimeZone)) {
+        // CLogger queues every event regardless of its loglevel (that
+        // only filters the serial/screen target), so the configured
+        // level is applied here. Severity LogPanic(0)..LogDebug(4)
+        // maps to config levels 1..5; level 0 drops everything.
+        if ((unsigned)Severity >= m_uiLogLevel) {
+            continue;
+        }
+
+        // Only back off for a failure that might not repeat. When the file was
+        // never opened every message fails, and sleeping for each one throttled
+        // the log queue to 50 events a second - which, since the queue is
+        // drained on a scheduler task, dragged the whole system down with it.
+        // A mistyped log path used to present as a Pi that had gone slow.
+        if (LogMessage(Severity, Time, nHundredthTime, nTimeZone, Source, Message) ==
+            LogResult::WriteFailed) {
+            CScheduler::Get()->Sleep(20);
+        }
+    }
+}
+
+CFileLogDaemon::LogResult CFileLogDaemon::LogMessage(TLogSeverity Severity,
+                                                     time_t FullTime, unsigned nPartialTime,
+                                                     int nTimeNumOffset,
+                                                     const char *pAppName, const char *pMsg) {
     if (!m_bFileInitialized) {
-        return FALSE;
+        return LogResult::NoFile;
     }
 
     // Format the log entry similar to base logger but tailored for file
@@ -161,14 +191,15 @@ boolean CFileLogDaemon::LogMessage(TLogSeverity Severity,
     UINT BytesWritten;
     FRESULT Result = f_write(&m_LogFile, LogEntry, strlen(LogEntry), &BytesWritten);
     if (Result != FR_OK) {
-        // TODO implement proper error handling here!!!
-        LOGERR("Failed to write to log file!");
-        return FALSE;
+        // Deliberately not logged: this runs while draining the log queue, and
+        // a message here would queue another event, which would fail the same
+        // way. The caller backs off instead.
+        return LogResult::WriteFailed;
     }
 
     f_sync(&m_LogFile);
 
-    return TRUE;
+    return LogResult::Written;
 }
 
 void CFileLogDaemon::EventNotificationHandler(void) {

--- a/addon/filelogdaemon/filelogdaemon.h
+++ b/addon/filelogdaemon/filelogdaemon.h
@@ -42,6 +42,23 @@ class CFileLogDaemon : public CTask {
     boolean Initialize();
     void Run(void);
 
+    /// One pass of Run()'s loop: drain whatever the logger has queued. Split
+    /// out because Run() never returns, and the drain is the part with the
+    /// interesting behaviour when the log file could not be opened.
+    void DrainOnce(void);
+
+    /// Whether the log file is actually open. The constructor cannot report a
+    /// failure, so the caller has to be able to ask afterwards - otherwise a
+    /// mistyped path silently produces a system with no file logging at all.
+    boolean IsFileLogging(void) const { return m_bFileInitialized; }
+
+    /// The path this daemon was asked for, for a caller that wants to name it
+    /// in a diagnostic.
+    const char *GetLogFilePath(void) const { return m_LogFilePath; }
+
+    /// The FatFs result from the attempt to open it. FR_OK once open.
+    FRESULT GetOpenResult(void) const { return m_OpenResult; }
+
     // Takes effect immediately; only affects the log file, not the
     // loglevel= filtering Circle applies to the serial/screen target.
     void SetLogLevel(unsigned uiLogLevel);
@@ -49,9 +66,20 @@ class CFileLogDaemon : public CTask {
     static CFileLogDaemon *Get(void);
 
    private:
-    boolean LogMessage(TLogSeverity Severity,
-                       time_t FullTime, unsigned nPartialTime, int nTimeNumOffset,
-                       const char *pAppName, const char *pMsg);
+    /// Why a message did not reach the file. The distinction matters: a write
+    /// that failed may well succeed next time and is worth backing off for,
+    /// but a file that was never opened will never take a message, and backing
+    /// off for each of those costs the whole system (see Run()).
+    enum class LogResult
+    {
+        Written,
+        WriteFailed,  // transient: the file is open, this write did not land
+        NoFile        // permanent for this boot: there is nothing to write to
+    };
+
+    LogResult LogMessage(TLogSeverity Severity,
+                         time_t FullTime, unsigned nPartialTime, int nTimeNumOffset,
+                         const char *pAppName, const char *pMsg);
 
     static void EventNotificationHandler(void);
     static void PanicHandler(void);
@@ -59,8 +87,13 @@ class CFileLogDaemon : public CTask {
    private:
     CSynchronizationEvent m_Event;
     static CFileLogDaemon *s_pThis;
-    boolean m_bFileInitialized;
-    const char *m_pLogFilePath;
+    /// Must start FALSE. An indeterminate value here let LogMessage() write to
+    /// an unopened FIL and the destructor close it, whenever the open failed.
+    boolean m_bFileInitialized = FALSE;
+    /// Copied, not aliased. The caller's string comes out of the config store,
+    /// which is free to replace it while this daemon is still running.
+    char m_LogFilePath[256] = {0};
+    FRESULT m_OpenResult = FR_NOT_READY;
     unsigned m_uiLogLevel;
     FIL m_LogFile;
 };

--- a/addon/filelogdaemon/filelogdaemon.h
+++ b/addon/filelogdaemon/filelogdaemon.h
@@ -59,6 +59,19 @@ class CFileLogDaemon : public CTask {
     /// The FatFs result from the attempt to open it. FR_OK once open.
     FRESULT GetOpenResult(void) const { return m_OpenResult; }
 
+    /// One line describing whether file logging is actually working, for the
+    /// web UI to show.
+    ///
+    /// Without this the only report of a failed open is a warning on the
+    /// serial console, and SCREEN_HEADLESS builds have nowhere else to put it
+    /// - so the user sees a device with no log file and no reason given, which
+    /// is the situation this whole fix exists to end.
+    void GetStatusText(char *pBuffer, size_t nBufferSize) const;
+
+    /// The configured path as an ordinary filesystem path (no "0:" volume
+    /// prefix), for callers that open it through newlib rather than FatFs.
+    void GetStdioPath(char *pBuffer, size_t nBufferSize) const;
+
     // Takes effect immediately; only affects the log file, not the
     // loglevel= filtering Circle applies to the serial/screen target.
     void SetLogLevel(unsigned uiLogLevel);

--- a/addon/filelogdaemon/filelogdaemon.h
+++ b/addon/filelogdaemon/filelogdaemon.h
@@ -42,34 +42,20 @@ class CFileLogDaemon : public CTask {
     boolean Initialize();
     void Run(void);
 
-    /// One pass of Run()'s loop: drain whatever the logger has queued. Split
-    /// out because Run() never returns, and the drain is the part with the
-    /// interesting behaviour when the log file could not be opened.
+    // One pass of Run()'s loop, split out so it can be tested; Run() never returns.
     void DrainOnce(void);
 
-    /// Whether the log file is actually open. The constructor cannot report a
-    /// failure, so the caller has to be able to ask afterwards - otherwise a
-    /// mistyped path silently produces a system with no file logging at all.
+    // The constructor cannot report a failed open, so callers ask afterwards.
     boolean IsFileLogging(void) const { return m_bFileInitialized; }
-
-    /// The path this daemon was asked for, for a caller that wants to name it
-    /// in a diagnostic.
     const char *GetLogFilePath(void) const { return m_LogFilePath; }
-
-    /// The FatFs result from the attempt to open it. FR_OK once open.
     FRESULT GetOpenResult(void) const { return m_OpenResult; }
 
-    /// One line describing whether file logging is actually working, for the
-    /// web UI to show.
-    ///
-    /// Without this the only report of a failed open is a warning on the
-    /// serial console, and SCREEN_HEADLESS builds have nowhere else to put it
-    /// - so the user sees a device with no log file and no reason given, which
-    /// is the situation this whole fix exists to end.
+    // One line for the web UI. SCREEN_HEADLESS builds have nowhere else to
+    // report a failed open.
     void GetStatusText(char *pBuffer, size_t nBufferSize) const;
 
-    /// The configured path as an ordinary filesystem path (no "0:" volume
-    /// prefix), for callers that open it through newlib rather than FatFs.
+    // The configured path without the volume prefix, for callers that open it
+    // through newlib rather than FatFs.
     void GetStdioPath(char *pBuffer, size_t nBufferSize) const;
 
     // Takes effect immediately; only affects the log file, not the
@@ -79,10 +65,8 @@ class CFileLogDaemon : public CTask {
     static CFileLogDaemon *Get(void);
 
    private:
-    /// Why a message did not reach the file. The distinction matters: a write
-    /// that failed may well succeed next time and is worth backing off for,
-    /// but a file that was never opened will never take a message, and backing
-    /// off for each of those costs the whole system (see Run()).
+    // A failed write is worth backing off for; a file that was never opened is
+    // not, and backing off for each of those costs the whole system (see Run()).
     enum class LogResult
     {
         Written,
@@ -100,11 +84,10 @@ class CFileLogDaemon : public CTask {
    private:
     CSynchronizationEvent m_Event;
     static CFileLogDaemon *s_pThis;
-    /// Must start FALSE. An indeterminate value here let LogMessage() write to
-    /// an unopened FIL and the destructor close it, whenever the open failed.
+    // Must start FALSE: uninitialized, a failed open still let LogMessage()
+    // write to an unopened FIL and the destructor close it.
     boolean m_bFileInitialized = FALSE;
-    /// Copied, not aliased. The caller's string comes out of the config store,
-    /// which is free to replace it while this daemon is still running.
+    // Copied, not aliased: the config store may replace the caller's string.
     char m_LogFilePath[256] = {0};
     FRESULT m_OpenResult = FR_NOT_READY;
     unsigned m_uiLogLevel;

--- a/addon/ftpserver/fatfspath.h
+++ b/addon/ftpserver/fatfspath.h
@@ -1,0 +1,78 @@
+#ifndef _ftpserver_fatfspath_h
+#define _ftpserver_fatfspath_h
+
+#include <stddef.h>
+#include <string.h>
+
+//
+// Comparing two FatFs paths for "same file".
+//
+// This lives in its own header, separate from the FTP worker, because the
+// worker needs a socket stack and cannot be compiled into the host test suite -
+// and the guard that stops a client deleting, renaming or overwriting the
+// mounted image failed TWICE in a row purely on path spelling, with no test
+// able to see it:
+//
+//   "1://Alien.cue"  RealPath() formats "%s/%s" onto m_CurrentPath, which is
+//                    "1:/" for the whole session when the worker auto-enters
+//                    the images partition on connect.
+//   "1:Alien.cue"    FTPPathToFatFsPath() consumes the slash that follows the
+//                    volume when it turns an absolute FTP path into a FatFs
+//                    one, and never puts it back.
+//   "1:/Alien.cue"   what SCSITBService::GetCurrentCDPath() always reports.
+//
+// FatFs resolves all three to the same file - a drive-relative path is taken
+// against that volume's current directory, which is its root here - so every
+// spelling works for f_open/f_unlink/f_rename and only a string comparison can
+// tell them apart. That is exactly the comparison the guard is.
+//
+
+// Canonical form: separators collapsed, no trailing separator, and always a
+// separator directly after the volume colon.
+static inline void NormalizeFatFsPath(const char *pIn, char *pOut, size_t nOutSize)
+{
+    size_t nOut = 0;
+    bool bVolumeSeen = false;
+
+    // Two spare bytes: one for a separator this may insert after the volume,
+    // one for the terminator.
+    for (size_t i = 0; pIn[i] != '\0' && nOut + 2 < nOutSize; i++)
+    {
+        if (pIn[i] == '/' && nOut > 0 && pOut[nOut - 1] == '/')
+            continue; // collapse repeated separators
+
+        pOut[nOut++] = pIn[i];
+
+        if (pIn[i] == ':' && !bVolumeSeen)
+        {
+            bVolumeSeen = true;
+            if (pIn[i + 1] != '/' && pIn[i + 1] != '\0')
+                pOut[nOut++] = '/'; // "1:name" -> "1:/name"
+        }
+    }
+
+    while (nOut > 1 && pOut[nOut - 1] == '/')
+        nOut--;
+
+    pOut[nOut] = '\0';
+}
+
+// Whether two FatFs paths name the same file. Case-insensitive, because FAT is.
+static inline bool FatFsPathsEqual(const char *pA, const char *pB, size_t nMax)
+{
+    if (pA == nullptr || pB == nullptr)
+        return false;
+
+    // 520 covers MAX_PATH_LEN (512) plus the inserted separator and terminator.
+    char NormA[520];
+    char NormB[520];
+    if (nMax > sizeof(NormA))
+        nMax = sizeof(NormA);
+
+    NormalizeFatFsPath(pA, NormA, nMax);
+    NormalizeFatFsPath(pB, NormB, nMax);
+
+    return strcasecmp(NormA, NormB) == 0;
+}
+
+#endif

--- a/addon/ftpserver/fatfspath.h
+++ b/addon/ftpserver/fatfspath.h
@@ -5,26 +5,13 @@
 #include <string.h>
 
 //
-// Comparing two FatFs paths for "same file".
+// Comparing two FatFs paths for "same file". Separate from the FTP worker so the
+// host test suite can reach it without a socket stack.
 //
-// This lives in its own header, separate from the FTP worker, because the
-// worker needs a socket stack and cannot be compiled into the host test suite -
-// and the guard that stops a client deleting, renaming or overwriting the
-// mounted image failed TWICE in a row purely on path spelling, with no test
-// able to see it:
-//
-//   "1://Alien.cue"  RealPath() formats "%s/%s" onto m_CurrentPath, which is
-//                    "1:/" for the whole session when the worker auto-enters
-//                    the images partition on connect.
-//   "1:Alien.cue"    FTPPathToFatFsPath() consumes the slash that follows the
-//                    volume when it turns an absolute FTP path into a FatFs
-//                    one, and never puts it back.
-//   "1:/Alien.cue"   what SCSITBService::GetCurrentCDPath() always reports.
-//
-// FatFs resolves all three to the same file - a drive-relative path is taken
-// against that volume's current directory, which is its root here - so every
-// spelling works for f_open/f_unlink/f_rename and only a string comparison can
-// tell them apart. That is exactly the comparison the guard is.
+// The same file arrives spelled three ways - "1://Alien.cue" from RealPath(),
+// "1:Alien.cue" from FTPPathToFatFsPath(), "1:/Alien.cue" from
+// GetCurrentCDPath() - and FatFs opens all three, so only a string comparison
+// distinguishes them. That comparison is what the mounted-image guard is.
 //
 
 // Canonical form: separators collapsed, no trailing separator, and always a

--- a/addon/ftpserver/ftpworker.cpp
+++ b/addon/ftpserver/ftpworker.cpp
@@ -32,6 +32,7 @@
 #include <discimage/util.h>
 #include "ftpworker.h"
 #include "utility.h"
+#include "fatfspath.h"
 
 // Use a per-instance name for the log macros
 #define From m_LogName
@@ -395,6 +396,38 @@ CString CFTPWorker::RealPath(const char* pInBuffer) const {
     return Path;
 }
 
+// Deleting, renaming or overwriting the mounted image leaves the gadget reading
+// a file that no longer has the contents it opened - the host keeps issuing
+// READ(10) against storage that has been unlinked or truncated under it, which
+// is one reported way of hanging the device. The web UI has always refused this
+// (deleteapi.cpp:43); FTP did not, so the same card could be broken over FTP in
+// a way the browser would not allow.
+bool CFTPWorker::IsMountedImage(const char* pPath) const {
+    assert(pPath != nullptr);
+
+    SCSITBService* svc =
+        static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
+    if (svc == nullptr)
+        return false;
+
+    const char* current = svc->GetCurrentCDPath();
+    if (current == nullptr || current[0] == '\0')
+        return false;
+
+    // Not a plain strcmp: the same file reaches here spelled three different
+    // ways depending on how the client addressed it. See fatfspath.h.
+    return FatFsPathsEqual(pPath, current, MAX_PATH_LEN);
+}
+
+// The service is a task looked up by name; every caller here treated it as
+// guaranteed and dereferenced it blind.
+void CFTPWorker::RefreshImageCache() const {
+    SCSITBService* svc =
+        static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
+    if (svc != nullptr)
+        svc->RefreshCache();
+}
+
 const TDirectoryListEntry* CFTPWorker::BuildDirectoryList(size_t& nOutEntries) const {
     DIR Dir;
     FILINFO FileInfo;
@@ -708,6 +741,20 @@ bool CFTPWorker::Store(const char* pArgs) {
 
     FIL File;
     CString Path = RealPath(pArgs);
+
+    // FA_CREATE_ALWAYS truncates, so uploading over the mounted image empties
+    // the file the host is reading from - worse than deleting it, because the
+    // directory entry survives and nothing looks wrong until a read fails.
+    if (IsMountedImage(Path)) {
+        // Log BEFORE replying: SendStatus() formats into m_CommandBuffer, and
+        // pArgs points into that same buffer, so the reply overwrites the
+        // argument being logged.
+        LOGERR("Refused to overwrite the mounted image %s", pArgs);
+        SendStatus(TFTPStatus::FileActionNotTaken,
+                   "That image is mounted. Mount another one first.");
+        return false;
+    }
+
     if (f_open(&File, Path, FA_CREATE_ALWAYS | FA_WRITE) != FR_OK) {
         SendStatus(TFTPStatus::FileActionNotTaken, "Could not open file for writing.");
         return false;
@@ -816,9 +863,7 @@ bool CFTPWorker::Store(const char* pArgs) {
 
     f_close(&File);
 
-    SCSITBService* svc = static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
-    if (svc != nullptr)
-        svc->RefreshCache();
+    RefreshImageCache();
 
     return true;
 }
@@ -829,6 +874,14 @@ bool CFTPWorker::Delete(const char* pArgs) {
 
     CString Path = RealPath(pArgs);
 
+    if (IsMountedImage(Path)) {
+        // Before the reply - SendStatus() overwrites the buffer pArgs is in.
+        LOGERR("Refused to delete the mounted image %s", pArgs);
+        SendStatus(TFTPStatus::FileActionNotTaken,
+                   "That image is mounted. Mount another one first.");
+        return true;
+    }
+
     if (f_unlink(Path) != FR_OK) {
         SendStatus(TFTPStatus::FileActionNotTaken, "File was not deleted.");
 	LOGERR("Couldn't delete %s", pArgs);
@@ -836,8 +889,7 @@ bool CFTPWorker::Delete(const char* pArgs) {
     else
         SendStatus(TFTPStatus::FileActionOk, "File deleted.");
 
-    SCSITBService* svc = static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
-    svc->RefreshCache();
+    RefreshImageCache();
 
     return true;
 }
@@ -1092,6 +1144,20 @@ bool CFTPWorker::RenameTo(const char* pArgs) {
     CString SourcePath = RealPath(m_RenameFrom);
     CString DestPath = RealPath(pArgs);
 
+    // Renaming the mounted image moves it out from under the live mount just as
+    // surely as deleting it; renaming something else ONTO it destroys it.
+    if (IsMountedImage(SourcePath) || IsMountedImage(DestPath)) {
+        // Before the reply - SendStatus() overwrites the buffer pArgs is in.
+        // This one proved it: the log line read "... -> hat image is mounted.
+        // Mount another one first." - the reply itself, offset by five bytes.
+        LOGERR("Refused to rename the mounted image (%s -> %s)",
+               static_cast<const char*>(m_RenameFrom), pArgs);
+        SendStatus(TFTPStatus::FileNameNotAllowed,
+                   "That image is mounted. Mount another one first.");
+        m_RenameFrom = "";
+        return true;
+    }
+
     if (f_rename(SourcePath, DestPath) != FR_OK)
         SendStatus(TFTPStatus::FileNameNotAllowed, "File name not allowed.");
     else
@@ -1099,8 +1165,7 @@ bool CFTPWorker::RenameTo(const char* pArgs) {
 
     m_RenameFrom = "";
 
-    SCSITBService* svc = static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
-    svc->RefreshCache();
+    RefreshImageCache();
 
     return true;
 }

--- a/addon/ftpserver/ftpworker.cpp
+++ b/addon/ftpserver/ftpworker.cpp
@@ -396,12 +396,10 @@ CString CFTPWorker::RealPath(const char* pInBuffer) const {
     return Path;
 }
 
-// Deleting, renaming or overwriting the mounted image leaves the gadget reading
-// a file that no longer has the contents it opened - the host keeps issuing
-// READ(10) against storage that has been unlinked or truncated under it, which
-// is one reported way of hanging the device. The web UI has always refused this
-// (deleteapi.cpp:43); FTP did not, so the same card could be broken over FTP in
-// a way the browser would not allow.
+// Deleting, renaming or overwriting the mounted image leaves the gadget issuing
+// READ(10) against a file that has been unlinked or truncated under it, which is
+// one reported way of hanging the device. The web UI already refuses this
+// (deleteapi.cpp:43); FTP did not.
 bool CFTPWorker::IsMountedImage(const char* pPath) const {
     assert(pPath != nullptr);
 
@@ -419,8 +417,7 @@ bool CFTPWorker::IsMountedImage(const char* pPath) const {
     return FatFsPathsEqual(pPath, current, MAX_PATH_LEN);
 }
 
-// The service is a task looked up by name; every caller here treated it as
-// guaranteed and dereferenced it blind.
+// The service is looked up by name and callers dereferenced it blind.
 void CFTPWorker::RefreshImageCache() const {
     SCSITBService* svc =
         static_cast<SCSITBService*>(CScheduler::Get()->GetTask("scsitbservice"));
@@ -742,13 +739,10 @@ bool CFTPWorker::Store(const char* pArgs) {
     FIL File;
     CString Path = RealPath(pArgs);
 
-    // FA_CREATE_ALWAYS truncates, so uploading over the mounted image empties
-    // the file the host is reading from - worse than deleting it, because the
-    // directory entry survives and nothing looks wrong until a read fails.
+    // FA_CREATE_ALWAYS truncates, so uploading over the mounted image empties the
+    // file the host is reading from, with the directory entry still looking fine.
     if (IsMountedImage(Path)) {
-        // Log BEFORE replying: SendStatus() formats into m_CommandBuffer, and
-        // pArgs points into that same buffer, so the reply overwrites the
-        // argument being logged.
+        // Before the reply - SendStatus() overwrites the buffer pArgs is in.
         LOGERR("Refused to overwrite the mounted image %s", pArgs);
         SendStatus(TFTPStatus::FileActionNotTaken,
                    "That image is mounted. Mount another one first.");
@@ -1148,8 +1142,7 @@ bool CFTPWorker::RenameTo(const char* pArgs) {
     // surely as deleting it; renaming something else ONTO it destroys it.
     if (IsMountedImage(SourcePath) || IsMountedImage(DestPath)) {
         // Before the reply - SendStatus() overwrites the buffer pArgs is in.
-        // This one proved it: the log line read "... -> hat image is mounted.
-        // Mount another one first." - the reply itself, offset by five bytes.
+        // Before the reply - SendStatus() overwrites the buffer pArgs is in.
         LOGERR("Refused to rename the mounted image (%s -> %s)",
                static_cast<const char*>(m_RenameFrom), pArgs);
         SendStatus(TFTPStatus::FileNameNotAllowed,

--- a/addon/ftpserver/ftpworker.h
+++ b/addon/ftpserver/ftpworker.h
@@ -104,6 +104,11 @@ class CFTPWorker : protected CTask {
     CString RealPath(const char* pInBuffer) const;
     const TDirectoryListEntry* BuildDirectoryList(size_t& nOutEntries) const;
 
+    // True if the path names the image the host currently has mounted.
+    bool IsMountedImage(const char* pPath) const;
+    // Rescan the image catalogue, tolerating the service not being there.
+    void RefreshImageCache() const;
+
     // FTP command handlers
     bool System(const char* pArgs);
     bool Username(const char* pArgs);

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -339,9 +339,16 @@ void SCSITBService::ScanDirectoryRecursive(const char* fullPath, const char* rel
                 bool listIt = iequals(ext, ".iso") || iequals(ext, ".mds") ||
                               iequals(ext, ".chd") || iequals(ext, ".toast");
                 if (!listIt && iequals(ext, ".cue")) {
-                    // Mounting a .cue opens the same-stem .bin, so only list
-                    // cue sheets whose data file is actually there
-                    listIt = siblingWithExtExists(fullPath, fno.fname, ".bin");
+                    // List every cue sheet, including one with no same-stem
+                    // .bin next to it. Hiding those was meant to keep a cue
+                    // whose data file is missing out of the way, but it also
+                    // hid split-track rips - where the cue is "Game.cue" and
+                    // the data is "Game (Track 1).bin" - so the browser
+                    // offered the raw track files and the disc itself simply
+                    // vanished with no explanation. A cue that cannot be
+                    // mounted now says why when you try, which is more use
+                    // than not being there.
+                    listIt = true;
                 } else if (!listIt && iequals(ext, ".bin")) {
                     // Hide the raw .bin of a cue/bin pair; its .cue is listed
                     listIt = !siblingWithExtExists(fullPath, fno.fname, ".cue");
@@ -489,10 +496,19 @@ void SCSITBService::ProcessPendingMount() {
 
     if (imageDevice == nullptr) {
         LOGERR("Failed to load image: %s", m_CurrentImagePath);
-        snprintf(m_LastMountError, sizeof(m_LastMountError),
-                 "Could not load %s. It may be an unsupported or damaged image; "
-                 "the log has the details. The previous disc is still mounted.",
-                 relativePath);
+        // Prefer the loader's own reason. "Unsupported or damaged" is true of
+        // every failure and useful for none of them, so it is only the
+        // fallback for a path that has not been given words yet.
+        const char* why = GetLastImageLoadError();
+        if (why != nullptr && why[0] != '\0') {
+            snprintf(m_LastMountError, sizeof(m_LastMountError),
+                     "%s (%s) The previous disc is still mounted.", why, relativePath);
+        } else {
+            snprintf(m_LastMountError, sizeof(m_LastMountError),
+                     "Could not load %s. It may be an unsupported or damaged image; "
+                     "the log has the details. The previous disc is still mounted.",
+                     relativePath);
+        }
         next_cd = -1;
         return;
     }

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -377,8 +377,18 @@ bool SCSITBService::RefreshCache() {
     LOGNOTE("SCSITBService::RefreshCache() called");
     m_Lock.Acquire();
 
-    // Get current loaded image from config
-    const char* current_image = configservice->GetCurrentImage(DEFAULT_IMAGE_FILENAME);
+    // Get current loaded image from config.
+    //
+    // Asked with an empty default, this distinguishes "the user has an image
+    // remembered" from "this card has never mounted anything". They must not
+    // behave the same: a remembered image that has gone missing should leave
+    // the drive empty and say so, but a freshly written card has no remembered
+    // image at all and must still auto-mount, or first boot would look broken.
+    // GetCurrentImage(DEFAULT_IMAGE_FILENAME) cannot tell them apart, because
+    // it hands back "image.iso" in both cases.
+    const char* saved_image = configservice->GetCurrentImage("");
+    const bool hadRememberedImage = (saved_image != nullptr && saved_image[0] != '\0');
+    const char* current_image = hadRememberedImage ? saved_image : DEFAULT_IMAGE_FILENAME;
     LOGNOTE("SCSITBService::RefreshCache() loaded current_image %s from config.txt", current_image);
 
     // Store the current image path if not already set
@@ -466,11 +476,23 @@ bool SCSITBService::RefreshCache() {
         }
     }
 
-    // Fallback to first image file if not found. Never while ejected: an empty
+    // Fallback to first image file if not found. Not while ejected: an empty
     // drive must stay empty, and this path also runs on rescans (upload, delete,
     // FTP), where auto-mounting a substitute would undo the user's eject and
     // then persist "inserted" over the saved state.
-    if (!found && m_FileCount > 0 && !IsEjected()) {
+    //
+    // The exception is a gadget that has never been brought up. Adopting an
+    // image is the ONLY thing that initializes it (cdromservice.cpp:59), so
+    // refusing here would leave the host seeing no USB device at all rather
+    // than an empty drive - and adopting cannot undo the eject anyway, because
+    // the boot-eject arm below keeps the medium hidden. Reachable whenever a
+    // remembered image goes missing while the drive is ejected, including the
+    // second boot after this code has itself come up empty and persisted it.
+    //
+    // m_FileCount == 0 still adopts nothing, which is what the QEMU boot test
+    // relies on - see tests/qemu-boot/README.md.
+    if (!found && m_FileCount > 0 &&
+        (!IsEjected() || (cdromservice && !cdromservice->IsGadgetInitialized()))) {
         for (size_t i = 0; i < m_FileCount; ++i) {
             if (m_FileEntries[i].isDirectory) {
                 continue;
@@ -486,6 +508,30 @@ bool SCSITBService::RefreshCache() {
             LOGNOTE("SCSITBService::RefreshCache() Current image not found, using: %s",
                     m_FileEntries[i].relativePath);
             next_cd = i;
+
+            // A remembered image that is simply gone must not be swapped for a
+            // different disc in silence - that is how a renamed file turned
+            // into "some other game is in the drive" with nothing to explain
+            // it. Adopt this one so the gadget has a geometry and Insert is
+            // instant, but present the drive as EMPTY and record what went
+            // missing. A card that never had a remembered image (fresh write)
+            // keeps the plain auto-mount.
+            if (hadRememberedImage) {
+                strncpy(m_MissingSavedImage, current_image, sizeof(m_MissingSavedImage) - 1);
+                m_MissingSavedImage[sizeof(m_MissingSavedImage) - 1] = '\0';
+                m_bAdoptAsEmpty = true;
+                LOGWARN("Saved image %s is not on the card; coming up empty with %s adopted",
+                        current_image, m_FileEntries[i].relativePath);
+            }
+
+            // Adopting while ejected MUST stay ejected. SetDevice() clears the
+            // ejected latch unless the boot-eject is armed, so without this the
+            // adoption we just allowed above would insert a disc the user had
+            // deliberately ejected - the exact thing the !IsEjected() guard
+            // exists to prevent.
+            if (IsEjected()) {
+                m_bAdoptAsEmpty = true;
+            }
             break;
         }
     }
@@ -501,6 +547,11 @@ bool SCSITBService::RefreshCache() {
 void SCSITBService::ProcessPendingMount() {
     if (next_cd <= -1)
         return;
+
+    // Consume the flag up front: every exit path below retires the request, so
+    // leaving it set would eject the next image the user deliberately mounts.
+    const bool adoptAsEmpty = m_bAdoptAsEmpty;
+    m_bAdoptAsEmpty = false;
 
     if ((size_t)next_cd >= m_FileCount) {
         snprintf(m_LastMountError, sizeof(m_LastMountError),
@@ -561,6 +612,15 @@ void SCSITBService::ProcessPendingMount() {
             (int)imageDevice->GetFileType(),
             imageDevice->HasSubchannelData() ? "yes" : "no");
 
+    // This image is only standing in for one that is no longer on the card, so
+    // take its geometry but keep the drive empty to the host. Armed BEFORE
+    // SetDevice() deliberately: SetDevice() decides the ejected state itself
+    // and can yield, so ejecting afterwards would leave a window in which the
+    // gadget reports ready and the host mounts a disc nobody asked for.
+    if (adoptAsEmpty) {
+        cdromservice->ArmBootEject();
+    }
+
     cdromservice->SetDevice(imageDevice);
 
     // Committed only now that the disc is really the one the host has.
@@ -570,8 +630,18 @@ void SCSITBService::ProcessPendingMount() {
     m_MountedRelativePath[sizeof(m_MountedRelativePath) - 1] = '\0';
     m_LastFailedRelativePath[0] = '\0';
 
-    // Save relative path to config (without "1:/" prefix)
-    configservice->SetCurrentImage(relativePath);
+    // Save relative path to config (without "1:/" prefix).
+    //
+    // Not for a stand-in: recording it would make the substitute the user's
+    // remembered image, so the explanation would vanish on the next boot and
+    // putting the missing file back would no longer bring it up. Leaving the
+    // old name in config means the notice persists until something is mounted
+    // deliberately, and the fallback does not fire again because the drive is
+    // now ejected.
+    if (!adoptAsEmpty) {
+        configservice->SetCurrentImage(relativePath);
+        m_MissingSavedImage[0] = '\0';
+    }
 
     current_cd = next_cd;
     next_cd = -1;

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -51,24 +51,6 @@ static bool iequals(const char* a, const char* b) {
     return *a == *b;
 }
 
-// True if a file with the same stem but a different extension exists next to
-// fileName in dirFullPath (e.g. "game.bin" + ".cue" -> "1:/Games/game.cue").
-// FAT name matching is case-insensitive, so GAME.CUE is found too.
-static bool siblingWithExtExists(const char* dirFullPath, const char* fileName, const char* newExt) {
-    const char* dot = strrchr(fileName, '.');
-    if (dot == nullptr)
-        return false;
-
-    char sibling[MAX_PATH_LEN];
-    int n = snprintf(sibling, sizeof(sibling), "%s/%.*s%s",
-                     dirFullPath, (int)(dot - fileName), fileName, newExt);
-    if (n < 0 || (size_t)n >= sizeof(sibling))
-        return false;
-
-    FILINFO fi;
-    return f_stat(sibling, &fi) == FR_OK && !(fi.fattrib & AM_DIR);
-}
-
 int compareFileEntries(const void* a, const void* b) {
     const FileEntry* fa = (const FileEntry*)a;
     const FileEntry* fb = (const FileEntry*)b;
@@ -349,10 +331,17 @@ void SCSITBService::ScanDirectoryRecursive(const char* fullPath, const char* rel
                     // mounted now says why when you try, which is more use
                     // than not being there.
                     listIt = true;
-                } else if (!listIt && iequals(ext, ".bin")) {
-                    // Hide the raw .bin of a cue/bin pair; its .cue is listed
-                    listIt = !siblingWithExtExists(fullPath, fno.fname, ".cue");
                 }
+                // A .bin is never listed. Mounting one rewrites its extension
+                // and reads the .cue first, so a .bin whose cue is missing
+                // cannot be mounted at all, and one whose cue is present is
+                // already represented by that cue.
+                //
+                // The rule here used to be "list it unless a same-stem .cue
+                // exists", which is precisely backwards: it hid every .bin
+                // that could be mounted and offered every one that could not.
+                // On a split-track rip that meant a browser full of track
+                // files, none of them mountable.
                 if (listIt) {
                     size_t len = my_strnlen(fno.fname, MAX_FILENAME_LEN - 1);
                     memcpy(m_FileEntries[m_FileCount].name, fno.fname, len);

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -624,10 +624,24 @@ void SCSITBService::ProcessPendingMount() {
     cdromservice->SetDevice(imageDevice);
 
     // Committed only now that the disc is really the one the host has.
+    //
+    // m_CurrentImagePath is the file the gadget holds open, and is set either
+    // way: the delete/rename/overwrite guards key off it, and a stand-in is
+    // just as destructive to yank away as a chosen disc.
     strncpy(m_CurrentImagePath, candidatePath, sizeof(m_CurrentImagePath) - 1);
     m_CurrentImagePath[sizeof(m_CurrentImagePath) - 1] = '\0';
-    strncpy(m_MountedRelativePath, relativePath, sizeof(m_MountedRelativePath) - 1);
-    m_MountedRelativePath[sizeof(m_MountedRelativePath) - 1] = '\0';
+
+    // m_MountedRelativePath is what the USER has mounted, and a stand-in is
+    // not that - the drive is empty. Leaving it clear resolves current_cd to
+    // -1, so the file list highlights nothing and GetCurrentCDName() returns
+    // "", which is what the host sees. Naming the stand-in as "current" read
+    // as an ordinary disc swap and hid the empty drive completely.
+    if (!adoptAsEmpty) {
+        strncpy(m_MountedRelativePath, relativePath, sizeof(m_MountedRelativePath) - 1);
+        m_MountedRelativePath[sizeof(m_MountedRelativePath) - 1] = '\0';
+    } else {
+        m_MountedRelativePath[0] = '\0';
+    }
     m_LastFailedRelativePath[0] = '\0';
 
     // Save relative path to config (without "1:/" prefix).
@@ -643,7 +657,9 @@ void SCSITBService::ProcessPendingMount() {
         m_MissingSavedImage[0] = '\0';
     }
 
-    current_cd = next_cd;
+    // Nothing is current when the drive is empty, so the file list agrees with
+    // what the host can see rather than contradicting it.
+    current_cd = adoptAsEmpty ? -1 : next_cd;
     next_cd = -1;
     m_MountSeq++;
 }

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -503,7 +503,10 @@ void SCSITBService::ProcessPendingMount() {
         return;
 
     if ((size_t)next_cd >= m_FileCount) {
+        snprintf(m_LastMountError, sizeof(m_LastMountError),
+                 "That image is no longer in the list; the card may have been rescanned.");
         next_cd = -1;
+        m_MountSeq++;
         return;
     }
 
@@ -519,6 +522,7 @@ void SCSITBService::ProcessPendingMount() {
         snprintf(m_LastMountError, sizeof(m_LastMountError),
                  "Path is too long to mount: %s", relativePath);
         next_cd = -1;
+        m_MountSeq++;
         return;
     }
     // Build the path locally. Writing it straight into m_CurrentImagePath
@@ -548,6 +552,7 @@ void SCSITBService::ProcessPendingMount() {
                      relativePath);
         }
         next_cd = -1;
+        m_MountSeq++;
         return;
     }
 
@@ -570,6 +575,35 @@ void SCSITBService::ProcessPendingMount() {
 
     current_cd = next_cd;
     next_cd = -1;
+    m_MountSeq++;
+}
+
+SCSITBService::MountOutcome SCSITBService::MountByNameAndWait(const char* file_name,
+                                                             unsigned timeoutMs) {
+    const unsigned startSeq = m_MountSeq;
+
+    if (!SetNextCDByName(file_name)) {
+        return MountOutcome::NotFound;
+    }
+
+    // Run() picks the request up on its next pass and retires it, bumping the
+    // sequence exactly once whatever the result. Poll rather than block: this
+    // runs on the web server's or the display's task, and the service task
+    // needs the CPU to do the work being waited for.
+    unsigned waited = 0;
+    const unsigned step = 20;
+    while (m_MountSeq == startSeq && waited < timeoutMs) {
+        CScheduler::Get()->MsSleep(step);
+        waited += step;
+    }
+
+    if (m_MountSeq == startSeq) {
+        // A large CHD on a slow card can genuinely take a while. Saying it
+        // failed would be a guess, and the wrong one more often than not.
+        return MountOutcome::Timeout;
+    }
+
+    return m_LastMountError[0] == '\0' ? MountOutcome::Success : MountOutcome::Failed;
 }
 
 void SCSITBService::Run() {

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -228,7 +228,17 @@ bool SCSITBService::IsEjected() const {
 }
 
 const char* SCSITBService::GetCurrentCDName() {
-	return GetName(GetCurrentCD());
+	// Never nullptr. current_cd is an int that can legitimately be -1 (nothing
+	// mounted), GetCurrentCD() hands that back as a size_t - so SIZE_MAX - and
+	// GetName() answers an out-of-range index with nullptr. Callers feed the
+	// result straight into std::string and into JSON, both of which are
+	// undefined on a null pointer, and this runs on every web page load.
+	//
+	// That was survivable only while current_cd was set once at boot and never
+	// cleared. It is now re-derived after each rescan, so "nothing is mounted"
+	// became a state the UI can actually reach.
+	const char* name = GetName(GetCurrentCD());
+	return name != nullptr ? name : "";
 }
 
 bool SCSITBService::SetNextCDByName(const char* file_name) {
@@ -393,6 +403,29 @@ bool SCSITBService::RefreshCache() {
     
     LOGNOTE("SCSITBService::RefreshCache() Found %d total entries", (int)m_FileCount);
 
+    // current_cd is an index into the list that was just rebuilt, so on its own
+    // it means nothing afterwards: entries move, and an index that used to name
+    // the mounted disc can end up naming some other file entirely. Re-derive it
+    // from the path that actually got mounted, and admit to nothing being
+    // current when that file is no longer there.
+    {
+        int resolved = -1;
+        if (m_MountedRelativePath[0] != '\0') {
+            for (size_t i = 0; i < m_FileCount; ++i) {
+                if (!m_FileEntries[i].isDirectory &&
+                    strcmp(m_FileEntries[i].relativePath, m_MountedRelativePath) == 0) {
+                    resolved = (int)i;
+                    break;
+                }
+            }
+        }
+        if (resolved != current_cd) {
+            LOGNOTE("SCSITBService::RefreshCache() current index %d -> %d after rescan",
+                    current_cd, resolved);
+        }
+        current_cd = resolved;
+    }
+
     // Find the current image in cache by matching relative path
     const char* searchPath = current_image;
     bool found = false;
@@ -439,12 +472,21 @@ bool SCSITBService::RefreshCache() {
     // then persist "inserted" over the saved state.
     if (!found && m_FileCount > 0 && !IsEjected()) {
         for (size_t i = 0; i < m_FileCount; ++i) {
-            if (!m_FileEntries[i].isDirectory) {
-                LOGNOTE("SCSITBService::RefreshCache() Current image not found, using: %s", 
-                        m_FileEntries[i].relativePath);
-                next_cd = i;
-                break;
+            if (m_FileEntries[i].isDirectory) {
+                continue;
             }
+            // Skip the one we already know will not load. A rescan happens on
+            // every upload, delete and FTP change, so without this the same
+            // image is picked and fails again each time, and the error banner
+            // reappears for a disc the user never asked for.
+            if (m_LastFailedRelativePath[0] != '\0' &&
+                strcmp(m_FileEntries[i].relativePath, m_LastFailedRelativePath) == 0) {
+                continue;
+            }
+            LOGNOTE("SCSITBService::RefreshCache() Current image not found, using: %s",
+                    m_FileEntries[i].relativePath);
+            next_cd = i;
+            break;
         }
     }
 
@@ -479,12 +521,19 @@ void SCSITBService::ProcessPendingMount() {
         next_cd = -1;
         return;
     }
-    snprintf(m_CurrentImagePath, sizeof(m_CurrentImagePath), "1:/%s", relativePath);
+    // Build the path locally. Writing it straight into m_CurrentImagePath
+    // before the load meant a failed mount renamed the "current" image to the
+    // one that had just refused to load, so the UI reported a disc the host
+    // had never been given.
+    char candidatePath[MAX_PATH_LEN];
+    snprintf(candidatePath, sizeof(candidatePath), "1:/%s", relativePath);
 
-    IImageDevice* imageDevice = loadImageDevice(m_CurrentImagePath);
+    IImageDevice* imageDevice = loadImageDevice(candidatePath);
 
     if (imageDevice == nullptr) {
-        LOGERR("Failed to load image: %s", m_CurrentImagePath);
+        LOGERR("Failed to load image: %s", candidatePath);
+        strncpy(m_LastFailedRelativePath, relativePath, sizeof(m_LastFailedRelativePath) - 1);
+        m_LastFailedRelativePath[sizeof(m_LastFailedRelativePath) - 1] = '\0';
         // Prefer the loader's own reason. "Unsupported or damaged" is true of
         // every failure and useful for none of them, so it is only the
         // fallback for a path that has not been given words yet.
@@ -503,11 +552,18 @@ void SCSITBService::ProcessPendingMount() {
     }
 
     LOGNOTE("Loaded image: %s (format: %d, has subchannels: %s)",
-            m_CurrentImagePath,
+            candidatePath,
             (int)imageDevice->GetFileType(),
             imageDevice->HasSubchannelData() ? "yes" : "no");
 
     cdromservice->SetDevice(imageDevice);
+
+    // Committed only now that the disc is really the one the host has.
+    strncpy(m_CurrentImagePath, candidatePath, sizeof(m_CurrentImagePath) - 1);
+    m_CurrentImagePath[sizeof(m_CurrentImagePath) - 1] = '\0';
+    strncpy(m_MountedRelativePath, relativePath, sizeof(m_MountedRelativePath) - 1);
+    m_MountedRelativePath[sizeof(m_MountedRelativePath) - 1] = '\0';
+    m_LastFailedRelativePath[0] = '\0';
 
     // Save relative path to config (without "1:/" prefix)
     configservice->SetCurrentImage(relativePath);

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -228,15 +228,8 @@ bool SCSITBService::IsEjected() const {
 }
 
 const char* SCSITBService::GetCurrentCDName() {
-	// Never nullptr. current_cd is an int that can legitimately be -1 (nothing
-	// mounted), GetCurrentCD() hands that back as a size_t - so SIZE_MAX - and
-	// GetName() answers an out-of-range index with nullptr. Callers feed the
-	// result straight into std::string and into JSON, both of which are
-	// undefined on a null pointer, and this runs on every web page load.
-	//
-	// That was survivable only while current_cd was set once at boot and never
-	// cleared. It is now re-derived after each rescan, so "nothing is mounted"
-	// became a state the UI can actually reach.
+	// Never nullptr: current_cd is -1 when nothing is mounted, which GetName()
+	// answers with nullptr, and callers feed this straight into std::string.
 	const char* name = GetName(GetCurrentCD());
 	return name != nullptr ? name : "";
 }
@@ -331,27 +324,12 @@ void SCSITBService::ScanDirectoryRecursive(const char* fullPath, const char* rel
                 bool listIt = iequals(ext, ".iso") || iequals(ext, ".mds") ||
                               iequals(ext, ".chd") || iequals(ext, ".toast");
                 if (!listIt && iequals(ext, ".cue")) {
-                    // List every cue sheet, including one with no same-stem
-                    // .bin next to it. Hiding those was meant to keep a cue
-                    // whose data file is missing out of the way, but it also
-                    // hid split-track rips - where the cue is "Game.cue" and
-                    // the data is "Game (Track 1).bin" - so the browser
-                    // offered the raw track files and the disc itself simply
-                    // vanished with no explanation. A cue that cannot be
-                    // mounted now says why when you try, which is more use
-                    // than not being there.
+                    // Even with no same-stem .bin: hiding those also hid
+                    // split-track rips, whose data is "Game (Track 1).bin".
                     listIt = true;
                 }
-                // A .bin is never listed. Mounting one rewrites its extension
-                // and reads the .cue first, so a .bin whose cue is missing
-                // cannot be mounted at all, and one whose cue is present is
-                // already represented by that cue.
-                //
-                // The rule here used to be "list it unless a same-stem .cue
-                // exists", which is precisely backwards: it hid every .bin
-                // that could be mounted and offered every one that could not.
-                // On a split-track rip that meant a browser full of track
-                // files, none of them mountable.
+                // A .bin is never listed: mounting one reads the .cue first, so
+                // it is either unmountable or already represented by that cue.
                 if (listIt) {
                     size_t len = my_strnlen(fno.fname, MAX_FILENAME_LEN - 1);
                     memcpy(m_FileEntries[m_FileCount].name, fno.fname, len);
@@ -377,15 +355,8 @@ bool SCSITBService::RefreshCache() {
     LOGNOTE("SCSITBService::RefreshCache() called");
     m_Lock.Acquire();
 
-    // Get current loaded image from config.
-    //
-    // Asked with an empty default, this distinguishes "the user has an image
-    // remembered" from "this card has never mounted anything". They must not
-    // behave the same: a remembered image that has gone missing should leave
-    // the drive empty and say so, but a freshly written card has no remembered
-    // image at all and must still auto-mount, or first boot would look broken.
-    // GetCurrentImage(DEFAULT_IMAGE_FILENAME) cannot tell them apart, because
-    // it hands back "image.iso" in both cases.
+    // Empty default, not DEFAULT_IMAGE_FILENAME, which conflates a remembered
+    // image that has gone missing with a fresh card that never had one.
     const char* saved_image = configservice->GetCurrentImage("");
     const bool hadRememberedImage = (saved_image != nullptr && saved_image[0] != '\0');
     const char* current_image = hadRememberedImage ? saved_image : DEFAULT_IMAGE_FILENAME;
@@ -413,11 +384,8 @@ bool SCSITBService::RefreshCache() {
     
     LOGNOTE("SCSITBService::RefreshCache() Found %d total entries", (int)m_FileCount);
 
-    // current_cd is an index into the list that was just rebuilt, so on its own
-    // it means nothing afterwards: entries move, and an index that used to name
-    // the mounted disc can end up naming some other file entirely. Re-derive it
-    // from the path that actually got mounted, and admit to nothing being
-    // current when that file is no longer there.
+    // The list was just rebuilt, so the old current_cd index may now name a
+    // different file. Re-derive it from the path that actually got mounted.
     {
         int resolved = -1;
         if (m_MountedRelativePath[0] != '\0') {
@@ -476,31 +444,17 @@ bool SCSITBService::RefreshCache() {
         }
     }
 
-    // Fallback to first image file if not found. Not while ejected: an empty
-    // drive must stay empty, and this path also runs on rescans (upload, delete,
-    // FTP), where auto-mounting a substitute would undo the user's eject and
-    // then persist "inserted" over the saved state.
-    //
-    // The exception is a gadget that has never been brought up. Adopting an
-    // image is the ONLY thing that initializes it (cdromservice.cpp:59), so
-    // refusing here would leave the host seeing no USB device at all rather
-    // than an empty drive - and adopting cannot undo the eject anyway, because
-    // the boot-eject arm below keeps the medium hidden. Reachable whenever a
-    // remembered image goes missing while the drive is ejected, including the
-    // second boot after this code has itself come up empty and persisted it.
-    //
-    // m_FileCount == 0 still adopts nothing, which is what the QEMU boot test
-    // relies on - see tests/qemu-boot/README.md.
+    // Fallback to the first image, but not while ejected: this also runs on
+    // rescans, where mounting a substitute would undo the user's eject. Unless
+    // the gadget has never come up, since adopting is what initializes it.
     if (!found && m_FileCount > 0 &&
         (!IsEjected() || (cdromservice && !cdromservice->IsGadgetInitialized()))) {
         for (size_t i = 0; i < m_FileCount; ++i) {
             if (m_FileEntries[i].isDirectory) {
                 continue;
             }
-            // Skip the one we already know will not load. A rescan happens on
-            // every upload, delete and FTP change, so without this the same
-            // image is picked and fails again each time, and the error banner
-            // reappears for a disc the user never asked for.
+            // Skip the one we already know will not load, or every rescan picks
+            // it again and re-raises the error banner.
             if (m_LastFailedRelativePath[0] != '\0' &&
                 strcmp(m_FileEntries[i].relativePath, m_LastFailedRelativePath) == 0) {
                 continue;
@@ -509,13 +463,9 @@ bool SCSITBService::RefreshCache() {
                     m_FileEntries[i].relativePath);
             next_cd = i;
 
-            // A remembered image that is simply gone must not be swapped for a
-            // different disc in silence - that is how a renamed file turned
-            // into "some other game is in the drive" with nothing to explain
-            // it. Adopt this one so the gadget has a geometry and Insert is
-            // instant, but present the drive as EMPTY and record what went
-            // missing. A card that never had a remembered image (fresh write)
-            // keeps the plain auto-mount.
+            // A remembered image that is gone must not be silently swapped for a
+            // different disc. Adopt this one so the gadget has a geometry, but
+            // present the drive as empty and record what went missing.
             if (hadRememberedImage) {
                 strncpy(m_MissingSavedImage, current_image, sizeof(m_MissingSavedImage) - 1);
                 m_MissingSavedImage[sizeof(m_MissingSavedImage) - 1] = '\0';
@@ -524,11 +474,8 @@ bool SCSITBService::RefreshCache() {
                         current_image, m_FileEntries[i].relativePath);
             }
 
-            // Adopting while ejected MUST stay ejected. SetDevice() clears the
-            // ejected latch unless the boot-eject is armed, so without this the
-            // adoption we just allowed above would insert a disc the user had
-            // deliberately ejected - the exact thing the !IsEjected() guard
-            // exists to prevent.
+            // SetDevice() clears the ejected latch unless the boot-eject is armed,
+            // so without this the adoption above would insert a disc the user ejected.
             if (IsEjected()) {
                 m_bAdoptAsEmpty = true;
             }
@@ -548,8 +495,8 @@ void SCSITBService::ProcessPendingMount() {
     if (next_cd <= -1)
         return;
 
-    // Consume the flag up front: every exit path below retires the request, so
-    // leaving it set would eject the next image the user deliberately mounts.
+    // Consume up front: every exit path below retires the request, so leaving it
+    // set would eject the next image the user deliberately mounts.
     const bool adoptAsEmpty = m_bAdoptAsEmpty;
     m_bAdoptAsEmpty = false;
 
@@ -561,8 +508,6 @@ void SCSITBService::ProcessPendingMount() {
         return;
     }
 
-    // Any failure below leaves the previous disc mounted, so the reason has to
-    // outlive this function or the user is told nothing at all.
     m_LastMountError[0] = '\0';
 
     // Build full path using relativePath from cache
@@ -576,10 +521,8 @@ void SCSITBService::ProcessPendingMount() {
         m_MountSeq++;
         return;
     }
-    // Build the path locally. Writing it straight into m_CurrentImagePath
-    // before the load meant a failed mount renamed the "current" image to the
-    // one that had just refused to load, so the UI reported a disc the host
-    // had never been given.
+    // Local, not m_CurrentImagePath: writing that before the load makes a failed
+    // mount report a disc the host was never given.
     char candidatePath[MAX_PATH_LEN];
     snprintf(candidatePath, sizeof(candidatePath), "1:/%s", relativePath);
 
@@ -589,9 +532,8 @@ void SCSITBService::ProcessPendingMount() {
         LOGERR("Failed to load image: %s", candidatePath);
         strncpy(m_LastFailedRelativePath, relativePath, sizeof(m_LastFailedRelativePath) - 1);
         m_LastFailedRelativePath[sizeof(m_LastFailedRelativePath) - 1] = '\0';
-        // Prefer the loader's own reason. "Unsupported or damaged" is true of
-        // every failure and useful for none of them, so it is only the
-        // fallback for a path that has not been given words yet.
+        // Prefer the loader's own reason; the generic wording below is only for
+        // failure paths that have not been given words yet.
         const char* why = GetLastImageLoadError();
         if (why != nullptr && why[0] != '\0') {
             snprintf(m_LastMountError, sizeof(m_LastMountError),
@@ -612,30 +554,22 @@ void SCSITBService::ProcessPendingMount() {
             (int)imageDevice->GetFileType(),
             imageDevice->HasSubchannelData() ? "yes" : "no");
 
-    // This image is only standing in for one that is no longer on the card, so
-    // take its geometry but keep the drive empty to the host. Armed BEFORE
-    // SetDevice() deliberately: SetDevice() decides the ejected state itself
-    // and can yield, so ejecting afterwards would leave a window in which the
-    // gadget reports ready and the host mounts a disc nobody asked for.
+    // Take the stand-in's geometry but keep the drive empty to the host. Armed
+    // before SetDevice(), which decides the ejected state itself and can yield:
+    // ejecting after it leaves a window where the host mounts the stand-in.
     if (adoptAsEmpty) {
         cdromservice->ArmBootEject();
     }
 
     cdromservice->SetDevice(imageDevice);
 
-    // Committed only now that the disc is really the one the host has.
-    //
-    // m_CurrentImagePath is the file the gadget holds open, and is set either
-    // way: the delete/rename/overwrite guards key off it, and a stand-in is
-    // just as destructive to yank away as a chosen disc.
+    // m_CurrentImagePath is the file the gadget holds open, set either way: the
+    // delete/rename guards key off it, and a stand-in is as destructive to yank.
     strncpy(m_CurrentImagePath, candidatePath, sizeof(m_CurrentImagePath) - 1);
     m_CurrentImagePath[sizeof(m_CurrentImagePath) - 1] = '\0';
 
-    // m_MountedRelativePath is what the USER has mounted, and a stand-in is
-    // not that - the drive is empty. Leaving it clear resolves current_cd to
-    // -1, so the file list highlights nothing and GetCurrentCDName() returns
-    // "", which is what the host sees. Naming the stand-in as "current" read
-    // as an ordinary disc swap and hid the empty drive completely.
+    // m_MountedRelativePath is what the USER mounted, which a stand-in is not.
+    // Left clear it resolves current_cd to -1, so the UI highlights nothing.
     if (!adoptAsEmpty) {
         strncpy(m_MountedRelativePath, relativePath, sizeof(m_MountedRelativePath) - 1);
         m_MountedRelativePath[sizeof(m_MountedRelativePath) - 1] = '\0';

--- a/addon/scsitbservice/scsitbservice.cpp
+++ b/addon/scsitbservice/scsitbservice.cpp
@@ -469,11 +469,17 @@ void SCSITBService::ProcessPendingMount() {
         return;
     }
 
+    // Any failure below leaves the previous disc mounted, so the reason has to
+    // outlive this function or the user is told nothing at all.
+    m_LastMountError[0] = '\0';
+
     // Build full path using relativePath from cache
     const char* relativePath = m_FileEntries[next_cd].relativePath;
     // Ensure we have room for "1:/" prefix (3 chars) + relativePath + null terminator
     if (strlen(relativePath) > MAX_PATH_LEN - 4) {
         LOGERR("Path too long: %s", relativePath);
+        snprintf(m_LastMountError, sizeof(m_LastMountError),
+                 "Path is too long to mount: %s", relativePath);
         next_cd = -1;
         return;
     }
@@ -483,6 +489,10 @@ void SCSITBService::ProcessPendingMount() {
 
     if (imageDevice == nullptr) {
         LOGERR("Failed to load image: %s", m_CurrentImagePath);
+        snprintf(m_LastMountError, sizeof(m_LastMountError),
+                 "Could not load %s. It may be an unsupported or damaged image; "
+                 "the log has the details. The previous disc is still mounted.",
+                 relativePath);
         next_cd = -1;
         return;
     }

--- a/addon/scsitbservice/scsitbservice.h
+++ b/addon/scsitbservice/scsitbservice.h
@@ -91,7 +91,21 @@ private:
     bool m_bPersistedEjected = false;
 
     // Set by ProcessPendingMount() on every failure path, cleared on success.
-    char m_LastMountError[160] = {0};
+    // Wide enough for the loader's own wording plus the file name; at 160 the
+    // split-track message was cut off mid-word on screen.
+    char m_LastMountError[320] = {0};
+
+    // Relative path of the image that is ACTUALLY mounted, written only after
+    // a load succeeds. current_cd is an index into a list that RefreshCache
+    // rebuilds, so it cannot survive a rescan on its own - hiding .bin files
+    // shifted every index and left "Current File Loaded" naming a file that
+    // had never been mounted. This is what current_cd is re-derived from.
+    char m_MountedRelativePath[MAX_PATH_LEN] = {0};
+
+    // Relative path of the last image that failed to load, so the
+    // pick-something fallback in RefreshCache does not keep choosing it and
+    // failing again on every rescan.
+    char m_LastFailedRelativePath[MAX_PATH_LEN] = {0};
 
     // Full path of currently mounted image (e.g., "1:/Games/game.iso")
     char m_CurrentImagePath[MAX_PATH_LEN];

--- a/addon/scsitbservice/scsitbservice.h
+++ b/addon/scsitbservice/scsitbservice.h
@@ -50,6 +50,40 @@ public:
     bool SetNextCD(size_t index);
     bool SetNextCDByName(const char* file_name);
 
+    /// What a mount attempt did. Anything that can tell the user should use
+    /// MountByNameAndWait() and report this, rather than SetNextCDByName(),
+    /// whose "true" only means the name was found in the catalogue.
+    enum class MountOutcome
+    {
+        Success,
+        NotFound,  // no such entry; nothing was attempted
+        Failed,    // the image was tried and would not load, see GetLastMountError()
+        Timeout    // still loading; too big or the card is slow, not known to have failed
+    };
+
+    /// Queue an image and wait for the service task to finish loading it.
+    ///
+    /// Mounting is asynchronous - the request is handed to Run() and picked up
+    /// on its next pass - so a caller that returns as soon as it has queued the
+    /// request can only report that the file exists. The web UI announced
+    /// "Successfully mounted" for images that then failed to load, which is how
+    /// a split-track cue came to report success and refusal on two consecutive
+    /// pages.
+    ///
+    /// TASK CONTEXT ONLY. This sleeps on the scheduler, so calling it from an
+    /// interrupt handler freezes the machine hard enough to need a power cycle.
+    /// That is not hypothetical: the sh1106 and st7789 button handlers run in
+    /// the GPIO interrupt (see PageManager::HandleButtonPress), and calling
+    /// this from there locked up the Pi on every mount. Those pages queue with
+    /// SetNextCDByName() and watch GetMountSeq() from their refresh loop
+    /// instead. Also not with m_Lock held, and not from a SCSI command handler
+    /// - the vendor toolbox picker has no way to show a result anyway.
+    MountOutcome MountByNameAndWait(const char* file_name, unsigned timeoutMs = 8000);
+
+    /// Counter of mount requests the service task has finished with, whatever
+    /// the result. Changes exactly once per retired request.
+    unsigned GetMountSeq() const { return m_MountSeq; }
+
     // Eject / insert the current medium. These queue the request for the Run()
     // loop (task context), matching how SetNextCD defers the actual work.
     void SetPendingEject();
@@ -101,6 +135,10 @@ private:
     // shifted every index and left "Current File Loaded" naming a file that
     // had never been mounted. This is what current_cd is re-derived from.
     char m_MountedRelativePath[MAX_PATH_LEN] = {0};
+
+    // Bumped once per mount request the service task retires, so a caller can
+    // tell "still queued" from "dealt with" without polling internal state.
+    volatile unsigned m_MountSeq = 0;
 
     // Relative path of the last image that failed to load, so the
     // pick-something fallback in RefreshCache does not keep choosing it and

--- a/addon/scsitbservice/scsitbservice.h
+++ b/addon/scsitbservice/scsitbservice.h
@@ -50,38 +50,24 @@ public:
     bool SetNextCD(size_t index);
     bool SetNextCDByName(const char* file_name);
 
-    /// What a mount attempt did. Anything that can tell the user should use
-    /// MountByNameAndWait() and report this, rather than SetNextCDByName(),
-    /// whose "true" only means the name was found in the catalogue.
+    // What a mount attempt did. Callers that report to the user want this and
+    // MountByNameAndWait(); SetNextCDByName()'s "true" only means the name exists.
     enum class MountOutcome
     {
         Success,
         NotFound,  // no such entry; nothing was attempted
-        Failed,    // the image was tried and would not load, see GetLastMountError()
-        Timeout    // still loading; too big or the card is slow, not known to have failed
+        Failed,    // tried and would not load, see GetLastMountError()
+        Timeout    // still loading; not known to have failed
     };
 
-    /// Queue an image and wait for the service task to finish loading it.
-    ///
-    /// Mounting is asynchronous - the request is handed to Run() and picked up
-    /// on its next pass - so a caller that returns as soon as it has queued the
-    /// request can only report that the file exists. The web UI announced
-    /// "Successfully mounted" for images that then failed to load, which is how
-    /// a split-track cue came to report success and refusal on two consecutive
-    /// pages.
-    ///
-    /// TASK CONTEXT ONLY. This sleeps on the scheduler, so calling it from an
-    /// interrupt handler freezes the machine hard enough to need a power cycle.
-    /// That is not hypothetical: the sh1106 and st7789 button handlers run in
-    /// the GPIO interrupt (see PageManager::HandleButtonPress), and calling
-    /// this from there locked up the Pi on every mount. Those pages queue with
-    /// SetNextCDByName() and watch GetMountSeq() from their refresh loop
-    /// instead. Also not with m_Lock held, and not from a SCSI command handler
-    /// - the vendor toolbox picker has no way to show a result anyway.
+    // Queue an image and wait for the service task to finish loading it.
+    // TASK CONTEXT ONLY: this sleeps, so calling it from an interrupt handler
+    // hard-locks the Pi. The sh1106 and st7789 button handlers run in the GPIO
+    // interrupt, so they queue with SetNextCDByName() and poll GetMountSeq().
+    // Not with m_Lock held either.
     MountOutcome MountByNameAndWait(const char* file_name, unsigned timeoutMs = 8000);
 
-    /// Counter of mount requests the service task has finished with, whatever
-    /// the result. Changes exactly once per retired request.
+    // Bumped once per mount request the service task retires, whatever the result.
     unsigned GetMountSeq() const { return m_MountSeq; }
 
     // Eject / insert the current medium. These queue the request for the Run()
@@ -90,23 +76,12 @@ public:
     void SetPendingInsert();
     bool IsEjected() const;  // delegates to cdromservice
 
-    /// Why the last mount attempt failed, or "" if the last one worked.
-    ///
-    /// Mounting is asynchronous: SetNextCDByName() only queues an index, so
-    /// the web UI's "ok" says the name was found in the catalog, not that the
-    /// image loaded. When the load then fails the old disc stays mounted and
-    /// the only record is a line in the log, which is how an image that cannot
-    /// be mounted looks to the user exactly like one that can.
+    // Why the last mount attempt failed, or "" if it worked.
     const char* GetLastMountError() const { return m_LastMountError; }
 
-    /// The image config remembered, when it is no longer on the card, or "".
-    ///
-    /// A saved image that has been renamed, deleted or left on another card
-    /// used to be replaced by whichever file sorted first, with nothing said:
-    /// the drive came up holding a game the user had not asked for. Now the
-    /// drive comes up EMPTY and this says which image went missing. The
-    /// substitute is still adopted behind the scenes so the gadget knows a
-    /// geometry and Insert is instant - see ProcessPendingMount().
+    // The image config remembered, when it is no longer on the card, or "".
+    // The drive comes up empty in that case; a substitute is still adopted
+    // behind the scenes so the gadget has a geometry, see ProcessPendingMount().
     const char* GetMissingSavedImage() const { return m_MissingSavedImage; }
 
     // Task entry point
@@ -135,34 +110,25 @@ private:
     bool m_bPersistedEjected = false;
 
     // Set by ProcessPendingMount() on every failure path, cleared on success.
-    // Wide enough for the loader's own wording plus the file name; at 160 the
-    // split-track message was cut off mid-word on screen.
+    // 320 because at 160 the split-track message was cut off mid-word on screen.
     char m_LastMountError[320] = {0};
 
-    // Relative path of the image that is ACTUALLY mounted, written only after
-    // a load succeeds. current_cd is an index into a list that RefreshCache
-    // rebuilds, so it cannot survive a rescan on its own - hiding .bin files
-    // shifted every index and left "Current File Loaded" naming a file that
-    // had never been mounted. This is what current_cd is re-derived from.
+    // The image that is ACTUALLY mounted, written only after a load succeeds.
+    // current_cd is an index into a list RefreshCache rebuilds, so it cannot
+    // survive a rescan on its own; it is re-derived from this.
     char m_MountedRelativePath[MAX_PATH_LEN] = {0};
 
-    // Bumped once per mount request the service task retires, so a caller can
-    // tell "still queued" from "dealt with" without polling internal state.
     volatile unsigned m_MountSeq = 0;
 
-    // The image config remembered when it turned out not to be on the card.
     // Kept until the user mounts something deliberately, so the explanation
-    // survives a reboot rather than scrolling past once.
+    // survives a reboot.
     char m_MissingSavedImage[MAX_PATH_LEN] = {0};
 
-    // Set by RefreshCache when the image it is about to mount is only a
-    // stand-in for a missing one, and consumed by ProcessPendingMount, which
-    // arms the boot-eject so the drive presents empty.
+    // Set by RefreshCache when the image it is about to mount is only a stand-in
+    // for a missing one; ProcessPendingMount arms the boot-eject so it reads empty.
     bool m_bAdoptAsEmpty = false;
 
-    // Relative path of the last image that failed to load, so the
-    // pick-something fallback in RefreshCache does not keep choosing it and
-    // failing again on every rescan.
+    // So the fallback in RefreshCache does not keep picking the same bad image.
     char m_LastFailedRelativePath[MAX_PATH_LEN] = {0};
 
     // Full path of currently mounted image (e.g., "1:/Games/game.iso")

--- a/addon/scsitbservice/scsitbservice.h
+++ b/addon/scsitbservice/scsitbservice.h
@@ -99,6 +99,16 @@ public:
     /// be mounted looks to the user exactly like one that can.
     const char* GetLastMountError() const { return m_LastMountError; }
 
+    /// The image config remembered, when it is no longer on the card, or "".
+    ///
+    /// A saved image that has been renamed, deleted or left on another card
+    /// used to be replaced by whichever file sorted first, with nothing said:
+    /// the drive came up holding a game the user had not asked for. Now the
+    /// drive comes up EMPTY and this says which image went missing. The
+    /// substitute is still adopted behind the scenes so the gadget knows a
+    /// geometry and Insert is instant - see ProcessPendingMount().
+    const char* GetMissingSavedImage() const { return m_MissingSavedImage; }
+
     // Task entry point
     void Run(void);
 
@@ -139,6 +149,16 @@ private:
     // Bumped once per mount request the service task retires, so a caller can
     // tell "still queued" from "dealt with" without polling internal state.
     volatile unsigned m_MountSeq = 0;
+
+    // The image config remembered when it turned out not to be on the card.
+    // Kept until the user mounts something deliberately, so the explanation
+    // survives a reboot rather than scrolling past once.
+    char m_MissingSavedImage[MAX_PATH_LEN] = {0};
+
+    // Set by RefreshCache when the image it is about to mount is only a
+    // stand-in for a missing one, and consumed by ProcessPendingMount, which
+    // arms the boot-eject so the drive presents empty.
+    bool m_bAdoptAsEmpty = false;
 
     // Relative path of the last image that failed to load, so the
     // pick-something fallback in RefreshCache does not keep choosing it and

--- a/addon/scsitbservice/scsitbservice.h
+++ b/addon/scsitbservice/scsitbservice.h
@@ -56,6 +56,15 @@ public:
     void SetPendingInsert();
     bool IsEjected() const;  // delegates to cdromservice
 
+    /// Why the last mount attempt failed, or "" if the last one worked.
+    ///
+    /// Mounting is asynchronous: SetNextCDByName() only queues an index, so
+    /// the web UI's "ok" says the name was found in the catalog, not that the
+    /// image loaded. When the load then fails the old disc stays mounted and
+    /// the only record is a line in the log, which is how an image that cannot
+    /// be mounted looks to the user exactly like one that can.
+    const char* GetLastMountError() const { return m_LastMountError; }
+
     // Task entry point
     void Run(void);
 
@@ -80,6 +89,9 @@ private:
     // currently written to config, so the Run loop only writes on a change.
     bool m_bBootEjectPending = false;
     bool m_bPersistedEjected = false;
+
+    // Set by ProcessPendingMount() on every failure path, cleared on success.
+    char m_LastMountError[160] = {0};
 
     // Full path of currently mounted image (e.g., "1:/Games/game.iso")
     char m_CurrentImagePath[MAX_PATH_LEN];

--- a/addon/usbcdgadget/cd_utils.cpp
+++ b/addon/usbcdgadget/cd_utils.cpp
@@ -418,19 +418,28 @@ int CDUtils::GetBlocksizeForTrack(CUSBCDGadget* gadget, CUETrackInfo trackInfo)
     //     return 2352;
     // }
 
+    // Gated, not bare NOTICE. This runs once per READ(10) and once per READ CD
+    // (scsi_read.cpp:129 and :436) - so, in IRQ context, on the hottest path in
+    // the device. A device log pulled on 2026-07-28 had 13,069 of these lines,
+    // peaking at 929 in a single second.
+    //
+    // The cost is not the log file. CLogger::WriteV() builds a CString and
+    // queues the event BEFORE it consults the log level, so every one of these
+    // heap-allocates inside an IRQ - and lowering loglevel does not avoid any
+    // of it. m_bDebugLogging does.
     switch (trackInfo.track_mode)
     {
     case CUETrack_MODE1_2048:
-        MLOGNOTE("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE1_2048");
+        CDROM_DEBUG_LOG("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE1_2048");
         return 2048;
     case CUETrack_MODE1_2352:
-        MLOGNOTE("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE1_2352");
+        CDROM_DEBUG_LOG("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE1_2352");
         return 2352;
     case CUETrack_MODE2_2352:
-        MLOGNOTE("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE2_2352");
+        CDROM_DEBUG_LOG("CDUtils::GetBlocksizeForTrack", "CUETrack_MODE2_2352");
         return 2352;
     case CUETrack_AUDIO:
-        MLOGNOTE("CDUtils::GetBlocksizeForTrack", "CUETrack_AUDIO");
+        CDROM_DEBUG_LOG("CDUtils::GetBlocksizeForTrack", "CUETrack_AUDIO");
         return 2352;
     default:
         MLOGERR("CDUtils::GetBlocksizeForTrack", "Track mode %d not handled", trackInfo.track_mode);

--- a/addon/usbcdgadget/tcdstate_update.cpp
+++ b/addon/usbcdgadget/tcdstate_update.cpp
@@ -37,6 +37,23 @@ void CUSBCDGadget::Update()
             switch (m_mediaState)
             {
             case MediaState::NO_MEDIUM:
+                // An ejected drive must never put a medium in by itself.
+                //
+                // SetDevice() arms this sequence whenever one device replaces
+                // another, and it used to run the transition below without
+                // consulting the ejected latch - so adopting an image while
+                // ejected re-inserted it 100 ms later and undid the eject. At
+                // boot m_pDevice is null, no swap is armed, and the path never
+                // runs, which is why the boot restore looked correct while the
+                // same thing on a running system silently put a disc back.
+                if (m_bEjected)
+                {
+                    m_bPendingDiscSwap = false;
+                    CDROM_DEBUG_LOG("CUSBCDGadget::Update",
+                                    "Disc swap: drive is ejected, staying NO_MEDIUM");
+                    break;
+                }
+
                 // Stage 2: Transition from NO_MEDIUM to UNIT_ATTENTION
                 CTraceLab::Get()->TraceMediaState((u8)m_mediaState, (u8)MediaState::MEDIUM_PRESENT_UNIT_ATTENTION);
                 m_CDReady = true;

--- a/addon/webserver/handlers/configpage.cpp
+++ b/addon/webserver/handlers/configpage.cpp
@@ -286,6 +286,21 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
         }
     }
     
+    // Whether file logging is actually working right now. The boot-time
+    // warning about a path that would not open goes to the serial console, and
+    // a SCREEN_HEADLESS build has nowhere else to put it - so without this the
+    // config page happily shows a log path that is doing nothing.
+    {
+        char status[256] = {0};
+        if (CFileLogDaemon::Get() != nullptr) {
+            CFileLogDaemon::Get()->GetStatusText(status, sizeof(status));
+        }
+        context["logfile_status"] = std::string(status);
+        context["logfile_broken"] = (CFileLogDaemon::Get() != nullptr &&
+                                     !CFileLogDaemon::Get()->IsFileLogging() &&
+                                     CFileLogDaemon::Get()->GetLogFilePath()[0] != '\0');
+    }
+
     // Set current values for display
     std::string current_displayhat = config->GetDisplayHat();
     std::string current_low_power_timeout = std::to_string(config->GetLowPowerTimeout());

--- a/addon/webserver/handlers/configpage.cpp
+++ b/addon/webserver/handlers/configpage.cpp
@@ -32,6 +32,74 @@ std::string ConfigPageHandler::GetHTML() {
     return std::string(s_Config);
 }
 
+// Normalize a log file path the user typed onto volume 0:, and reject what
+// FatFs will not be able to open.
+//
+// This is the only validation the value ever gets, and it used to be one line:
+// prepend "0:/" unless the string already started with it. A user who entered
+// "SD:/usbode-logs.txt" - a reasonable guess at how to name the card - got
+// "0:/SD:/usbode-logs.txt" saved, which cannot be opened, and the next boot
+// came up with no log file at all.
+//
+// An empty result means logging is switched off, which is a legitimate choice
+// rather than an error.
+static bool NormalizeLogfilePath(std::string& path, std::string& error) {
+    const size_t first = path.find_first_not_of(" \t");
+    if (first == std::string::npos) {
+        path.clear();
+        return true;
+    }
+    path = path.substr(first, path.find_last_not_of(" \t") - first + 1);
+
+    // FatFs accepts either separator and users type both.
+    std::replace(path.begin(), path.end(), '\\', '/');
+
+    // Take off a volume prefix if one was typed, and refuse any volume other
+    // than the boot partition. Volume 1: is a real volume but it is not
+    // mounted until well after the log daemon starts, so a log file there
+    // would fail at every boot.
+    const size_t colon = path.find(':');
+    if (colon != std::string::npos) {
+        const std::string volume = path.substr(0, colon);
+        if (volume != "0") {
+            error = "Log file must be on the boot partition. Remove the \"" + volume +
+                    ":\" prefix and give a path like usbode-log.txt.";
+            return false;
+        }
+        path.erase(0, colon + 1);
+    }
+    while (!path.empty() && path[0] == '/') {
+        path.erase(0, 1);
+    }
+
+    if (path.empty() || path.back() == '/') {
+        error = "Log file path has to name a file, not a directory.";
+        return false;
+    }
+    if (path.find(':') != std::string::npos) {
+        error = "Log file path cannot contain a colon.";
+        return false;
+    }
+
+    // The directory has to exist. FatFs will not create one, so a path under a
+    // missing directory is accepted here and then fails silently at boot -
+    // which is exactly the failure this is here to stop. f_opendir rather than
+    // f_stat, because f_stat cannot describe the root of a volume.
+    const size_t slash = path.find_last_of('/');
+    if (slash != std::string::npos) {
+        const std::string dir = path.substr(0, slash);
+        DIR probe;
+        if (f_opendir(&probe, ("0:/" + dir).c_str()) != FR_OK) {
+            error = "Directory \"" + dir + "\" does not exist on the boot partition.";
+            return false;
+        }
+        f_closedir(&probe);
+    }
+
+    path = "0:/" + path;
+    return true;
+}
+
 std::map<std::string, std::string> ConfigPageHandler::ParseFormData(const char* pFormData) {
     std::map<std::string, std::string> params;
     
@@ -126,15 +194,19 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
                 config->SetST7789SleepBrightness(std::atoi(form_params["st7789_sleep_brightness"].c_str()));
             }
             
-            // Log file configuration
+            // Log file configuration. An empty value is honoured as "turn file
+            // logging off" - the page already displays an empty setting that
+            // way, and previously the write path ignored it, so the setting
+            // could not be cleared once set.
             if (form_params.count("logfile")) {
                 std::string logfile = form_params["logfile"];
-                if (!logfile.empty()) {
-                    // Ensure 0:/ prefix
-                    if (logfile.find("0:/") != 0) {
-                        logfile = "0:/" + logfile;
-                    }
+                std::string logfileError;
+                if (NormalizeLogfilePath(logfile, logfileError)) {
                     config->SetLogfile(logfile.c_str());
+                } else {
+                    error_message = logfileError;
+                    LOGWARN("Rejected log file path '%s': %s",
+                            form_params["logfile"].c_str(), logfileError.c_str());
                 }
             }
             
@@ -193,8 +265,14 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
             
             // Check for action parameter to determine what to do after saving
             std::string action = form_params.count("action") ? form_params["action"] : "save";
-            
-            if (action == "save_reboot") {
+
+            // Something was rejected above. Everything else in the form was
+            // still saved, but saying "saved successfully" alongside the
+            // rejection would read as though the rejected value went in too -
+            // and rebooting on top of that would hide the message entirely.
+            if (!error_message.empty()) {
+                error_message += " Other settings were saved.";
+            } else if (action == "save_reboot") {
                 success_message = "Configuration saved successfully. Rebooting in 3 seconds...";
                 // Schedule a reboot in 3 seconds
                 new CShutdown(ShutdownReboot, 3000);

--- a/addon/webserver/handlers/configpage.cpp
+++ b/addon/webserver/handlers/configpage.cpp
@@ -32,17 +32,10 @@ std::string ConfigPageHandler::GetHTML() {
     return std::string(s_Config);
 }
 
-// Normalize a log file path the user typed onto volume 0:, and reject what
-// FatFs will not be able to open.
-//
-// This is the only validation the value ever gets, and it used to be one line:
-// prepend "0:/" unless the string already started with it. A user who entered
-// "SD:/usbode-logs.txt" - a reasonable guess at how to name the card - got
-// "0:/SD:/usbode-logs.txt" saved, which cannot be opened, and the next boot
-// came up with no log file at all.
-//
-// An empty result means logging is switched off, which is a legitimate choice
-// rather than an error.
+// Normalize a user-typed log path onto volume 0: and reject what FatFs cannot
+// open. This is the only validation the value gets, and a rejected path is not
+// discovered until the next boot comes up with no log file. An empty result
+// means logging is off, which is a choice rather than an error.
 static bool NormalizeLogfilePath(std::string& path, std::string& error) {
     const size_t first = path.find_first_not_of(" \t");
     if (first == std::string::npos) {
@@ -54,10 +47,8 @@ static bool NormalizeLogfilePath(std::string& path, std::string& error) {
     // FatFs accepts either separator and users type both.
     std::replace(path.begin(), path.end(), '\\', '/');
 
-    // Take off a volume prefix if one was typed, and refuse any volume other
-    // than the boot partition. Volume 1: is a real volume but it is not
-    // mounted until well after the log daemon starts, so a log file there
-    // would fail at every boot.
+    // Refuse any volume but the boot partition: 1: is real but is not mounted
+    // until well after the log daemon starts.
     const size_t colon = path.find(':');
     if (colon != std::string::npos) {
         const std::string volume = path.substr(0, colon);
@@ -81,10 +72,8 @@ static bool NormalizeLogfilePath(std::string& path, std::string& error) {
         return false;
     }
 
-    // The directory has to exist. FatFs will not create one, so a path under a
-    // missing directory is accepted here and then fails silently at boot -
-    // which is exactly the failure this is here to stop. f_opendir rather than
-    // f_stat, because f_stat cannot describe the root of a volume.
+    // FatFs will not create a directory, so a path under a missing one fails
+    // silently at boot. f_opendir, not f_stat, which cannot describe a root.
     const size_t slash = path.find_last_of('/');
     if (slash != std::string::npos) {
         const std::string dir = path.substr(0, slash);
@@ -194,10 +183,8 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
                 config->SetST7789SleepBrightness(std::atoi(form_params["st7789_sleep_brightness"].c_str()));
             }
             
-            // Log file configuration. An empty value is honoured as "turn file
-            // logging off" - the page already displays an empty setting that
-            // way, and previously the write path ignored it, so the setting
-            // could not be cleared once set.
+            // An empty value means "off". The write path used to ignore it, so
+            // the setting could not be cleared once set.
             if (form_params.count("logfile")) {
                 std::string logfile = form_params["logfile"];
                 std::string logfileError;
@@ -266,10 +253,8 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
             // Check for action parameter to determine what to do after saving
             std::string action = form_params.count("action") ? form_params["action"] : "save";
 
-            // Something was rejected above. Everything else in the form was
-            // still saved, but saying "saved successfully" alongside the
-            // rejection would read as though the rejected value went in too -
-            // and rebooting on top of that would hide the message entirely.
+            // Everything else was saved, but "saved successfully" next to a
+            // rejection would read as though the rejected value went in too.
             if (!error_message.empty()) {
                 error_message += " Other settings were saved.";
             } else if (action == "save_reboot") {
@@ -286,10 +271,8 @@ THTTPStatus ConfigPageHandler::PopulateContext(kainjow::mustache::data& context,
         }
     }
     
-    // Whether file logging is actually working right now. The boot-time
-    // warning about a path that would not open goes to the serial console, and
-    // a SCREEN_HEADLESS build has nowhere else to put it - so without this the
-    // config page happily shows a log path that is doing nothing.
+    // The boot-time warning goes to the serial console, which a SCREEN_HEADLESS
+    // build has no equivalent of, so the page would show a path doing nothing.
     {
         char status[256] = {0};
         if (CFileLogDaemon::Get() != nullptr) {

--- a/addon/webserver/handlers/imagenameapi.cpp
+++ b/addon/webserver/handlers/imagenameapi.cpp
@@ -26,6 +26,16 @@ THTTPStatus ImageNameAPIHandler::GetJson(nlohmann::json& j,
     j = {
 	    {"name", svc->GetCurrentCDName()}
     };
+
+    // Mounting happens on the service task well after the mount request was
+    // answered "ok", so a failure has no other way back to the user. The page
+    // already polls this endpoint for the current image name; a disc that
+    // refused to mount shows up here as the reason the name did not change.
+    const char* mountError = svc->GetLastMountError();
+    if (mountError != nullptr && mountError[0] != '\0') {
+	    j["mount_error"] = mountError;
+    }
+
     return HTTPOK;
 
 }

--- a/addon/webserver/handlers/imagenameapi.cpp
+++ b/addon/webserver/handlers/imagenameapi.cpp
@@ -23,8 +23,10 @@ THTTPStatus ImageNameAPIHandler::GetJson(nlohmann::json& j,
             return HTTPInternalServerError;
     }
 
+    // Defensive: nlohmann's string construction is undefined on a null char*.
+    const char* name = svc->GetCurrentCDName();
     j = {
-	    {"name", svc->GetCurrentCDName()}
+	    {"name", name != nullptr ? name : ""}
     };
 
     // Mounting happens on the service task well after the mount request was

--- a/addon/webserver/handlers/logpage.cpp
+++ b/addon/webserver/handlers/logpage.cpp
@@ -15,6 +15,7 @@
 #include "logpage.h"
 #include "../util.h"
 #include <cdplayer/cdplayer.h>
+#include <filelogdaemon/filelogdaemon.h>
 
 using namespace kainjow;
 
@@ -61,8 +62,31 @@ THTTPStatus LogPageHandler::PopulateContext(kainjow::mustache::data& context,
                                    const char  *pFormData)
 {
     LOGNOTE("Log page called");
-    
-    context["log_lines"] = read_loglines("/usbode-logs.txt");
-    
+
+    // Read the file that is actually configured. This used to be hardcoded to
+    // "/usbode-logs.txt", so anyone who set a different path got a blank page
+    // and no hint that they were looking in the wrong place.
+    char path[256] = {0};
+    char status[256] = {0};
+    CFileLogDaemon *pDaemon = CFileLogDaemon::Get();
+    if (pDaemon != nullptr) {
+        pDaemon->GetStdioPath(path, sizeof(path));
+        pDaemon->GetStatusText(status, sizeof(status));
+    }
+
+    std::string lines = path[0] != '\0' ? read_loglines(path) : std::string();
+
+    // An empty page is the one thing this must never be: a missing log file
+    // and an empty log file look identical, and the reason is what the user
+    // needs.
+    if (lines.empty()) {
+        lines = status[0] != '\0'
+                    ? std::string(status)
+                    : std::string("No log file is available.");
+    }
+
+    context["log_lines"] = lines;
+    context["log_status"] = std::string(status);
+
     return HTTPOK;
 }

--- a/addon/webserver/handlers/mountapi.cpp
+++ b/addon/webserver/handlers/mountapi.cpp
@@ -33,10 +33,24 @@ THTTPStatus MountAPIHandler::GetJson(nlohmann::json& j,
 
     LOGNOTE("MountAPI: Mounting image with relative path: %s", file_param.c_str());
 
-    // Use SetNextCDByName which now searches by relativePath in the cache
-    if (svc->SetNextCDByName(file_param.c_str())) {
+    // Report what the load actually did, not merely that the name was found.
+    switch (svc->MountByNameAndWait(file_param.c_str())) {
+    case SCSITBService::MountOutcome::Success:
         j = {{"status", "ok"}};
         return HTTPOK;
+
+    case SCSITBService::MountOutcome::Failed:
+        j = {{"status", "error"}, {"error", std::string(svc->GetLastMountError())}};
+        return HTTPOK;
+
+    case SCSITBService::MountOutcome::Timeout:
+        j = {{"status", "pending"},
+             {"error", "Still loading; check the current image shortly."}};
+        return HTTPOK;
+
+    case SCSITBService::MountOutcome::NotFound:
+    default:
+        break;
     }
 
     return HTTPNotFound;

--- a/addon/webserver/handlers/mountpage.cpp
+++ b/addon/webserver/handlers/mountpage.cpp
@@ -54,9 +54,34 @@ THTTPStatus MountPageHandler::PopulateContext(kainjow::mustache::data& context,
         return HTTPInternalServerError;
 	}
 
-	// Use SetNextCDByName which now searches by relativePath in the cache
-	if (svc->SetNextCDByName(file_param.c_str())) {
+	// Wait for the load to actually happen before saying anything about it.
+	// Queueing the request and reporting success announced "Successfully
+	// mounted" for images that then refused to load, so the very next page
+	// contradicted this one.
+	switch (svc->MountByNameAndWait(file_param.c_str())) {
+	case SCSITBService::MountOutcome::Success:
+		context.set("mounted", true);
 		return HTTPOK;
+
+	case SCSITBService::MountOutcome::Failed:
+		context.set("mounted", false);
+		context.set("mount_failed", true);
+		context.set("mount_message", std::string(svc->GetLastMountError()));
+		// Stay put rather than bouncing to the homepage; the reason is here.
+		context.set("meta_refresh_url", "");
+		return HTTPOK;
+
+	case SCSITBService::MountOutcome::Timeout:
+		context.set("mounted", false);
+		context.set("mount_pending", true);
+		context.set("mount_message",
+			    std::string("Still loading. Large images on a slow card can take a "
+					"while; the homepage will show it once it is ready."));
+		return HTTPOK;
+
+	case SCSITBService::MountOutcome::NotFound:
+	default:
+		break;
 	}
 
 	return HTTPNotFound;

--- a/addon/webserver/handlers/pagehandlerbase.cpp
+++ b/addon/webserver/handlers/pagehandlerbase.cpp
@@ -64,6 +64,17 @@ THTTPStatus PageHandlerBase::GetContent(const char *pPath,
         // Get current loaded image
         std::string current_image = svc->GetCurrentCDName();
 
+        // If the last mount attempt failed, say so on every page. Mounting is
+        // asynchronous - the request is answered "ok" as soon as the name is
+        // found in the catalog - so without this the UI reports success for an
+        // image that never loaded and goes on showing the previous disc as
+        // though nothing happened. Set only when non-empty, so the template
+        // section stays falsy the rest of the time.
+        const char* mountError = svc->GetLastMountError();
+        if (mountError != nullptr && mountError[0] != '\0') {
+            context.set("mount_error", std::string(mountError));
+        }
+
 	// Get our config service
 	ConfigService* config = static_cast<ConfigService*>(CScheduler::Get()->GetTask("configservice"));
 

--- a/addon/webserver/handlers/pagehandlerbase.cpp
+++ b/addon/webserver/handlers/pagehandlerbase.cpp
@@ -61,8 +61,11 @@ THTTPStatus PageHandlerBase::GetContent(const char *pPath,
         if (!svc)
             return HTTPInternalServerError;
 
-        // Get current loaded image
-        std::string current_image = svc->GetCurrentCDName();
+        // Get current loaded image. Constructing a std::string from a null
+        // char* is undefined, and this runs for every page the server serves,
+        // so it is checked here as well as at the source.
+        const char* current_image_name = svc->GetCurrentCDName();
+        std::string current_image = current_image_name != nullptr ? current_image_name : "";
 
         // If the last mount attempt failed, say so on every page. Mounting is
         // asynchronous - the request is answered "ok" as soon as the name is

--- a/addon/webserver/handlers/pagehandlerbase.cpp
+++ b/addon/webserver/handlers/pagehandlerbase.cpp
@@ -61,28 +61,21 @@ THTTPStatus PageHandlerBase::GetContent(const char *pPath,
         if (!svc)
             return HTTPInternalServerError;
 
-        // Get current loaded image. Constructing a std::string from a null
-        // char* is undefined, and this runs for every page the server serves,
-        // so it is checked here as well as at the source.
+        // std::string from a null char* is undefined, and this runs for every
+        // page, so it is checked here as well as at the source.
         const char* current_image_name = svc->GetCurrentCDName();
         std::string current_image = current_image_name != nullptr ? current_image_name : "";
 
-        // If the last mount attempt failed, say so on every page. Mounting is
-        // asynchronous - the request is answered "ok" as soon as the name is
-        // found in the catalog - so without this the UI reports success for an
-        // image that never loaded and goes on showing the previous disc as
-        // though nothing happened. Set only when non-empty, so the template
-        // section stays falsy the rest of the time.
+        // Say so on every page: mounting is asynchronous, so the request is
+        // answered "ok" before the image has actually loaded. Set only when
+        // non-empty, so the template section stays falsy otherwise.
         const char* mountError = svc->GetLastMountError();
         if (mountError != nullptr && mountError[0] != '\0') {
             context.set("mount_error", std::string(mountError));
         }
 
-        // The saved image was not on the card, so the drive came up empty
-        // rather than holding a disc the user never chose. Shown on every page
-        // and until something is mounted deliberately: this survives a reboot,
-        // so a one-shot message would be missed by exactly the person it is
-        // for.
+        // The saved image was missing, so the drive came up empty. Shown until
+        // something is mounted deliberately, since this survives a reboot.
         const char* missingImage = svc->GetMissingSavedImage();
         if (missingImage != nullptr && missingImage[0] != '\0') {
             context.set("missing_image", std::string(missingImage));

--- a/addon/webserver/handlers/pagehandlerbase.cpp
+++ b/addon/webserver/handlers/pagehandlerbase.cpp
@@ -78,6 +78,16 @@ THTTPStatus PageHandlerBase::GetContent(const char *pPath,
             context.set("mount_error", std::string(mountError));
         }
 
+        // The saved image was not on the card, so the drive came up empty
+        // rather than holding a disc the user never chose. Shown on every page
+        // and until something is mounted deliberately: this survives a reboot,
+        // so a one-shot message would be missed by exactly the person it is
+        // for.
+        const char* missingImage = svc->GetMissingSavedImage();
+        if (missingImage != nullptr && missingImage[0] != '\0') {
+            context.set("missing_image", std::string(missingImage));
+        }
+
 	// Get our config service
 	ConfigService* config = static_cast<ConfigService*>(CScheduler::Get()->GetTask("configservice"));
 

--- a/addon/webserver/pages/config.html
+++ b/addon/webserver/pages/config.html
@@ -131,6 +131,7 @@
             <div class="current-value">Current: {{current_logfile}}</div>
             <input type="text" name="logfile" id="logfile" value="{{logfile}}" size="30">
             <div class="current-value">A file on the boot partition, e.g. usbode-log.txt. The directory must already exist. Leave empty to disable file logging.</div>
+            <div class="current-value" {{#logfile_broken}}style="color:#b00020;font-weight:bold"{{/logfile_broken}}>Status: {{logfile_status}}</div>
         </div>
         <div class="form-group">
             <label for="loglevel">Log Level:</label>

--- a/addon/webserver/pages/config.html
+++ b/addon/webserver/pages/config.html
@@ -130,7 +130,7 @@
             <label for="logfile">Log File Path:</label>
             <div class="current-value">Current: {{current_logfile}}</div>
             <input type="text" name="logfile" id="logfile" value="{{logfile}}" size="30">
-            <div class="current-value">Leave empty to disable file logging. Will be automatically prefixed with 0:/</div>
+            <div class="current-value">A file on the boot partition, e.g. usbode-log.txt. The directory must already exist. Leave empty to disable file logging.</div>
         </div>
         <div class="form-group">
             <label for="loglevel">Log Level:</label>

--- a/addon/webserver/pages/mount.html
+++ b/addon/webserver/pages/mount.html
@@ -1,8 +1,25 @@
 <h3>Mounting File</h3>
+
+{{#mounted}}
 <div class="info-box">
 	<p>Successfully mounted: <strong>{{image_name}}</strong></p>
 	<p>Returning to homepage in {{meta_refresh_timeout}} seconds</p>
 </div>
+{{/mounted}}
+
+{{#mount_failed}}
+<div class="message warning" style="color:#b00020;font-weight:bold">
+	<p>Could not mount: <strong>{{image_name}}</strong></p>
+	<p>{{mount_message}}</p>
+</div>
+{{/mount_failed}}
+
+{{#mount_pending}}
+<div class="info-box">
+	<p>Mounting: <strong>{{image_name}}</strong></p>
+	<p>{{mount_message}}</p>
+</div>
+{{/mount_pending}}
 
 <div class="navigation">
 	<a class="button" href="/">Return to File List</a>

--- a/addon/webserver/pages/template.html
+++ b/addon/webserver/pages/template.html
@@ -19,6 +19,12 @@
 
 			<div class="content">
 
+			{{#mount_error}}
+				<div class="message warning" style="color:#b00020;font-weight:bold">
+					<strong>Last mount failed:</strong> {{mount_error}}
+				</div>
+			{{/mount_error}}
+
 			{{#cdrom}}
 				{{>content}}
 			{{/cdrom}}

--- a/addon/webserver/pages/template.html
+++ b/addon/webserver/pages/template.html
@@ -25,6 +25,13 @@
 				</div>
 			{{/mount_error}}
 
+			{{#missing_image}}
+				<div class="message warning" style="color:#b00020;font-weight:bold">
+					<strong>Drive is empty:</strong> {{missing_image}} is no longer on the card.
+					Mount an image to clear this.
+				</div>
+			{{/missing_image}}
+
 			{{#cdrom}}
 				{{>content}}
 			{{/cdrom}}

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -68,6 +68,13 @@ DISCIMAGE_SRCS := \
 	$(ADDON)/discimage/mdsfile.cpp \
 	$(ADDON)/mdsparser/mdsparser.cpp
 
+# The file log daemon. Not a disc-image path, but it reaches the SD card
+# through the same FatFs seam, and what it does when that open FAILS is the
+# behaviour worth pinning: a bad path used to cost 20 ms of scheduler time per
+# log event, which presented as the whole Pi having gone slow.
+SERVICE_SRCS := \
+	$(ADDON)/filelogdaemon/filelogdaemon.cpp
+
 CHDR_OBJS :=
 ifeq ($(WITH_CHD),1)
 DISCIMAGE_SRCS += $(ADDON)/discimage/chdfile.cpp
@@ -97,7 +104,7 @@ endif
 HARNESS_SRCS := $(wildcard harness/*.cpp)
 TEST_SRCS    := $(wildcard test-suite/*.cpp)
 
-CXX_SRCS := $(GADGET_SRCS) $(DISCIMAGE_SRCS) $(HARNESS_SRCS) $(TEST_SRCS)
+CXX_SRCS := $(GADGET_SRCS) $(DISCIMAGE_SRCS) $(SERVICE_SRCS) $(HARNESS_SRCS) $(TEST_SRCS)
 CXX_OBJS := $(addprefix $(BUILD)/,$(notdir $(CXX_SRCS:.cpp=.o)))
 OBJS := $(CXX_OBJS) $(CHDR_OBJS)
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -11,6 +11,22 @@ make -C integration-tests WITH_CHD=1 # also run the real .chd image through libc
 USBODE_TEST_VERBOSE=1 integration-tests/out/usbode-host-tests   # with firmware logs
 ```
 
+Under a sanitizer. Note that a `CXXFLAGS` on the command line **replaces** the
+one the Makefile builds up rather than adding to it, so `-std=c++17` has to be
+repeated or the build fails:
+
+```
+make -C integration-tests clean
+make -C integration-tests \
+    CXXFLAGS="-std=c++17 -O0 -g -fsanitize=address,undefined" \
+    CFLAGS="-O0 -g -fsanitize=address,undefined" \
+    LDFLAGS="-fsanitize=address,undefined"
+```
+
+Worth running when a fix is about an uninitialised member: a `bool` that holds
+neither 0 nor 1 is undefined to read, so an ordinary assertion cannot pin it -
+the optimizer folds the test - but UBSan names the exact line.
+
 ## What this is
 
 The **real firmware sources** — all of `addon/usbcdgadget` (command
@@ -198,16 +214,25 @@ integration-tests/
   Makefile             host build; `make` = build + run, WITH_CHD=1 adds CHD
   harness/
     stubs/             minimal Circle/service headers (circle/, cdplayer/, fatfs/, ...)
-    stubs.cpp          logger/scheduler/timer/endpoint implementations
+    stubs.cpp          logger/scheduler/timer/endpoint implementations; the
+                       logger keeps a real event queue and the scheduler counts
+                       sleeps, so a task that drains the log can be tested
     testbus.h          records BeginTransfer()/Stall() from the gadget
     fakedisc.*         in-memory disc images + cue sheets
-    fatfs_host.cpp     FatFs f_open/f_read/... over host stdio (real-image reads)
+    fatfs_host.cpp     FatFs f_open/f_read/... over host stdio (real-image
+                       reads, and writes for the log daemon)
     discimage_host.cpp FatFsOptimizer no-op backing (fast seek n/a on host)
     bench.*            the virtual USB host
     framework.*        tiny TEST()/CHECK() runner
-  test-suite/          one file per command family, plus test_realimages.cpp
-                       and test_mdsimages.cpp
+  test-suite/          one file per command family, plus test_realimages.cpp,
+                       test_mdsimages.cpp and test_logdaemon.cpp
 ```
+
+Not everything here is a SCSI command. `addon/filelogdaemon` is compiled in
+too, because it reaches the SD card through the same FatFs seam and its
+interesting behaviour is what it does when that open **fails**: a log path
+under a directory that does not exist used to cost 20 ms of scheduler time per
+log event, which presented as the whole Pi having gone slow.
 
 Two production accommodations (both inert on the device):
 

--- a/integration-tests/harness/fatfs_host.cpp
+++ b/integration-tests/harness/fatfs_host.cpp
@@ -18,8 +18,31 @@ FRESULT f_open(FIL* fp, const TCHAR* path, BYTE mode)
     if (!fp || !path) {
         return FR_INVALID_PARAMETER;
     }
-    // The readers only ever open images read-only.
-    FILE* f = fopen(path, "rb");
+
+    // The image readers only ever read, but the log daemon opens its file for
+    // append, and whether that open SUCCEEDS is the whole subject of its
+    // tests - so the mode has to be honoured rather than assumed.
+    //
+    // FA_OPEN_ALWAYS means "open it, creating it if absent", which is "r+b"
+    // falling back to "w+b". Letting the fallback run only when the file is
+    // genuinely missing is what keeps a bad directory an error: fopen cannot
+    // create a file under a directory that does not exist, so a path like
+    // 0:/nosuchdir/log.txt fails here exactly as FatFs would fail it.
+    const char* stdioMode = "rb";
+    if (mode & (FA_WRITE | FA_CREATE_ALWAYS | FA_CREATE_NEW | FA_OPEN_ALWAYS)) {
+        if (mode & FA_CREATE_ALWAYS) {
+            stdioMode = "w+b";
+        } else if ((mode & FA_OPEN_APPEND) == FA_OPEN_APPEND) {
+            stdioMode = "a+b";
+        } else {
+            stdioMode = "r+b";
+        }
+    }
+
+    FILE* f = fopen(path, stdioMode);
+    if (!f && (mode & (FA_OPEN_ALWAYS | FA_CREATE_NEW))) {
+        f = fopen(path, "w+b");
+    }
     if (!f) {
         return FR_NO_FILE;
     }
@@ -84,6 +107,14 @@ FRESULT f_write(FIL* fp, const void* buff, UINT btw, UINT* bw)
         *bw = (UINT)n;
     }
     return (n == btw) ? FR_OK : FR_DISK_ERR;
+}
+
+FRESULT f_sync(FIL* fp)
+{
+    if (!fp || !fp->host_fp) {
+        return FR_INVALID_OBJECT;
+    }
+    return fflush((FILE*)fp->host_fp) == 0 ? FR_OK : FR_DISK_ERR;
 }
 
 FRESULT f_lseek(FIL* fp, FSIZE_t ofs)

--- a/integration-tests/harness/framework.cpp
+++ b/integration-tests/harness/framework.cpp
@@ -59,6 +59,7 @@ namespace
         {"test_realimages", "Real disc images"},
         {"test_mdsimages", "MDS/MDF images"},
         {"test_multisession", "Multi-session and CD Extra"},
+        {"test_logdaemon", "File log daemon"},
     };
 
     // "test-suite/test_read10.cpp" -> "SCSI read commands"

--- a/integration-tests/harness/framework.cpp
+++ b/integration-tests/harness/framework.cpp
@@ -60,6 +60,7 @@ namespace
         {"test_mdsimages", "MDS/MDF images"},
         {"test_multisession", "Multi-session and CD Extra"},
         {"test_logdaemon", "File log daemon"},
+        {"test_ftppaths", "FTP path matching"},
     };
 
     // "test-suite/test_read10.cpp" -> "SCSI read commands"

--- a/integration-tests/harness/stubs.cpp
+++ b/integration-tests/harness/stubs.cpp
@@ -43,23 +43,117 @@ CLogger *CLogger::Get(void)
     return &instance;
 }
 
+namespace
+{
+struct LogEvent
+{
+    TLogSeverity severity;
+    std::string source;
+    std::string message;
+};
+
+// Bounded so a long run cannot grow it without limit. The real logger's queue
+// is a fixed ring too; what matters for the tests is that events survive until
+// something drains them.
+const size_t kMaxQueuedEvents = 256;
+
+std::vector<LogEvent> &EventQueue()
+{
+    static std::vector<LogEvent> queue;
+    return queue;
+}
+
+TLogEventNotificationHandler *g_pEventHandler = nullptr;
+TLogPanicHandler *g_pPanicHandler = nullptr;
+} // namespace
+
 void CLogger::Write(const char *pSource, TLogSeverity Severity, const char *pMessage, ...)
 {
     static const bool verbose = getenv("USBODE_TEST_VERBOSE") != nullptr;
+
+    char formatted[LOG_MAX_MESSAGE];
+    va_list var;
+    va_start(var, pMessage);
+    vsnprintf(formatted, sizeof(formatted), pMessage, var);
+    va_end(var);
+
+    // Queue first, and unconditionally: the real logger does not consult any
+    // loglevel here.
+    TestQueueEvent(Severity, pSource, formatted);
+
     if (!verbose)
     {
         return;
     }
 
     static const char *severityNames[] = {"panic", "error", "warn", "note", "debug"};
-    fprintf(stdout, "[%s] %s: ", severityNames[Severity], pSource);
+    fprintf(stdout, "[%s] %s: %s\n", severityNames[Severity], pSource, formatted);
+}
 
-    va_list var;
-    va_start(var, pMessage);
-    vfprintf(stdout, pMessage, var);
-    va_end(var);
+void CLogger::TestQueueEvent(TLogSeverity Severity, const char *pSource, const char *pMessage)
+{
+    std::vector<LogEvent> &queue = EventQueue();
+    if (queue.size() >= kMaxQueuedEvents)
+    {
+        queue.erase(queue.begin());
+    }
+    queue.push_back({Severity, pSource ? pSource : "", pMessage ? pMessage : ""});
 
-    fprintf(stdout, "\n");
+    if (g_pEventHandler != nullptr)
+    {
+        g_pEventHandler();
+    }
+}
+
+void CLogger::TestClearEvents(void)
+{
+    EventQueue().clear();
+}
+
+unsigned CLogger::TestQueuedEventCount(void)
+{
+    return (unsigned)EventQueue().size();
+}
+
+boolean CLogger::ReadEvent(TLogSeverity *pSeverity, char *pSource, char *pMessage,
+                           time_t *pTime, unsigned *pHundredthTime, int *pTimeZone)
+{
+    std::vector<LogEvent> &queue = EventQueue();
+    if (queue.empty())
+    {
+        return FALSE;
+    }
+
+    LogEvent event = queue.front();
+    queue.erase(queue.begin());
+
+    if (pSeverity) *pSeverity = event.severity;
+    if (pSource)
+    {
+        strncpy(pSource, event.source.c_str(), LOG_MAX_SOURCE - 1);
+        pSource[LOG_MAX_SOURCE - 1] = '\0';
+    }
+    if (pMessage)
+    {
+        strncpy(pMessage, event.message.c_str(), LOG_MAX_MESSAGE - 1);
+        pMessage[LOG_MAX_MESSAGE - 1] = '\0';
+    }
+    // A fixed time keeps log lines byte-comparable between runs.
+    if (pTime) *pTime = 0;
+    if (pHundredthTime) *pHundredthTime = 0;
+    if (pTimeZone) *pTimeZone = 0;
+
+    return TRUE;
+}
+
+void CLogger::RegisterEventNotificationHandler(TLogEventNotificationHandler *pHandler)
+{
+    g_pEventHandler = pHandler;
+}
+
+void CLogger::RegisterPanicHandler(TLogPanicHandler *pHandler)
+{
+    g_pPanicHandler = pHandler;
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +195,26 @@ void CScheduler::TestRegisterTask(const char *pName, CTask *pTask)
 void CScheduler::TestClearTasks(void)
 {
     TaskRegistry().clear();
+}
+
+namespace
+{
+unsigned g_nSleepCount = 0;
+}
+
+void CScheduler::TestNoteSleep(void)
+{
+    g_nSleepCount++;
+}
+
+unsigned CScheduler::TestSleepCount(void)
+{
+    return g_nSleepCount;
+}
+
+void CScheduler::TestResetSleepCount(void)
+{
+    g_nSleepCount = 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/integration-tests/harness/stubs/circle/logger.h
+++ b/integration-tests/harness/stubs/circle/logger.h
@@ -7,6 +7,7 @@
 #define _circle_logger_h
 
 #include <circle/types.h>
+#include <time.h>
 
 enum TLogSeverity
 {
@@ -17,12 +18,39 @@ enum TLogSeverity
     LogDebug
 };
 
+// Sizes as declared by the real circle/logger.h, since CFileLogDaemon sizes
+// its own ReadEvent() buffers from them.
+#define LOG_MAX_SOURCE   50
+#define LOG_MAX_MESSAGE  200
+
+typedef void TLogEventNotificationHandler(void);
+typedef void TLogPanicHandler(void);
+
 class CLogger
 {
 public:
     static CLogger *Get(void);
 
     void Write(const char *pSource, TLogSeverity Severity, const char *pMessage, ...);
+
+    // The event queue. The real CLogger queues EVERY event regardless of the
+    // configured loglevel - that only filters the serial and screen targets -
+    // and consumers such as CFileLogDaemon apply their own filter as they
+    // drain. Reproducing that here is the point: a daemon that filtered on the
+    // wrong side of the queue would look correct against a stub that dropped
+    // events itself.
+    boolean ReadEvent(TLogSeverity *pSeverity, char *pSource, char *pMessage,
+                      time_t *pTime, unsigned *pHundredthTime, int *pTimeZone);
+
+    void RegisterEventNotificationHandler(TLogEventNotificationHandler *pHandler);
+    void RegisterPanicHandler(TLogPanicHandler *pHandler);
+
+    // Test-side control. Queue an event as if firmware code had logged it, and
+    // empty the queue between tests so one test's chatter cannot be read by
+    // the next.
+    static void TestQueueEvent(TLogSeverity Severity, const char *pSource, const char *pMessage);
+    static void TestClearEvents(void);
+    static unsigned TestQueuedEventCount(void);
 };
 
 // Match the real Circle logging macros so firmware sources that use

--- a/integration-tests/harness/stubs/circle/sched/scheduler.h
+++ b/integration-tests/harness/stubs/circle/sched/scheduler.h
@@ -17,14 +17,21 @@ public:
 
     CTask *GetTask(const char *pTaskName);
 
-    void Sleep(unsigned nSeconds) {}
-    void MsSleep(unsigned nMilliSeconds) {}
-    void usSleep(unsigned nMicroSeconds) {}
+    // Sleeping cannot actually happen on a single-threaded host build, but it
+    // is counted: on a real Pi a sleep on a per-event path costs the whole
+    // system, and counting is the only way a host test can see that a code
+    // path stopped taking one.
+    void Sleep(unsigned nSeconds) { TestNoteSleep(); }
+    void MsSleep(unsigned nMilliSeconds) { TestNoteSleep(); }
+    void usSleep(unsigned nMicroSeconds) { TestNoteSleep(); }
     void Yield(void) {}
 
     // Test control
     void TestRegisterTask(const char *pName, CTask *pTask);
     void TestClearTasks(void);
+    static void TestNoteSleep(void);
+    static unsigned TestSleepCount(void);
+    static void TestResetSleepCount(void);
 };
 
 #endif

--- a/integration-tests/harness/stubs/circle/sched/synchronizationevent.h
+++ b/integration-tests/harness/stubs/circle/sched/synchronizationevent.h
@@ -4,13 +4,21 @@
 #ifndef _circle_sched_synchronizationevent_h
 #define _circle_sched_synchronizationevent_h
 
+// The state is tracked rather than discarded so a test can tell whether a
+// daemon was woken. Wait() cannot block: the host build is single-threaded and
+// there is no scheduler to yield to, so a task under test is driven one step at
+// a time instead of by running its loop.
 class CSynchronizationEvent
 {
 public:
-    CSynchronizationEvent(void) {}
-    void Set(void) {}
-    void Clear(void) {}
+    CSynchronizationEvent(void) : m_bState(false) {}
+    void Set(void) { m_bState = true; }
+    void Clear(void) { m_bState = false; }
     void Wait(void) {}
+    bool GetState(void) const { return m_bState; }
+
+private:
+    bool m_bState;
 };
 
 #endif

--- a/integration-tests/harness/stubs/circle/sched/task.h
+++ b/integration-tests/harness/stubs/circle/sched/task.h
@@ -6,13 +6,34 @@
 
 #include <circle/types.h>
 
+#include <string.h>
+
 class CTask
 {
 public:
-    CTask(void) {}
+    CTask(void) { m_Name[0] = '\0'; }
     virtual ~CTask(void) {}
 
     virtual void Run(void) {}
+
+    // Circle uses the name to find a task through CScheduler::GetTask(); tasks
+    // that set one are reachable that way, so the stub has to keep it rather
+    // than discard it.
+    void SetName(const char *pName)
+    {
+        if (pName == nullptr)
+        {
+            m_Name[0] = '\0';
+            return;
+        }
+        strncpy(m_Name, pName, sizeof(m_Name) - 1);
+        m_Name[sizeof(m_Name) - 1] = '\0';
+    }
+
+    const char *GetName(void) const { return m_Name; }
+
+private:
+    char m_Name[32];
 };
 
 #endif

--- a/integration-tests/harness/stubs/circle/string.h
+++ b/integration-tests/harness/stubs/circle/string.h
@@ -1,0 +1,13 @@
+//
+// Host-build stub for <circle/string.h>.
+//
+// Circle's CString is not needed by anything the suite compiles - the sources
+// that include this header do so for other declarations that come with it -
+// so this is deliberately empty rather than a partial reimplementation. If a
+// firmware source under test starts using CString, add it here rather than
+// letting the compiler pick up a lookalike from somewhere else.
+//
+#ifndef _circle_string_h
+#define _circle_string_h
+
+#endif

--- a/integration-tests/harness/stubs/circle/time.h
+++ b/integration-tests/harness/stubs/circle/time.h
@@ -1,0 +1,13 @@
+//
+// Host-build stub for <circle/time.h>.
+//
+// Circle declares CTime here and pulls in time_t. Only time_t is used by the
+// sources the suite compiles (it appears in the logger's event signatures), so
+// this hands that straight to the host's own <time.h> instead of restating it.
+//
+#ifndef _circle_time_h
+#define _circle_time_h
+
+#include <time.h>
+
+#endif

--- a/integration-tests/harness/stubs/fatfs/ff.h
+++ b/integration-tests/harness/stubs/fatfs/ff.h
@@ -110,6 +110,7 @@ FRESULT f_open  (FIL* fp, const TCHAR* path, BYTE mode);
 FRESULT f_close (FIL* fp);
 FRESULT f_read  (FIL* fp, void* buff, UINT btr, UINT* br);
 FRESULT f_write (FIL* fp, const void* buff, UINT btw, UINT* bw);
+FRESULT f_sync  (FIL* fp);
 FRESULT f_lseek (FIL* fp, FSIZE_t ofs);
 
 // Directory walk: link-only stubs for mdsfile.cpp (MDS is not under test).

--- a/integration-tests/test-suite/test_cuequirks.cpp
+++ b/integration-tests/test-suite/test_cuequirks.cpp
@@ -19,6 +19,7 @@
 #include "framework.h"
 
 #include <cueparser/cueparser.h>
+#include <cueparser/cueutil.h>
 
 #include <string>
 #include <vector>
@@ -224,8 +225,12 @@ TEST(cue_unstored_pregap_shifts_following_tracks)
 //
 // The parser cannot place these tracks correctly without the real file sizes,
 // and the loader does not have them (it ignores the FILE names and always
-// opens the bin named after the cue). So the guarantee here is the one that
-// can be met today: every track lands somewhere sane on the disc.
+// opens the bin named after the cue). Bounding the arithmetic keeps the
+// addresses sane, but sane is not correct - so the loader refuses these images
+// outright rather than mounting a disc whose TOC is wrong. See
+// multifile_cue_is_detected_so_the_loader_can_refuse_it below; this test still
+// covers the parser, which has to survive the sheet either way because the
+// same parser reads it to make that decision.
 TEST(multifile_cue_does_not_underflow_into_a_nonsense_lba)
 {
     const char *cue =
@@ -261,4 +266,70 @@ TEST(multifile_cue_does_not_underflow_into_a_nonsense_lba)
     const CUETrackInfo *third = parser.next_track();
     CHECK_EQ(third->track_number, 3);
     CHECK_EQ(third->track_start, 150u);
+}
+
+// The check the loader makes before it will open anything. A split-track rip
+// has to be recognised from the cue sheet alone, because by the time the disc
+// is mounted the damage is a wrong TOC rather than a failure.
+//
+// The negative cases matter as much as the positive one: refusing an ordinary
+// single-file cue would make perfectly good images unmountable, and these are
+// the shapes that could fool a scan for the word FILE - a filename containing
+// it, a REM line mentioning it, and a commented-out second FILE.
+TEST(multifile_cue_is_detected_so_the_loader_can_refuse_it)
+{
+    const char *split =
+        "FILE \"Game (Track 1).bin\" BINARY\n"
+        "  TRACK 01 MODE1/2352\n"
+        "    INDEX 01 00:00:00\n"
+        "FILE \"Game (Track 2).bin\" BINARY\n"
+        "  TRACK 02 AUDIO\n"
+        "    INDEX 01 00:00:00\n";
+    CHECK(CueHasMultipleFiles(split));
+
+    const char *single =
+        "FILE \"Game.bin\" BINARY\n"
+        "  TRACK 01 MODE1/2352\n"
+        "    INDEX 01 00:00:00\n"
+        "  TRACK 02 AUDIO\n"
+        "    INDEX 01 04:12:33\n"
+        "  TRACK 03 AUDIO\n"
+        "    INDEX 01 08:24:66\n";
+    CHECK(!CueHasMultipleFiles(single));
+
+    // "FILE" inside the data file's own name.
+    const char *namedFile =
+        "FILE \"MY FILE (1996).bin\" BINARY\n"
+        "  TRACK 01 MODE1/2352\n"
+        "    INDEX 01 00:00:00\n";
+    CHECK(!CueHasMultipleFiles(namedFile));
+
+    // Metadata that mentions a file, and a rem'd-out second FILE line - the
+    // kind of leftover a ripper or a hand edit produces.
+    const char *remmed =
+        "REM ORIGINAL FILE Game.iso\n"
+        "FILE \"Game.bin\" BINARY\n"
+        "  TRACK 01 MODE1/2352\n"
+        "    INDEX 01 00:00:00\n"
+        "REM FILE \"Game (Track 2).bin\" BINARY\n";
+    CHECK(!CueHasMultipleFiles(remmed));
+
+    // A sheet with no tracks at all must not be reported as split; it fails
+    // later, for its own reason.
+    CHECK(!CueHasMultipleFiles(""));
+    CHECK(!CueHasMultipleFiles(nullptr));
+
+    // Three files, and lowercase - keywords are case-insensitive everywhere
+    // else in the parser and have to be here too.
+    const char *lower =
+        "file \"a.bin\" binary\n"
+        "  track 01 audio\n"
+        "    index 01 00:00:00\n"
+        "file \"b.bin\" binary\n"
+        "  track 02 audio\n"
+        "    index 01 00:00:00\n"
+        "file \"c.bin\" binary\n"
+        "  track 03 audio\n"
+        "    index 01 00:00:00\n";
+    CHECK(CueHasMultipleFiles(lower));
 }

--- a/integration-tests/test-suite/test_ftppaths.cpp
+++ b/integration-tests/test-suite/test_ftppaths.cpp
@@ -1,0 +1,94 @@
+//
+// The FTP mounted-image guard is a path comparison, and it has now been wrong
+// twice in a row for the same underlying reason: the same file arrives spelled
+// differently depending on how the client addressed it, and every spelling
+// works for FatFs, so nothing except the comparison itself can notice.
+//
+// ftpworker.cpp cannot be compiled here (it needs the socket stack), so the
+// comparison lives in its own header and is pinned directly.
+//
+#include "framework.h"
+
+#include <ftpserver/fatfspath.h>
+
+// What SCSITBService::GetCurrentCDPath() always reports.
+static const char *kMounted = "1:/Alien Trilogy.cue";
+
+// Every spelling below is a real one produced by the FTP worker, not an
+// invented variation:
+//
+//   "1://x"  RealPath() formats "%s/%s" and m_CurrentPath is "1:/" for the
+//            whole session when the worker auto-enters the images partition
+//            on connect. This is what a plain "DELE x" produces.
+//   "1:x"    FTPPathToFatFsPath() eats the separator after the volume when it
+//            converts an absolute FTP path, and never restores it. This is
+//            what a client sending "/1/x" produces - and it is what defeated
+//            the first fix, which only collapsed duplicate separators.
+TEST(ftp_guard_matches_every_spelling_of_the_mounted_image)
+{
+    CHECK(FatFsPathsEqual("1:/Alien Trilogy.cue", kMounted, 512));
+    CHECK(FatFsPathsEqual("1://Alien Trilogy.cue", kMounted, 512));
+    CHECK(FatFsPathsEqual("1:Alien Trilogy.cue", kMounted, 512));
+    CHECK(FatFsPathsEqual("1:///Alien Trilogy.cue", kMounted, 512));
+
+    // FAT is case-insensitive, so a differently-cased name is the same file
+    // and must not slip past the guard.
+    CHECK(FatFsPathsEqual("1:/ALIEN TRILOGY.CUE", kMounted, 512));
+    CHECK(FatFsPathsEqual("1:alien trilogy.cue", kMounted, 512));
+}
+
+// The guard must not over-reach either: refusing to delete files that are not
+// mounted would be its own bug, and a prefix match would do exactly that.
+TEST(ftp_guard_does_not_match_other_files)
+{
+    CHECK(!FatFsPathsEqual("1:/Alien Trilogy.bin", kMounted, 512));
+    CHECK(!FatFsPathsEqual("1:/Alien Trilogy.cue.bak", kMounted, 512));
+    CHECK(!FatFsPathsEqual("1:/Alien", kMounted, 512));
+    CHECK(!FatFsPathsEqual("1:/Games/Alien Trilogy.cue", kMounted, 512));
+
+    // Same name, different volume: 0: is the boot partition, not images.
+    CHECK(!FatFsPathsEqual("0:/Alien Trilogy.cue", kMounted, 512));
+
+    CHECK(!FatFsPathsEqual(nullptr, kMounted, 512));
+    CHECK(!FatFsPathsEqual("1:/x.cue", nullptr, 512));
+}
+
+// Subfolders are the common case for anyone who organises their images, and
+// the CWD path builds them by a different route than the root case.
+TEST(ftp_guard_handles_paths_in_subfolders)
+{
+    const char *mounted = "1:/Games/RPG/game.cue";
+
+    CHECK(FatFsPathsEqual("1:/Games/RPG/game.cue", mounted, 512));
+    CHECK(FatFsPathsEqual("1://Games/RPG/game.cue", mounted, 512));
+    CHECK(FatFsPathsEqual("1:Games/RPG/game.cue", mounted, 512));
+    CHECK(FatFsPathsEqual("1:/Games//RPG/game.cue", mounted, 512));
+
+    CHECK(!FatFsPathsEqual("1:/Games/RPG2/game.cue", mounted, 512));
+    CHECK(!FatFsPathsEqual("1:/Games/game.cue", mounted, 512));
+}
+
+// Normalization details worth stating outright, since the guard rests on them.
+TEST(fatfs_path_normalization_is_canonical)
+{
+    char out[520];
+
+    NormalizeFatFsPath("1://a//b///c.cue", out, sizeof(out));
+    CHECK(strcmp(out, "1:/a/b/c.cue") == 0);
+
+    NormalizeFatFsPath("1:a/b.cue", out, sizeof(out));
+    CHECK(strcmp(out, "1:/a/b.cue") == 0);
+
+    // A trailing separator names the same directory as none.
+    NormalizeFatFsPath("1:/Games/", out, sizeof(out));
+    CHECK(strcmp(out, "1:/Games") == 0);
+
+    // A bare volume is left alone rather than growing a separator.
+    NormalizeFatFsPath("1:", out, sizeof(out));
+    CHECK(strcmp(out, "1:") == 0);
+
+    // Truncation must still terminate, never run off the buffer.
+    char small[8];
+    NormalizeFatFsPath("1:/averylongname.cue", small, sizeof(small));
+    CHECK(strlen(small) < sizeof(small));
+}

--- a/integration-tests/test-suite/test_logdaemon.cpp
+++ b/integration-tests/test-suite/test_logdaemon.cpp
@@ -1,0 +1,249 @@
+//
+// test_logdaemon.cpp
+//
+// The file log daemon (addon/filelogdaemon/filelogdaemon.cpp), driven on the
+// host through the same FatFs seam the disc-image readers use.
+//
+// The interesting behaviour is not the happy path. A user reported a Pi that
+// had gone slow and had no log file, from a log path of
+// "0:/SD:/usbode-logs.txt" - a value the web form built out of what he typed.
+// Every one of these tests is about what the daemon does when the file it was
+// told to open is not there to open.
+//
+// Run() never returns, so the tests drive DrainOnce(), which is one pass of
+// its loop.
+//
+#include "framework.h"
+
+#include <circle/logger.h>
+#include <circle/sched/scheduler.h>
+#include <fatfs/ff.h>
+#include <filelogdaemon/filelogdaemon.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <new>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::string TestDataDir()
+{
+#ifdef USBODE_TESTDATA
+    return USBODE_TESTDATA;
+#else
+    return "out/images";
+#endif
+}
+
+static void QueueEvents(unsigned n, TLogSeverity severity = LogError)
+{
+    for (unsigned i = 0; i < n; i++) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "event %u", i);
+        CLogger::TestQueueEvent(severity, "test", msg);
+    }
+}
+
+static std::string ReadWholeFile(const std::string &path)
+{
+    FILE *f = fopen(path.c_str(), "rb");
+    if (!f) {
+        return std::string();
+    }
+    std::string out;
+    char buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
+        out.append(buf, n);
+    }
+    fclose(f);
+    return out;
+}
+
+static void RemoveFile(const std::string &path)
+{
+    remove(path.c_str());
+}
+
+// Every test starts from a clean queue: the firmware sources the rest of the
+// suite exercises log freely, and those events sit in the same queue.
+static void ResetLogging()
+{
+    CLogger::TestClearEvents();
+    CScheduler::TestResetSleepCount();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// The headline defect. With no file open every message fails, and the drain
+// loop used to sleep 20 ms for each one - so the log queue retired 50 events a
+// second and took the scheduler down with it. The daemon still has to consume
+// the events (leaving them queued would strand the logger), it just must not
+// pay for them.
+TEST(logdaemon_unopenable_path_drains_without_sleeping)
+{
+    ResetLogging();
+
+    // A directory that does not exist, which is the shape of the reported
+    // value: "SD:/usbode-logs.txt" with "0:/" pasted on the front.
+    const std::string path = TestDataDir() + "/no-such-dir/usbode-logs.txt";
+
+    CFileLogDaemon daemon(path.c_str(), 5);
+    CHECK(!daemon.IsFileLogging());
+    CHECK(daemon.GetOpenResult() != FR_OK);
+
+    // Constructing the daemon logs its own failure, which queues an event.
+    // Clear so the count below is only what this test put there.
+    ResetLogging();
+
+    const unsigned kEvents = 200;
+    QueueEvents(kEvents);
+    CHECK_EQ(CLogger::TestQueuedEventCount(), kEvents);
+
+    daemon.DrainOnce();
+
+    // Consumed, and for free.
+    CHECK_EQ(CLogger::TestQueuedEventCount(), 0u);
+    CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+}
+
+// m_bFileInitialized had no initializer and was not in the constructor's init
+// list, so when the open failed it held whatever was already in that memory.
+// Non-zero meant LogMessage() wrote to an unopened FIL and the destructor
+// closed one.
+//
+// Constructing over poisoned storage is what exposes that. Note what actually
+// catches it, though: the flag is a bool, and reading a bool that holds
+// neither 0 nor 1 is undefined, so an ordinary CHECK cannot be relied on - the
+// optimizer is free to fold the test either way, and at -O1 it does. The pin
+// is the sanitizer build:
+//
+//   make -C integration-tests clean
+//   make -C integration-tests \
+//       CXXFLAGS="-std=c++17 -O0 -g -fsanitize=address,undefined" \
+//       CFLAGS="-O0 -g -fsanitize=address,undefined" \
+//       LDFLAGS="-fsanitize=address,undefined"
+//
+// Remove the initializer and that run reports "load of value 248, which is not
+// a valid value for type 'boolean'" at all three places the flag is read: the
+// IsFileLogging() accessor, LogMessage()'s guard, and the destructor's decision
+// to close the file. What is asserted below is the behaviour that follows from
+// the flag being false - nothing written, nothing closed, no back-off.
+TEST(logdaemon_failed_open_leaves_the_file_flag_false)
+{
+    ResetLogging();
+
+    const std::string path = TestDataDir() + "/no-such-dir/usbode-logs.txt";
+
+    alignas(CFileLogDaemon) static unsigned char storage[sizeof(CFileLogDaemon)];
+    memset(storage, 0xAA, sizeof(storage));
+
+    CFileLogDaemon *daemon = new (storage) CFileLogDaemon(path.c_str(), 5);
+    CHECK(!daemon->IsFileLogging());
+
+    ResetLogging();
+    QueueEvents(4);
+    daemon->DrainOnce();
+    CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+
+    daemon->~CFileLogDaemon();
+}
+
+// An empty path is the config's way of saying "no file logging", not a
+// mistake, so it must not be reported as a failure to open something.
+TEST(logdaemon_empty_path_is_logging_disabled)
+{
+    ResetLogging();
+
+    CFileLogDaemon daemon("", 5);
+    CHECK(!daemon.IsFileLogging());
+    CHECK_EQ(daemon.GetOpenResult(), FR_INVALID_NAME);
+
+    ResetLogging();
+    QueueEvents(16);
+    daemon.DrainOnce();
+    CHECK_EQ(CLogger::TestQueuedEventCount(), 0u);
+    CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+}
+
+// The path that has to keep working: a usable file gets the messages, with the
+// configured level applied on this side of the queue (CLogger queues
+// everything regardless of level, so a daemon that relied on the queue to
+// filter would log too much).
+TEST(logdaemon_writes_and_applies_the_configured_level)
+{
+    ResetLogging();
+
+    const std::string path = TestDataDir() + "/logdaemon.txt";
+    RemoveFile(path);
+
+    {
+        // Level 3 keeps panic(0), error(1) and warning(2); notice(3) and
+        // debug(4) are dropped.
+        CFileLogDaemon daemon(path.c_str(), 3);
+        CHECK(daemon.IsFileLogging());
+        CHECK_EQ(daemon.GetOpenResult(), FR_OK);
+
+        ResetLogging();
+        CLogger::TestQueueEvent(LogError, "src", "an error");
+        CLogger::TestQueueEvent(LogWarning, "src", "a warning");
+        CLogger::TestQueueEvent(LogNotice, "src", "a notice");
+        CLogger::TestQueueEvent(LogDebug, "src", "a debug line");
+        daemon.DrainOnce();
+
+        CHECK_EQ(CLogger::TestQueuedEventCount(), 0u);
+        CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+    }
+
+    const std::string contents = ReadWholeFile(path);
+    CHECK(contents.find("an error") != std::string::npos);
+    CHECK(contents.find("a warning") != std::string::npos);
+    CHECK(contents.find("a notice") == std::string::npos);
+    CHECK(contents.find("a debug line") == std::string::npos);
+
+    RemoveFile(path);
+}
+
+// The daemon kept the caller's pointer rather than the string. It came from
+// the config store, which is free to replace the value while the daemon is
+// still running - and the web UI does exactly that when the log path is
+// edited. Overwrite the caller's buffer and the daemon must be unaffected.
+TEST(logdaemon_keeps_its_own_copy_of_the_path)
+{
+    ResetLogging();
+
+    const std::string path = TestDataDir() + "/logdaemon-copy.txt";
+    RemoveFile(path);
+
+    char caller[256];
+    strncpy(caller, path.c_str(), sizeof(caller) - 1);
+    caller[sizeof(caller) - 1] = '\0';
+
+    {
+        CFileLogDaemon daemon(caller, 5);
+        CHECK(daemon.IsFileLogging());
+
+        // The config store hands out a new value for the key.
+        memset(caller, 0, sizeof(caller));
+        strncpy(caller, "0:/somewhere-else.txt", sizeof(caller) - 1);
+
+        CHECK(strcmp(daemon.GetLogFilePath(), path.c_str()) == 0);
+
+        ResetLogging();
+        CLogger::TestQueueEvent(LogError, "src", "still the original file");
+        daemon.DrainOnce();
+        CHECK_EQ(CScheduler::TestSleepCount(), 0u);
+    }
+
+    const std::string contents = ReadWholeFile(path);
+    CHECK(contents.find("still the original file") != std::string::npos);
+
+    RemoveFile(path);
+}

--- a/integration-tests/test-suite/test_logdaemon.cpp
+++ b/integration-tests/test-suite/test_logdaemon.cpp
@@ -211,6 +211,61 @@ TEST(logdaemon_writes_and_applies_the_configured_level)
     RemoveFile(path);
 }
 
+// What the web UI shows. The boot-time warning about a path that will not open
+// goes to the serial console, and a SCREEN_HEADLESS build has nowhere else to
+// put it - so if the config page does not say this, a user with a bad path sees
+// a device that lists a log file and silently has none. Found by David testing
+// exactly that case and reporting "didn't see any warning".
+TEST(logdaemon_reports_its_status_for_the_web_ui)
+{
+    ResetLogging();
+    char status[256];
+
+    // Working.
+    const std::string good = TestDataDir() + "/logdaemon-status.txt";
+    RemoveFile(good);
+    {
+        CFileLogDaemon daemon(good.c_str(), 5);
+        CHECK(daemon.IsFileLogging());
+        daemon.GetStatusText(status, sizeof(status));
+        CHECK(strstr(status, "Writing to") != nullptr);
+        CHECK(strstr(status, "NOT LOGGING") == nullptr);
+    }
+    RemoveFile(good);
+
+    // Broken: has to name the path and say it is not logging, because that is
+    // the whole message.
+    ResetLogging();
+    const std::string bad = TestDataDir() + "/no-such-dir/usbode-logs.txt";
+    {
+        CFileLogDaemon daemon(bad.c_str(), 5);
+        CHECK(!daemon.IsFileLogging());
+        daemon.GetStatusText(status, sizeof(status));
+        CHECK(strstr(status, "NOT LOGGING") != nullptr);
+        CHECK(strstr(status, "usbode-logs.txt") != nullptr);
+    }
+
+    // Off on purpose is not an error and must not read like one.
+    ResetLogging();
+    {
+        CFileLogDaemon daemon("", 5);
+        daemon.GetStatusText(status, sizeof(status));
+        CHECK(strstr(status, "off") != nullptr);
+        CHECK(strstr(status, "NOT LOGGING") == nullptr);
+    }
+
+    // The log viewer opens the file through newlib, which wants an ordinary
+    // path rather than the FatFs volume form the config stores. It used to
+    // hardcode "/usbode-logs.txt" and show a blank page for any other setting.
+    ResetLogging();
+    {
+        CFileLogDaemon daemon("0:/somewhere/usbode-log.txt", 5);
+        char path[256];
+        daemon.GetStdioPath(path, sizeof(path));
+        CHECK(strcmp(path, "/somewhere/usbode-log.txt") == 0);
+    }
+}
+
 // The daemon kept the caller's pointer rather than the string. It came from
 // the config store, which is free to replace the value while the daemon is
 // still running - and the web UI does exactly that when the log path is

--- a/integration-tests/test-suite/test_mdsimages.cpp
+++ b/integration-tests/test-suite/test_mdsimages.cpp
@@ -1015,6 +1015,235 @@ TEST(mds_unstored_pregap_reads_as_zeros)
     delete disc;
 }
 
+// The gap handling above can only work if the reader knows which frame it is
+// on, and it did not always know. Seek() decided it was already in position by
+// comparing Tell() - a PHYSICAL offset into the MDF - against the LOGICAL disc
+// offset it was asked for, and took an early exit without recording the LBA.
+// Read() then keyed its gap check off whatever LBA was left over from before.
+//
+// The two tests below are the same defect reached from opposite directions,
+// and neither is exotic: each one is what an ordinary host produces when it
+// reads a file that happens to end on a frame boundary.
+//
+// The fixture above does not catch this because every read in it jumps to a
+// new address, so the physical and logical offsets never coincide.
+TEST(mds_gap_reached_by_a_sequential_read_still_reads_as_zeros)
+{
+    // On a contiguous 2352-byte image the physical and logical offsets are the
+    // same number for every frame, so reading the last stored frame of a track
+    // leaves the file pointer exactly at the logical offset of the first frame
+    // of the hole - and the early exit fires on the very next read.
+    const u32 kTrack1Len = 16;  // LBA 0..15; the file's next frame is the ISO PVD
+    const u32 kGap = 150;
+    const u32 kTrack2LBA = kTrack1Len + kGap;
+    const u32 kTrack2Len = 16;
+
+    std::vector<u8> raw = RawMode1Sectors(kIso, 0, kTrack1Len + kTrack2Len);
+    CHECK_EQ(raw.size(), (size_t)(kTrack1Len + kTrack2Len) * 2352);
+    if (raw.size() != (size_t)(kTrack1Len + kTrack2Len) * 2352) {
+        return;
+    }
+
+    const std::string mds = TestDataDir() + "/mdsgapseq.mds";
+    const std::string mdf = TestDataDir() + "/mdsgapseq.mdf";
+    WriteBytes(mdf, raw);
+
+    MdsTrackSpec t1;
+    t1.mode = 0xAA;
+    t1.point = 1;
+    t1.sectorSize = 2352;
+    t1.startSector = 0;
+    t1.startOffset = 0;
+    t1.length = kTrack1Len;
+
+    MdsTrackSpec t2;
+    t2.mode = 0xAA;
+    t2.point = 2;
+    t2.sectorSize = 2352;
+    t2.startSector = kTrack2LBA;                 // 150 frames later on the disc
+    t2.startOffset = (u64)kTrack1Len * 2352;     // but straight after in the file
+    t2.pregap = kGap;
+    t2.length = kTrack2Len;
+
+    WriteMdsFile(mds, {t1, t2}, "mdsgapseq.mdf");
+
+    CMDSFileDevice *disc = OpenMds(mds);
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    auto read = [&bench](u32 lba, u32 blocks) {
+        const u8 cdb[10] = {0x28, 0, (u8)(lba >> 24), (u8)(lba >> 16), (u8)(lba >> 8), (u8)lba,
+                            0, (u8)(blocks >> 8), (u8)blocks, 0};
+        return bench.SendCommand(cdb, sizeof(cdb), blocks * 2048);
+    };
+
+    // Walk up to the last stored frame of track 1. This read is the setup: it
+    // is what parks the file pointer on the boundary.
+    auto last = read(kTrack1Len - 1, 1);
+    CHECK_EQ(last.csw.bmCSWStatus, 0);
+
+    // The next frame is the hole, and it has to read as zeros. Serving the
+    // file pointer instead is unmistakable here: the bytes sitting there are
+    // track 2's primary volume descriptor.
+    auto gap = read(kTrack1Len, 1);
+    CHECK_EQ(gap.csw.bmCSWStatus, 0);
+    CHECK_EQ(gap.data.size(), (size_t)2048);
+    if (gap.data.size() == 2048) {
+        CHECK(memcmp(gap.data.data() + 1, "CD001", 5) != 0);
+        for (size_t i = 0; i < 2048; i++) {
+            if (gap.data[i] != 0) {
+                char msg[128];
+                snprintf(msg, sizeof(msg),
+                         "gap frame LBA %u: byte %zu is 0x%02x, expected the hole to read as zeros",
+                         kTrack1Len, i, gap.data[i]);
+                ReportFailure(__FILE__, __LINE__, msg);
+                break;
+            }
+        }
+    }
+
+    // Track 2 itself still resolves, so the fix cannot have been to stop
+    // trusting start_offset.
+    auto t2read = read(kTrack2LBA, 1);
+    CHECK_EQ(t2read.csw.bmCSWStatus, 0);
+    if (t2read.data.size() == 2048) {
+        CHECK(memcmp(t2read.data.data() + 1, "CD001", 5) == 0);
+    }
+
+    // The same defect without a Seek() to trigger it. Reading on from where
+    // the last read finished is a caller the gadget does not currently
+    // produce - it seeks before every batch - but it is what the reader now
+    // says it supports, and the plain path is the only one of the three that
+    // used to leave the position behind. Two frames of track 1, then straight
+    // on into the hole.
+    CHECK_EQ(disc->Seek((u64)(kTrack1Len - 2) * 2352), (u64)(kTrack1Len - 2) * 2352);
+    std::vector<u8> twoFrames(2 * 2352);
+    CHECK_EQ(disc->Read(twoFrames.data(), twoFrames.size()), (int)twoFrames.size());
+
+    std::vector<u8> nextFrame(2352, 0xAA);
+    CHECK_EQ(disc->Read(nextFrame.data(), nextFrame.size()), (int)nextFrame.size());
+    for (size_t i = 0; i < nextFrame.size(); i++) {
+        if (nextFrame[i] != 0) {
+            char msg[128];
+            snprintf(msg, sizeof(msg),
+                     "read on into the hole: byte %zu is 0x%02x, expected zeros",
+                     i, nextFrame[i]);
+            ReportFailure(__FILE__, __LINE__, msg);
+            break;
+        }
+    }
+
+    delete disc;
+}
+
+// The two operations that reach a hole by a route other than a whole-frame
+// READ(10), driven against the reader directly because no host command
+// produces them on this geometry.
+//
+// Both used to be the odd one out. A read shorter than a frame skipped the gap
+// check on its size alone and returned whatever the file pointer was resting
+// on, and ReadSubchannel() failed outright on a frame that Seek() and Read()
+// were both willing to answer with zeros - so a subchannel request spanning a
+// track boundary was the one operation a sparse image still could not serve.
+TEST(mds_gap_answers_short_reads_and_subchannel_requests_too)
+{
+    const u32 kTrack1Len = 16;
+    const u32 kGap = 150;
+    const u32 kTrack2LBA = kTrack1Len + kGap;
+    const u32 kTrack2Len = 16;
+    const u32 kTotal = kTrack2LBA + kTrack2Len;
+
+    std::vector<u8> raw = RawMode1Sectors(kIso, 0, kTrack1Len + kTrack2Len);
+    if (raw.empty()) {
+        CHECK(false);
+        return;
+    }
+    // Subchannel bytes on both stored tracks, so the hole is the only place a
+    // request can come back empty.
+    std::vector<u8> image((size_t)(kTrack1Len + kTrack2Len) * 2448);
+    for (u32 i = 0; i < kTrack1Len + kTrack2Len; i++) {
+        memcpy(image.data() + (size_t)i * 2448, raw.data() + (size_t)i * 2352, 2352);
+        for (u32 j = 0; j < 96; j++) {
+            image[(size_t)i * 2448 + 2352 + j] = SubchannelByte(i, j);
+        }
+    }
+
+    const std::string mds = TestDataDir() + "/mdsgapsub.mds";
+    const std::string mdf = TestDataDir() + "/mdsgapsub.mdf";
+    WriteBytes(mdf, image);
+
+    MdsTrackSpec t1;
+    t1.mode = 0xAA;
+    t1.subchannel = 0x08;
+    t1.point = 1;
+    t1.sectorSize = 2448;
+    t1.startSector = 0;
+    t1.startOffset = 0;
+    t1.length = kTrack1Len;
+
+    MdsTrackSpec t2;
+    t2.mode = 0xAA;
+    t2.subchannel = 0x08;
+    t2.point = 2;
+    t2.sectorSize = 2448;
+    t2.startSector = kTrack2LBA;
+    t2.startOffset = (u64)kTrack1Len * 2448;
+    t2.pregap = kGap;
+    t2.length = kTrack2Len;
+
+    WriteMdsFile(mds, {t1, t2}, "mdsgapsub.mdf");
+
+    CMDSFileDevice *disc = OpenMds(mds);
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    // A stored frame's subchannel still comes back as itself.
+    u8 sub[96];
+    memset(sub, 0xAA, sizeof(sub));
+    CHECK_EQ(disc->ReadSubchannel(kTrack1Len - 1, sub), 96);
+    u8 expected[96];
+    for (u32 i = 0; i < 96; i++) {
+        expected[i] = SubchannelByte(kTrack1Len - 1, i);
+    }
+    CHECK_BYTES(sub, sizeof(sub), expected, sizeof(expected));
+
+    // A frame in the hole answers with zeros rather than failing.
+    memset(sub, 0xAA, sizeof(sub));
+    CHECK_EQ(disc->ReadSubchannel(kTrack1Len, sub), 96);
+    u8 zeros[96];
+    memset(zeros, 0, sizeof(zeros));
+    CHECK_BYTES(sub, sizeof(sub), zeros, sizeof(zeros));
+
+    // Past the disc is still an error, not another hole.
+    CHECK_EQ(disc->ReadSubchannel(kTotal + 4, sub), -1);
+
+    // A read of less than one frame, landing in the hole.
+    u8 partial[2048];
+    memset(partial, 0xAA, sizeof(partial));
+    CHECK_EQ(disc->Seek((u64)kTrack1Len * 2352), (u64)kTrack1Len * 2352);
+    CHECK_EQ(disc->Read(partial, sizeof(partial)), (int)sizeof(partial));
+    for (size_t i = 0; i < sizeof(partial); i++) {
+        if (partial[i] != 0) {
+            char msg[128];
+            snprintf(msg, sizeof(msg),
+                     "short read in the hole: byte %zu is 0x%02x, expected zeros",
+                     i, partial[i]);
+            ReportFailure(__FILE__, __LINE__, msg);
+            break;
+        }
+    }
+
+    delete disc;
+}
+
 // ---------------------------------------------------------------------------
 // Subchannel images (2448-byte sectors)
 // ---------------------------------------------------------------------------
@@ -1136,6 +1365,96 @@ TEST(mds_subchannel_image_strips_and_exposes_subchannel_data)
         }
         CHECK_BYTES(batch.data.data(), batch.data.size(), expected.data(), expected.size());
     }
+}
+
+// The other direction onto the same defect, and the reason it survived the
+// gap fix: on a 2448-byte image the physical and logical offsets advance at
+// different rates, so they are equal only at frames where lba * 2448 is
+// divisible by 2352 - every 49th frame, since 2448/48 = 51 and 2352/48 = 49.
+// Read up to frame 48 and the file pointer sits at 49 * 2448 = 119952, which
+// is also 51 * 2352. A host that then reads LBA 51 hits the early exit, the
+// LBA stays at 49, and the reader serves frame 49 while reporting success.
+//
+// Nothing about that read order is unusual - it is one ordinary seek after one
+// ordinary sequential run - and there is such a coincidence point every 49
+// frames across the whole disc.
+TEST(mds_subchannel_seek_after_a_read_does_not_serve_a_stale_frame)
+{
+    const u32 nSectors = 64;
+    const u32 kSetupLBA = 48;   // leaves the file pointer at 49 * 2448
+    const u32 kTargetLBA = 51;  // whose logical offset is the same 119952
+    static_assert(kSetupLBA + 1 == 49 && 49 * 2448 == 51 * 2352,
+                  "the coincidence this test relies on");
+
+    const std::string mds = TestDataDir() + "/mdsstale.mds";
+    const std::string mdf = TestDataDir() + "/mdsstale.mdf";
+
+    std::vector<u8> raw = RawMode1Sectors(kIso, 0, nSectors);
+    if (raw.empty()) {
+        CHECK(false);
+        return;
+    }
+    std::vector<u8> image((size_t)nSectors * 2448);
+    for (u32 lba = 0; lba < nSectors; lba++) {
+        memcpy(image.data() + (size_t)lba * 2448, raw.data() + (size_t)lba * 2352, 2352);
+        for (u32 i = 0; i < 96; i++) {
+            image[(size_t)lba * 2448 + 2352 + i] = SubchannelByte(lba, i);
+        }
+    }
+    // Past the ISO's system area every frame here would otherwise be zeros,
+    // which cannot tell a stale frame from the right one. Stamp each frame's
+    // user data with its own LBA so a misread names the frame it came from.
+    for (u32 lba = 0; lba < nSectors; lba++) {
+        u8 *user = image.data() + (size_t)lba * 2448 + 16;
+        for (u32 i = 0; i < 2048; i++) {
+            user[i] = (u8)(lba * 7u + i * 3u + 11u);
+        }
+        memcpy(raw.data() + (size_t)lba * 2352 + 16, user, 2048);
+    }
+    WriteBytes(mdf, image);
+
+    MdsTrackSpec track;
+    track.mode = 0xAA;
+    track.subchannel = 0x08;
+    track.point = 1;
+    track.sectorSize = 2448;
+    track.length = nSectors;
+    WriteMdsFile(mds, {track}, "mdsstale.mdf");
+
+    CMDSFileDevice *disc = OpenMds(mds);
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    auto read = [&bench](u32 lba) {
+        const u8 cdb[10] = {0x28, 0, (u8)(lba >> 24), (u8)(lba >> 16), (u8)(lba >> 8), (u8)lba,
+                            0, 0, 1, 0};
+        return bench.SendCommand(cdb, sizeof(cdb), 2048);
+    };
+    auto expectFrame = [&raw](const std::vector<u8> &d, u32 lba) {
+        if (d.size() != 2048) {
+            return;
+        }
+        u8 expected[2048];
+        memcpy(expected, raw.data() + (size_t)lba * 2352 + 16, 2048);
+        CHECK_BYTES(d.data(), d.size(), expected, sizeof(expected));
+    };
+
+    auto setup = read(kSetupLBA);
+    CHECK_EQ(setup.csw.bmCSWStatus, 0);
+    expectFrame(setup.data, kSetupLBA);
+
+    auto target = read(kTargetLBA);
+    CHECK_EQ(target.csw.bmCSWStatus, 0);
+    CHECK_EQ(target.data.size(), (size_t)2048);
+    expectFrame(target.data, kTargetLBA);
+
+    delete disc;
 }
 
 // READ CD (0xBE) asking for the subchannel data alongside the user data.

--- a/integration-tests/test-suite/test_mediachange.cpp
+++ b/integration-tests/test-suite/test_mediachange.cpp
@@ -176,3 +176,56 @@ TEST(gesn_async_notification_unsupported)
     CHECK_EQ(s.data[12], 0x24); // INVALID FIELD IN CDB
     CHECK_EQ(s.data[13], 0x00);
 }
+
+// Adopting an image while the drive is ejected must leave it ejected.
+//
+// This is the "saved image went missing" path: a stand-in image is loaded so
+// the gadget has a geometry, with the boot-eject armed so the host still sees
+// an empty drive. It worked at boot and silently failed at runtime, because at
+// boot m_pDevice is null and SetDevice() therefore arms no disc swap - whereas
+// replacing a device on a running system does, and Update() drove
+// NO_MEDIUM -> UNIT_ATTENTION without ever consulting the ejected latch. The
+// stand-in appeared in the host 100 ms later, so a renamed image looked like
+// it had simply been swapped for a different game.
+TEST(adopting_an_image_while_ejected_stays_ejected)
+{
+    CFakeImageDevice *discA = MakeDataISO(500);
+    CGadgetTestBench bench(discA);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Sanity: disc A is really readable before we eject.
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 0);
+
+    // Arm the boot-eject and adopt a stand-in, exactly as ProcessPendingMount
+    // does when the remembered image is no longer on the card.
+    bench.gadget->ArmBootEject();
+    CFakeImageDevice *standIn = MakeDataISO(1500);
+    bench.gadget->SetDevice(standIn);
+
+    // Empty drive: TEST UNIT READY fails with NOT READY / MEDIUM NOT PRESENT.
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+
+    // Now let the swap settle window elapse several times over. Nothing here
+    // may put the stand-in into the drive.
+    for (int i = 0; i < 5; i++)
+        SettleDiscSwap(bench);
+
+    CHECK(bench.gadget->IsEjected());
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 1);
+    {
+        auto s = bench.RequestSense();
+        CHECK(s.data.size() >= 14);
+        CHECK_EQ(s.data[2], 0x02);  // NOT READY
+        CHECK_EQ(s.data[12], 0x3a); // MEDIUM NOT PRESENT
+    }
+    // And no data can be read out of a drive the user was told is empty.
+    CHECK_EQ(Read10LBA0(bench).csw.bmCSWStatus, 1);
+
+    // A deliberate insert still works - the drive is empty, not broken.
+    bench.gadget->Insert();
+    for (int i = 0; i < 5; i++)
+        SettleDiscSwap(bench);
+    bench.RequestSense(); // clear the medium-changed UNIT ATTENTION
+    CHECK_EQ(TestUnitReady(bench).csw.bmCSWStatus, 0);
+}

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -43,7 +43,6 @@
 #define FIRMWARE_PATH ROOTDRIVE "/firmware/"
 #define SUPPLICANT_CONFIG_FILE ROOTDRIVE "/wpa_supplicant.conf"
 #define CONFIG_FILE ROOTDRIVE "/config.txt"
-#define LOG_FILE ROOTDRIVE "/logfile.txt"
 #define HOSTNAME "usbode"
 #define SPI_MASTER_DEVICE 0
 
@@ -142,13 +141,25 @@ boolean CKernel::Initialize(void)
             m_pConfigService = new ConfigService();
             LOGNOTE("Initialized Config service");
 
-            // Start file logging with proper config
+            // Start file logging with proper config. Whether the file opened
+            // has to be reported: the daemon runs either way, so a path that
+            // cannot be opened leaves a system that looks fine and logs
+            // nothing, and the user's only clue is the missing file. Only
+            // volume 0: is mounted at this point (1: comes later, below), so a
+            // path anywhere else fails here by design.
             const char *logfile = m_pConfigService->GetLogfile();
-            if (logfile)
+            CFileLogDaemon *pLogDaemon =
+                new CFileLogDaemon(logfile ? logfile : "", m_pConfigService->GetLogLevel());
+            if (pLogDaemon->IsFileLogging())
             {
-                new CFileLogDaemon(logfile, m_pConfigService->GetLogLevel());
-                // CScheduler::Get()->MsSleep(100);
-                LOGNOTE("Started early file logging");
+                LOGNOTE("Started early file logging to %s", pLogDaemon->GetLogFilePath());
+            }
+            else if (pLogDaemon->GetLogFilePath()[0] != '\0')
+            {
+                LOGWARN("File logging is OFF: cannot open '%s' (FatFs error %d). "
+                        "Check the log path on the web UI's config page; it must be "
+                        "a file in an existing directory on the boot partition.",
+                        pLogDaemon->GetLogFilePath(), (int)pLogDaemon->GetOpenResult());
             }
         }
     }


### PR DESCRIPTION
This collects the work from yesterday into a single branch instead of six. It is 13 commits on top of main (558bf4e), rebased clean with no merge commits. Tested on hardware: ran on a Pi yesterday, stable, no lockups.

**Mounting and cue handling**

A cue sheet that splits its tracks across several files used to mount anyway, and the drive would come up with the wrong disc in it. It is now refused outright. Along with that, the mount path stopped reporting success when the image had actually failed to load, and it now says what the mount did rather than just that the filename was found. When an image cannot be mounted, the reason is shown to the user instead of being swallowed. Saved images that have gone missing now leave the drive empty rather than quietly substituting a different disc, and an ejected drive no longer puts a disc back in by itself. The file browser also stopped listing .bin files, which were never mountable on their own.

**Logging**

A bad log file path could take the whole system down with it. It cannot now. The web UI shows whether file logging is actually working, and the config page describes the path rule that the form enforces.

**FTP**

Deleting, renaming or overwriting the currently mounted image is now refused.

**MDS**

The reader tracks its read position directly instead of inferring it from the file pointer.

**Hot path**

Removed the log line that fired on every SCSI read.

**Tests**

The host regression suite passes at 162 tests, 0 failures, including two new groups added here: FTP path matching, and file log daemon.
