### PR TITLE
cue: synthesize the multisession gap across a FILE boundary

### DIFF
--- a/addon/cueparser/cueparser.cpp
+++ b/addon/cueparser/cueparser.cpp
@@ -73,10 +73,17 @@ const CUETrackInfo *CUEParser::next_track() {
     return next_track(prev_file_size);
 }
 
+// Orange Book: 90 seconds of lead-out (6750 frames) then 60 seconds of
+// lead-in (4500) separate one session's content from the next session's.
+static const uint32_t kSessionGapFrames = 11250;
+static const uint32_t kTrackPregapFrames = 150;
+
 const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size) {
     // Previous track info is needed to track file offset
     m_track_info.cumulative_offset += m_track_info.unstored_pregap_length;
     uint32_t prev_sector_length = get_sector_length(m_track_info.file_mode, m_track_info.track_mode);  // Defaults to 2352 before first track
+    int prev_session = m_track_info.session;  // 0 before the first track
+    uint32_t session_gap = 0;
 
     bool got_file = false;
     bool got_track = false;
@@ -127,6 +134,10 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size) {
             m_track_info.track_mode = parse_track_mode(skip_space(endptr));
             m_track_info.sector_length = get_sector_length(m_track_info.file_mode, m_track_info.track_mode);
             m_track_info.session = m_current_session;
+            // A session boundary that is also a FILE boundary: the new file's
+            // INDEX times restart at 0, so the gap has to be synthesized.
+            if (got_file && prev_session > 0 && m_current_session > prev_session)
+                session_gap = kSessionGapFrames;
             m_track_info.prev_session_leadout = m_pending_leadout;
             m_pending_leadout = 0;
             m_track_info.unstored_pregap_length = 0;
@@ -182,6 +193,22 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size) {
     if (got_data && !got_pause) {
         m_track_info.track_start = m_track_info.data_start;
         m_track_info.data_start += m_track_info.unstored_pregap_length;
+    }
+
+    if (session_gap != 0 && got_track && got_data) {
+        // Disc addresses only: file_start and file_offset stay untouched, so
+        // the new session's INDEX 01 still resolves to offset 0 of its file.
+        m_track_info.cumulative_offset += session_gap;
+        m_track_info.track_start += session_gap;
+        m_track_info.data_start += session_gap;
+
+        // A pregap the sheet states is already in the addresses above. One it
+        // does not state is unstored, and the track still has to have one.
+        bool stored_pregap = got_pause && index01_time > index00_time;
+        if (!stored_pregap && m_track_info.unstored_pregap_length == 0) {
+            m_track_info.unstored_pregap_length = kTrackPregapFrames;
+            m_track_info.data_start += kTrackPregapFrames;
+        }
     }
 
     if (got_track && got_data) {

--- a/addon/discimage/cuebinfile.cpp
+++ b/addon/discimage/cuebinfile.cpp
@@ -55,6 +55,7 @@ CCueBinFileDevice::CCueBinFileDevice(FIL *pFile, char *cue_str, MEDIA_TYPE media
         m_Files[0].nSize = f_size(m_pFile);
         m_FileSizes[0] = m_Files[0].nSize;
         m_nFileCount = 1;
+        m_nVirtualSize = m_Files[0].nSize;
         FatFsOptimizer::EnableFastSeek(m_pFile, &m_Files[0].pCLMT, 256, "BIN/ISO: ");
         m_nLogicalPos = f_tell(m_pFile);
     }
@@ -97,13 +98,21 @@ bool CCueBinFileDevice::AddDataFile(FIL *pFile) {
         return false;
     }
 
-    DataFile &prev = m_Files[m_nFileCount - 1];
     DataFile &next = m_Files[m_nFileCount];
     next.pFile = pFile;
-    next.nBase = prev.nBase + prev.nSize;
     next.nSize = f_size(pFile);
     m_FileSizes[m_nFileCount] = next.nSize;
     m_nFileCount++;
+
+    // On rejection the file was never adopted: the caller still owns and closes
+    // it, so drop it here or the destructor closes it a second time.
+    if (!RebuildLayout()) {
+        next.pFile = nullptr;
+        next.nSize = 0;
+        m_FileSizes[--m_nFileCount] = 0;
+        RebuildLayout();
+        return false;
+    }
 
     // Without a link map every seek walks the FAT chain and stalls playback.
     if (!FatFsOptimizer::EnableFastSeek(pFile, &next.pCLMT, 256, "BIN/ISO split: ")) {
@@ -112,13 +121,141 @@ bool CCueBinFileDevice::AddDataFile(FIL *pFile) {
     return true;
 }
 
+namespace {
+
+// Where one file's stored frames begin and end on the disc.
+struct FileFrameExtent {
+    u32 nStartLBA = 0;
+    u32 nEndLBA = 0;
+    u32 nSectorLength = 0;
+    bool bValid = false;
+};
+
+}  // namespace
+
+// A boundary this cannot represent must not become a contiguous one: abutting
+// the files is exactly the aliasing that unbacked frames have to avoid.
+bool CCueBinFileDevice::RebuildLayout() {
+    if (m_nFileCount <= 1) {
+        m_nSparseCount = 0;
+        m_Files[0].nBase = 0;
+        m_nVirtualSize = (m_nFileCount == 1) ? m_Files[0].nSize : 0;
+        return true;
+    }
+
+    if (m_cue_str == nullptr) {
+        LOGERR("Split image has %d files and no cue sheet", m_nFileCount);
+        return false;
+    }
+
+    FileFrameExtent extents[MaxDataFiles];
+    CUEParser parser(m_cue_str);
+    const CUETrackInfo *track = nullptr;
+    int prevFileIndex = 0;
+    while ((track = parser.next_track(prevFileIndex >= 1 && prevFileIndex <= m_nFileCount
+                                          ? m_FileSizes[prevFileIndex - 1]
+                                          : 0)) != nullptr) {
+        prevFileIndex = track->file_index;
+        int f = track->file_index - 1;
+        if (f < 0 || f >= m_nFileCount) {
+            continue;  // a file the cue names but the loader has not opened yet
+        }
+        if (track->sector_length == 0) {
+            LOGERR("File %d track %d has no sector length", f, track->track_number);
+            return false;
+        }
+
+        u32 headFrames = (u32)(track->file_offset / track->sector_length);
+        FileFrameExtent &ext = extents[f];
+        if (!ext.bValid) {
+            if (track->data_start < headFrames) {
+                LOGERR("File %d starts at frame %lu, under its offset of %lu frames",
+                       f, (unsigned long)track->data_start, (unsigned long)headFrames);
+                return false;
+            }
+            ext.nStartLBA = track->data_start - headFrames;
+            ext.bValid = true;
+        }
+
+        // The last track of a file owns its tail, so this keeps overwriting.
+        ext.nSectorLength = track->sector_length;
+        const u64 size = m_FileSizes[f];
+        ext.nEndLBA = (size > track->file_offset)
+                          ? track->data_start +
+                                (u32)((size - track->file_offset) / track->sector_length)
+                          : track->data_start;
+    }
+
+    // Staged, so a rejected boundary leaves the previous layout in place.
+    u64 bases[MaxDataFiles];
+    SparseRange holes[MaxDataFiles];
+    int holeCount = 0;
+    u64 base = 0;
+
+    for (int i = 0; i < m_nFileCount; i++) {
+        if (!extents[i].bValid) {
+            LOGERR("File %d is open but no cue track places it", i);
+            return false;
+        }
+        if (base > (u64)-1 - m_Files[i].nSize) {
+            LOGERR("File %d overflows the address space at base %llu", i, base);
+            return false;
+        }
+        bases[i] = base;
+        base += m_Files[i].nSize;
+
+        if (i + 1 >= m_nFileCount || extents[i + 1].nStartLBA <= extents[i].nEndLBA) {
+            continue;  // last file, contiguous, or a cue that overlaps its files
+        }
+
+        u32 frames = extents[i + 1].nStartLBA - extents[i].nEndLBA;
+        if (frames > MaxGapFrames || extents[i].nSectorLength == 0) {
+            LOGERR("Unbacked gap of %lu frames before file %d cannot be represented",
+                   (unsigned long)frames, i + 1);
+            return false;
+        }
+
+        SparseRange &hole = holes[holeCount++];
+        hole.nStartLBA = extents[i].nEndLBA;
+        hole.nEndLBA = extents[i + 1].nStartLBA;
+        hole.nSectorLength = extents[i].nSectorLength;
+        hole.nLength = (u64)frames * hole.nSectorLength;
+        hole.nBase = base;
+        if (base > (u64)-1 - hole.nLength) {
+            LOGERR("Gap before file %d overflows the address space", i + 1);
+            return false;
+        }
+        base += hole.nLength;
+    }
+
+    for (int i = 0; i < m_nFileCount; i++) {
+        m_Files[i].nBase = bases[i];
+    }
+    for (int i = 0; i < holeCount; i++) {
+        m_Sparse[i] = holes[i];
+    }
+    m_nSparseCount = holeCount;
+    m_nVirtualSize = base;
+    return true;
+}
+
 int CCueBinFileDevice::FileIndexForOffset(u64 nOffset) const {
     for (int i = 0; i < m_nFileCount; i++) {
-        if (nOffset < m_Files[i].nBase + m_Files[i].nSize) {
+        if (nOffset >= m_Files[i].nBase && nOffset < m_Files[i].nBase + m_Files[i].nSize) {
             return i;
         }
     }
     return -1;
+}
+
+u64 CCueBinFileDevice::SparseBytesAt(u64 nOffset) const {
+    for (int i = 0; i < m_nSparseCount; i++) {
+        const SparseRange &hole = m_Sparse[i];
+        if (nOffset >= hole.nBase && nOffset < hole.nBase + hole.nLength) {
+            return hole.nBase + hole.nLength - nOffset;
+        }
+    }
+    return 0;
 }
 
 int CCueBinFileDevice::Read(void *pBuffer, size_t nSize) {
@@ -160,6 +297,17 @@ int CCueBinFileDevice::ReadWithinFile(void *pBuffer, size_t nSize) {
 
     int nFile = FileIndexForOffset(m_nLogicalPos);
     if (nFile < 0) {
+        // In a hole no .bin is opened, seeked or cached: the frames are
+        // digital silence, which is what a single-.bin rip stores there.
+        u64 nHole = SparseBytesAt(m_nLogicalPos);
+        if (nHole > 0) {
+            if (nSize > nHole) {
+                nSize = (size_t)nHole;
+            }
+            memset(pBuffer, 0, nSize);
+            m_nLogicalPos += nSize;
+            return (int)nSize;
+        }
         if (m_nLogicalPos == GetSize()) {
             return 0;
         }
@@ -282,6 +430,15 @@ u64 CCueBinFileDevice::GetByteOffsetForLBA(u32 lba) const {
         return CueLBAToByteOffset(m_cue_str, lba);
     }
 
+    // A frame no .bin stores answers inside its hole, so the read that follows
+    // sees zeros rather than the next file's first bytes.
+    for (int i = 0; i < m_nSparseCount; i++) {
+        const SparseRange &hole = m_Sparse[i];
+        if (lba >= hole.nStartLBA && lba < hole.nEndLBA) {
+            return hole.nBase + (u64)(lba - hole.nStartLBA) * hole.nSectorLength;
+        }
+    }
+
     // The sheet needs the earlier files' sizes, and answers relative to one file.
     u64 sizes[MaxDataFiles];
     for (int i = 0; i < m_nFileCount; i++) {
@@ -304,8 +461,7 @@ u64 CCueBinFileDevice::GetSize(void) const {
         return 0;
     }
 
-    const DataFile &last = m_Files[m_nFileCount - 1];
-    return last.nBase + last.nSize;
+    return m_nVirtualSize;
 }
 
 const char *CCueBinFileDevice::GetCueSheet() const {

--- a/addon/discimage/cuebinfile.h
+++ b/addon/discimage/cuebinfile.h
@@ -35,6 +35,8 @@ class CCueBinFileDevice : public ICueDevice {
     // IImageDevice interface
     // ========================================================================
     u64 Seek(u64 ullOffset) override;
+    // Addressable bytes of the Seek() space, which on a split rip includes
+    // the unbacked inter-session holes. GetDataFileSizes() stays physical.
     u64 GetSize(void) const override;
     u64 Tell() const override;
     u64 GetByteOffsetForLBA(u32 lba) const override;
@@ -61,7 +63,8 @@ class CCueBinFileDevice : public ICueDevice {
     const u64* GetDataFileSizes() const override { return m_FileSizes; }
     
    private:
-    // Split files form one logical image; each FIL owns its CLMT.
+    // Split files form one logical image; each FIL owns its CLMT. nBase is the
+    // file's start in virtual seek space, which a hole before it can push up.
     struct DataFile {
         FIL* pFile = nullptr;
         DWORD* pCLMT = nullptr;
@@ -74,7 +77,28 @@ class CCueBinFileDevice : public ICueDevice {
     u64 m_FileSizes[MaxDataFiles] = {};
     int m_nFileCount = 0;
 
+    // Disc frames between two files that no .bin stores: the lead-out and
+    // lead-in of a session boundary the rip split across a FILE. Read as zeros.
+    struct SparseRange {
+        u32 nStartLBA = 0;
+        u32 nEndLBA = 0;
+        u64 nBase = 0;  // virtual offset of nStartLBA
+        u64 nLength = 0;
+        u32 nSectorLength = 0;
+    };
+    // At most one hole per FILE boundary.
+    SparseRange m_Sparse[MaxDataFiles];
+    int m_nSparseCount = 0;
+    u64 m_nVirtualSize = 0;
+
+    // A disc holds under 100 minutes of frames; a wider hole is a bad cue.
+    static constexpr u32 MaxGapFrames = 100 * 60 * 75;
+
+    // False when the cue describes a boundary this layout cannot represent;
+    // the previous layout is left untouched.
+    bool RebuildLayout();
     int FileIndexForOffset(u64 nOffset) const;
+    u64 SparseBytesAt(u64 nOffset) const;
 
     int ReadWithinFile(void* pBuffer, size_t nCount);
 

--- a/addon/discimage/util.cpp
+++ b/addon/discimage/util.cpp
@@ -429,7 +429,8 @@ IImageDevice* loadCueBinIsoFileDevice(const char* imagePath) {
 
         if (!device->AddDataFile(extraFile)) {
             LOGERR("Cannot adopt split-rip data file: %s", binPath);
-            SetImageLoadError("This image has more data files than %s can hold.", name);
+            SetImageLoadError("This image's data files do not form a usable disc layout at %s.",
+                              name);
             f_close(extraFile);
             delete extraFile;
             delete device;

--- a/addon/usbcdgadget/scsi_read.cpp
+++ b/addon/usbcdgadget/scsi_read.cpp
@@ -411,12 +411,16 @@ void SCSIRead::ReadCD(CUSBCDGadget* gadget)
     // bound lands too high on mixed-mode BIN/CUE images (2048-byte data
     // track before 2352-byte audio), falsely rejecting every read of the
     // last track as out of range.
-    u64 readEnd = gadget->m_pDevice->GetByteOffsetForLBA(gadget->m_nblock_address) +
-                  (u64)gadget->m_nnumber_blocks * trackInfo.sector_length;
-    if (readEnd > gadget->m_pDevice->GetSize())
+    // Compared by subtraction: the byte count a host can ask for overflows the
+    // sum, and a translation failure answers (u64)-1 rather than an offset.
+    const u64 readStart = gadget->m_pDevice->GetByteOffsetForLBA(gadget->m_nblock_address);
+    const u64 deviceSize = gadget->m_pDevice->GetSize();
+    const u64 readLength = (u64)gadget->m_nnumber_blocks * trackInfo.sector_length;
+    if (readStart == (u64)-1 || readStart > deviceSize || readLength > deviceSize - readStart)
     {
         MLOGNOTE("SCSIRead::ReadCD",
-                 "READ CD: Read exceeds image size");
+                 "READ CD: LBA %u does not resolve %llu bytes inside the image",
+                 gadget->m_nblock_address, readLength);
         gadget->setSenseData(0x05, 0x21, 0x00); // LOGICAL BLOCK ADDRESS OUT OF RANGE
         gadget->sendCheckCondition();
         return;

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -137,7 +137,9 @@ TEST_IMAGES := $(IMAGES)/image.iso \
 	$(OUT)/outside.bin $(IMAGES)/splittraversal.cue \
 	$(IMAGES)/splitbackslash.cue $(IMAGES)/splitabsolute.cue \
 	$(IMAGES)/splitdot.cue $(IMAGES)/tracks/nested-t2.bin \
-	$(IMAGES)/splitnested.cue
+	$(IMAGES)/splitnested.cue \
+	$(IMAGES)/splitsession-t2.bin $(IMAGES)/splitsession.cue \
+	$(IMAGES)/splitsessionfar.cue
 
 # Red Book audio is 16-bit stereo at 44.1 kHz, which is exactly what
 # sdcard/test.pcm.gz holds, so the sound-test sample the firmware already
@@ -316,6 +318,24 @@ $(IMAGES)/splitnested.cue: $(IMAGES)/splitaudio-t1.bin $(IMAGES)/tracks/nested-t
 	@mkdir -p $(IMAGES)
 	@printf 'FILE "splitaudio-t1.bin" BINARY\n  TRACK 01 AUDIO\n    INDEX 01 00:00:00\n' > $@
 	@printf 'FILE "tracks/nested-t2.bin" BINARY\n  TRACK 02 AUDIO\n    INDEX 01 00:00:00\n' >> $@
+
+# Split Enhanced CD session 2: Mode 2 Form 1, INDEX 01 at LBA 11550 (02:36:00)
+# per its own sector headers, CD001 descriptor in local sector 16's user data.
+$(IMAGES)/splitsession-t2.bin:
+	@mkdir -p $(IMAGES)
+	@python3 -c 'import sys; bcd=lambda v:((v//10)<<4)|(v%10); base=11550; hdr=lambda i:bytes([bcd((base+i+150)//4500),bcd(((base+i+150)//75)%60),bcd((base+i+150)%75),2]); user=lambda i:(b"\x01CD001\x01\x00" if i==16 else bytes([i&0xFF])*8).ljust(2048,b"\x00"); o=open(sys.argv[1],"wb"); [o.write(b"\x00"+b"\xff"*10+b"\x00"+hdr(i)+b"\x00\x00\x09\x00\x00\x00\x09\x00"+user(i)+b"\x00"*280) for i in range(40)]; o.close()' $@
+
+$(IMAGES)/splitsession.cue: $(IMAGES)/splitaudio-t1.bin $(IMAGES)/splitsession-t2.bin
+	@mkdir -p $(IMAGES)
+	@printf 'REM SESSION 01\nFILE "splitaudio-t1.bin" BINARY\n  TRACK 01 AUDIO\n    INDEX 01 00:00:00\n' > $@
+	@printf 'REM SESSION 02\nFILE "splitsession-t2.bin" BINARY\n  TRACK 02 MODE2/2352\n    INDEX 01 00:00:00\n' >> $@
+
+# The same rip with session 2 placed past the end of any disc, so the hole it
+# would open is wider than the sparse layout will accept.
+$(IMAGES)/splitsessionfar.cue: $(IMAGES)/splitaudio-t1.bin $(IMAGES)/splitsession-t2.bin
+	@mkdir -p $(IMAGES)
+	@printf 'REM SESSION 01\nFILE "splitaudio-t1.bin" BINARY\n  TRACK 01 AUDIO\n    INDEX 01 00:00:00\n' > $@
+	@printf 'REM SESSION 02\nFILE "splitsession-t2.bin" BINARY\n  TRACK 02 MODE2/2352\n    INDEX 01 99:00:00\n' >> $@
 
 # Real disc-image fixtures under testdata/ (see testdata/README-testdata.md).
 # .gz images are decompressed; .cue/.chd are copied as-is next to their data.

--- a/integration-tests/test-suite/test_cuequirks.cpp
+++ b/integration-tests/test-suite/test_cuequirks.cpp
@@ -21,6 +21,7 @@
 #include <cueparser/cueparser.h>
 #include <cueparser/cueutil.h>
 
+#include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -371,4 +372,198 @@ TEST(single_file_cue_resolution_is_unchanged)
         CHECK_EQ(loc.file_index, 0);
         CHECK_EQ(loc.offset, CueLBAToByteOffset(kCanonicalCue, lba));
     }
+}
+
+// A split rip's session 2 is its own BIN whose INDEX times restart at zero, so
+// nothing in the sheet says where it begins and the gap must be synthesized.
+static const char *const kSplitSessionCue =
+    "REM SESSION 01\n"
+    "FILE \"s1.bin\" BINARY\n"
+    "  TRACK 01 AUDIO\n"
+    "    INDEX 01 00:00:00\n"
+    "REM SESSION 02\n"
+    "FILE \"s2.bin\" BINARY\n"
+    "  TRACK 02 MODE2/2352\n"
+    "    INDEX 01 00:00:00\n";
+
+static const uint64_t kSplitSessionSizes[2] = {150ull * 2352, 40ull * 2352};
+
+// Session 1's 150 sectors, then 6750 lead-out + 4500 lead-in, then the pregap.
+static const uint32_t kSplitTrackStart = 150 + 11250;
+static const uint32_t kSplitDataStart = kSplitTrackStart + 150;
+
+TEST(split_session_data_track_clears_the_leadout_leadin_and_pregap)
+{
+    CUEParser parser(kSplitSessionCue);
+    parser.set_file_sizes(kSplitSessionSizes, 2);
+
+    const CUETrackInfo *t1 = parser.next_track();
+    CHECK_EQ(t1->session, 1);
+    CHECK_EQ(t1->data_start, 0u);
+
+    // None of it is stored, so the pregap is the unstored kind.
+    const CUETrackInfo *t2 = parser.next_track();
+    CHECK_EQ(t2->session, 2);
+    CHECK_EQ(t2->track_start, kSplitTrackStart);
+    CHECK_EQ(t2->data_start, kSplitDataStart);
+    CHECK_EQ(t2->unstored_pregap_length, 150u);
+    CHECK_EQ(t2->file_index, 2);
+    CHECK_EQ(t2->file_offset, 0ull);
+}
+
+// The gap is disc addresses only: no bytes were invented, so the data track's
+// first frame is still the first byte of the second BIN.
+TEST(split_session_gap_costs_no_file_bytes)
+{
+    CueFileLocation loc;
+
+    CHECK(CueResolveLBA(kSplitSessionCue, kSplitDataStart, kSplitSessionSizes, 2, &loc));
+    CHECK_EQ(loc.file_index, 1);
+    CHECK(strcmp(loc.filename, "s2.bin") == 0);
+    CHECK_EQ(loc.offset, 0ull);
+
+    // Sector 16 of that file, where the volume descriptor lives.
+    CHECK(CueResolveLBA(kSplitSessionCue, kSplitDataStart + 16, kSplitSessionSizes, 2, &loc));
+    CHECK_EQ(loc.file_index, 1);
+    CHECK_EQ(loc.offset, 16ull * 2352);
+
+    // Session 1 is untouched by the gap that follows it.
+    CHECK(CueResolveLBA(kSplitSessionCue, 149, kSplitSessionSizes, 2, &loc));
+    CHECK_EQ(loc.file_index, 0);
+    CHECK_EQ(loc.offset, 149ull * 2352);
+}
+
+// Session 2's track, from a two-file cue whose pregap lines are given.
+static bool SecondSessionTrack(const char *pregap, CUETrackInfo *out)
+{
+    char cue[512];
+    snprintf(cue, sizeof(cue),
+             "REM SESSION 01\n"
+             "FILE \"s1.bin\" BINARY\n"
+             "  TRACK 01 AUDIO\n"
+             "    INDEX 01 00:00:00\n"
+             "REM SESSION 02\n"
+             "FILE \"s2.bin\" BINARY\n"
+             "  TRACK 02 MODE2/2352\n"
+             "%s",
+             pregap);
+
+    CUEParser parser(cue);
+    parser.set_file_sizes(kSplitSessionSizes, 2);
+    const CUETrackInfo *t = parser.next_track();
+    if (t == nullptr || (t = parser.next_track()) == nullptr) {
+        return false;
+    }
+    *out = *t;
+    return true;
+}
+
+// A pregap the sheet states is the sheet's to place; only the 11250-frame
+// lead-out/lead-in area is missing, and no second 150 frames are added.
+TEST(split_session_keeps_a_pregap_the_cue_states)
+{
+    CUETrackInfo t;
+
+    // Stored: the file's first 150 sectors are the pregap.
+    CHECK(SecondSessionTrack("    INDEX 00 00:00:00\n    INDEX 01 00:02:00\n", &t));
+    CHECK_EQ(t.track_start, kSplitTrackStart);
+    CHECK_EQ(t.data_start, kSplitDataStart);
+    CHECK_EQ(t.unstored_pregap_length, 0u);
+    CHECK_EQ(t.file_offset, 150ull * 2352);
+
+    // Unstored: same addresses, but the file holds no pregap sectors.
+    CHECK(SecondSessionTrack("    PREGAP 00:02:00\n    INDEX 01 00:00:00\n", &t));
+    CHECK_EQ(t.track_start, kSplitTrackStart);
+    CHECK_EQ(t.data_start, kSplitDataStart);
+    CHECK_EQ(t.unstored_pregap_length, 150u);
+    CHECK_EQ(t.file_offset, 0ull);
+
+    // INDEX 00 equal to INDEX 01 declares a pregap of no length, so the file
+    // stores none and the synthesized one is still owed.
+    CHECK(SecondSessionTrack("    INDEX 00 00:00:00\n    INDEX 01 00:00:00\n", &t));
+    CHECK_EQ(t.track_start, kSplitTrackStart);
+    CHECK_EQ(t.data_start, kSplitDataStart);
+    CHECK_EQ(t.unstored_pregap_length, 150u);
+    CHECK_EQ(t.file_offset, 0ull);
+}
+
+// The stored pregap is the head of its own file; the unstored one costs nothing.
+TEST(split_session_pregap_resolves_to_the_head_of_its_file)
+{
+    const char *stored =
+        "REM SESSION 01\n"
+        "FILE \"s1.bin\" BINARY\n"
+        "  TRACK 01 AUDIO\n"
+        "    INDEX 01 00:00:00\n"
+        "REM SESSION 02\n"
+        "FILE \"s2.bin\" BINARY\n"
+        "  TRACK 02 MODE2/2352\n"
+        "    INDEX 00 00:00:00\n"
+        "    INDEX 01 00:02:00\n";
+
+    CueFileLocation loc;
+    CHECK(CueResolveLBA(stored, kSplitTrackStart, kSplitSessionSizes, 2, &loc));
+    CHECK_EQ(loc.file_index, 1);
+    CHECK_EQ(loc.offset, 0ull);
+
+    // An unstored pregap has no bytes, so it clamps to the track's data start.
+    CHECK(CueResolveLBA(kSplitSessionCue, kSplitTrackStart, kSplitSessionSizes, 2, &loc));
+    CHECK_EQ(loc.file_index, 1);
+    CHECK_EQ(loc.offset, 0ull);
+}
+
+// A later track in the same session picks the gap up through cumulative_offset.
+TEST(split_session_gap_carries_into_the_tracks_after_it)
+{
+    const char *cue =
+        "REM SESSION 01\n"
+        "FILE \"s1.bin\" BINARY\n"
+        "  TRACK 01 AUDIO\n"
+        "    INDEX 01 00:00:00\n"
+        "REM SESSION 02\n"
+        "FILE \"s2.bin\" BINARY\n"
+        "  TRACK 02 MODE2/2352\n"
+        "    INDEX 01 00:00:00\n"
+        "  TRACK 03 AUDIO\n"
+        "    INDEX 01 00:00:20\n";
+
+    CUEParser parser(cue);
+    parser.set_file_sizes(kSplitSessionSizes, 2);
+    CHECK(parser.next_track() != nullptr);
+    CHECK(parser.next_track() != nullptr);
+
+    const CUETrackInfo *t3 = parser.next_track();
+    CHECK_EQ(t3->data_start, kSplitDataStart + 20u);
+    CHECK_EQ(t3->file_offset, 20ull * 2352);
+}
+
+// A FILE boundary inside one session is not a session boundary, and a session
+// boundary inside one FILE already has absolute INDEX times. Neither moves.
+TEST(split_cue_without_a_session_boundary_gains_no_gap)
+{
+    const char *sameSession =
+        "FILE \"s1.bin\" BINARY\n"
+        "  TRACK 01 AUDIO\n"
+        "    INDEX 01 00:00:00\n"
+        "FILE \"s2.bin\" BINARY\n"
+        "  TRACK 02 AUDIO\n"
+        "    INDEX 01 00:00:00\n";
+
+    CUEParser parser(sameSession);
+    parser.set_file_sizes(kSplitSessionSizes, 2);
+    CHECK(parser.next_track() != nullptr);
+    CHECK_EQ(parser.next_track()->data_start, 150u);
+
+    const char *oneFile =
+        "REM SESSION 01\n"
+        "FILE \"whole.bin\" BINARY\n"
+        "  TRACK 01 AUDIO\n"
+        "    INDEX 01 00:00:00\n"
+        "REM SESSION 02\n"
+        "  TRACK 02 MODE2/2352\n"
+        "    INDEX 01 02:48:00\n";
+
+    CUEParser single(oneFile);
+    CHECK(single.next_track() != nullptr);
+    CHECK_EQ(single.next_track()->data_start, 12600u);
 }

--- a/integration-tests/test-suite/test_realimages.cpp
+++ b/integration-tests/test-suite/test_realimages.cpp
@@ -997,6 +997,527 @@ TEST(real_single_file_cue_with_stale_file_name_still_loads)
     delete dev;
 }
 
+// Split Enhanced CD: session 1 audio BIN, session 2 data BIN;
+// session 2's INDEX times restart at zero.
+
+// 150 sectors of session 1, then lead-out + lead-in, then the track pregap.
+static const u32 kSplitSessionDataLBA = 150 + 11250 + 150;
+
+// The gap has no bytes in either .bin, so the second file's virtual base sits
+// a whole gap's worth of addresses past the first file's 150 stored sectors.
+static const u64 kSplitSessionFile2Base = (u64)kSplitSessionDataLBA * 2352;
+
+// One session's 0xA2 lead-out pointer, decoded from a full TOC reply.
+static bool LeadoutForSession(const std::vector<u8> &toc, u8 session, u32 *out)
+{
+    for (size_t i = 4; i + 11 <= toc.size(); i += 11) {
+        if (toc[i] == session && toc[i + 3] == 0xA2) {
+            *out = ((u32)toc[i + 8] * 60 + toc[i + 9]) * 75 + toc[i + 10] - 150;
+            return true;
+        }
+    }
+    return false;
+}
+
+TEST(real_split_session_data_track_sits_past_the_multisession_gap)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CHECK_EQ(disc->GetDataFileCount(), 2);
+
+    // GetSize() is addressable bytes, so it spans the hole; the files themselves
+    // are still only what they store.
+    CHECK_EQ(disc->GetSize(), (u64)(kSplitSessionDataLBA + 40) * 2352);
+    CHECK_EQ(disc->GetDataFileSizes()[0], (u64)150 * 2352);
+    CHECK_EQ(disc->GetDataFileSizes()[1], (u64)40 * 2352);
+
+    // And the data track's first frame is the first byte of the second file.
+    CHECK_EQ(disc->GetByteOffsetForLBA(kSplitSessionDataLBA), kSplitSessionFile2Base);
+    CHECK_EQ(disc->GetByteOffsetForLBA(kSplitSessionDataLBA + 16),
+             kSplitSessionFile2Base + (u64)16 * 2352);
+
+    // Every frame the gap covers answers inside the hole, in order, and none of
+    // them reaches the second file's base.
+    CHECK_EQ(disc->GetByteOffsetForLBA(150), (u64)150 * 2352);
+    CHECK_EQ(disc->GetByteOffsetForLBA(kSplitSessionDataLBA - 1),
+             kSplitSessionFile2Base - 2352);
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // READ TOC format 0x01: two sessions, and where the filesystem starts.
+    const u8 siCdb[10] = {0x43, 0x00, 0x01, 0, 0, 0, 0, 0, 12, 0};
+    auto si = bench.SendCommand(siCdb, sizeof(siCdb), 12);
+    CHECK_EQ(si.csw.bmCSWStatus, 0);
+    const u8 expected[12] = {
+        0x00, 0x0A,             // length 10
+        0x01, 0x02,             // first session 1, last session 2
+        0x00, 0x14, 0x02, 0x00, // data track 2, control 0x14
+        0x00, 0x00, 0x2D, 0x1E, // LBA 11550, not 150
+    };
+    CHECK_BYTES(si.data.data(), si.data.size(), expected, sizeof(expected));
+}
+
+TEST(real_split_session_read10_finds_the_volume_descriptor)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Sector 16 of the data track, where a host looks for CD001. READ(10)
+    // strips the 16-byte header and the 8-byte Form 1 subheader.
+    const u32 lba = kSplitSessionDataLBA + 16;
+    const u8 rdCdb[10] = {0x28, 0, (u8)(lba >> 24), (u8)(lba >> 16), (u8)(lba >> 8),
+                          (u8)lba, 0, 0, 1, 0};
+    auto rd = bench.SendCommand(rdCdb, sizeof(rdCdb), 2048);
+    CHECK_EQ(rd.csw.bmCSWStatus, 0);
+    CHECK_EQ(rd.data.size(), (size_t)2048);
+    if (rd.data.size() >= 8) {
+        CHECK_EQ(rd.data[0], 0x01); // primary volume descriptor
+        CHECK(memcmp(rd.data.data() + 1, "CD001", 5) == 0);
+    }
+}
+
+TEST(real_split_session_leadout_ends_session_one_at_its_audio)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 tocCdb[10] = {0x43, 0x00, 0x02, 0, 0, 0, 0, 0, (u8)200, 0};
+    auto toc = bench.SendCommand(tocCdb, sizeof(tocCdb), 200);
+    CHECK_EQ(toc.csw.bmCSWStatus, 0);
+
+    // Session 1's lead-out must land where its audio ends: 11250 frames back
+    // from the data track's start, which is itself 150 frames before INDEX 01.
+    u32 lba = 0;
+    CHECK(LeadoutForSession(toc.data, 1, &lba));
+    CHECK_EQ(lba, 150u);
+
+    // The disc lead-out is the end of session 2's 40 stored sectors.
+    CHECK(LeadoutForSession(toc.data, 2, &lba));
+    CHECK_EQ(lba, kSplitSessionDataLBA + 40);
+}
+
+// Whole-sector READ CD: sectorType 1 demands CD-DA, 0 accepts the track's own
+// kind, and fields asks for every field so 2352 bytes come back either way.
+static std::vector<u8> ReadCdRaw(CGadgetTestBench &bench, u32 lba, u32 sectors,
+                                 u8 sectorType, u8 fields)
+{
+    const u8 cdb[12] = {0xBE, (u8)(sectorType << 2), (u8)(lba >> 24), (u8)(lba >> 16),
+                        (u8)(lba >> 8), (u8)lba, (u8)(sectors >> 16), (u8)(sectors >> 8),
+                        (u8)sectors, fields, 0x00, 0x00};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), sectors * 2352);
+    CHECK_EQ(r.csw.bmCSWStatus, 0);
+    return r.data;
+}
+
+static std::vector<u8> ReadCdAudio(CGadgetTestBench &bench, u32 lba, u32 sectors)
+{
+    return ReadCdRaw(bench, lba, sectors, 1, 0xF0);
+}
+
+// A data track's frames: EDC/ECC included, or the reply is 2072 bytes a sector.
+static std::vector<u8> ReadCdAnyType(CGadgetTestBench &bench, u32 lba, u32 sectors)
+{
+    return ReadCdRaw(bench, lba, sectors, 0, 0xF8);
+}
+
+// The inter-session gap has no bytes in any .bin. Serving the offset anyway
+// ran off session 1's file into session 2's, as ~1 s of modem noise.
+TEST(real_split_session_gap_reads_as_silence_not_the_next_bin)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Wholly inside the gap, starting at the first unbacked LBA.
+    std::vector<u8> gap = ReadCdAudio(bench, 150, 8);
+    CHECK_EQ(gap.size(), (size_t)8 * 2352);
+    if (gap.size() < (size_t)8 * 2352) {
+        return;
+    }
+    for (size_t i = 0; i < gap.size(); i++) {
+        CHECK_EQ(gap[i], 0);
+    }
+
+    // Specifically not session 2's first sector, which is what used to come
+    // back: a Mode 2 sync pattern read as if it were audio.
+    u8 session2[2352];
+    CHECK_EQ(disc->Seek(kSplitSessionFile2Base), kSplitSessionFile2Base);
+    CHECK_EQ(disc->Read(session2, sizeof(session2)), (int)sizeof(session2));
+    CHECK_EQ(session2[0], 0x00);
+    CHECK_EQ(session2[1], 0xFF); // sync -- the noise the host played
+    CHECK(memcmp(gap.data(), session2, 2352) != 0);
+
+    // The gap's far end is silence too. Track 2 owns those frames, so asking
+    // for CD-DA there is a sector-type mismatch: read them as whatever they are.
+    std::vector<u8> tail = ReadCdAnyType(bench, kSplitSessionDataLBA - 4, 4);
+    CHECK_EQ(tail.size(), (size_t)4 * 2352);
+    for (size_t i = 0; i < tail.size(); i++) {
+        CHECK_EQ(tail[i], 0);
+    }
+}
+
+// The hole is addresses, not a shortcut: a read that starts in it and runs on
+// must land on session 2's real bytes, at the right offset.
+TEST(real_split_session_read_spanning_audio_gap_and_data_resumes_correctly)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    // Two real audio frames, the whole 11400-frame hole, then four data frames.
+    const u32 lba = 148;
+    const u32 sectors = 2 + (kSplitSessionDataLBA - 150) + 4;
+
+    u8 audio[2 * 2352];
+    CHECK_EQ(disc->Seek((u64)148 * 2352), (u64)148 * 2352);
+    CHECK_EQ(disc->Read(audio, sizeof(audio)), (int)sizeof(audio));
+
+    u8 data[4 * 2352];
+    CHECK_EQ(disc->Seek(kSplitSessionFile2Base), kSplitSessionFile2Base);
+    CHECK_EQ(disc->Read(data, sizeof(data)), (int)sizeof(data));
+
+    std::vector<u8> buf((size_t)sectors * 2352);
+    CHECK_EQ(disc->Seek(disc->GetByteOffsetForLBA(lba)), (u64)lba * 2352);
+    CHECK_EQ(disc->Read(buf.data(), buf.size()), (int)buf.size());
+
+    CHECK_BYTES(buf.data(), sizeof(audio), audio, sizeof(audio));
+    CHECK_BYTES(buf.data() + buf.size() - sizeof(data), sizeof(data), data, sizeof(data));
+
+    // Nothing of session 2 leaked into the hole between them.
+    bool holeIsSilent = true;
+    for (size_t i = sizeof(audio); i < buf.size() - sizeof(data); i++) {
+        if (buf[i] != 0) {
+            holeIsSilent = false;
+        }
+    }
+    CHECK(holeIsSilent);
+}
+
+// Session 2's first stored frame is its file's first byte, whichever way it
+// is addressed, and the frame below it is still hole.
+TEST(real_split_session_data_track_index01_returns_its_first_stored_sector)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    std::vector<u8> r = ReadCdAnyType(bench, kSplitSessionDataLBA, 2);
+    CHECK_EQ(r.size(), (size_t)2 * 2352);
+    if (r.size() < (size_t)2 * 2352) {
+        return;
+    }
+
+    u8 expected[2 * 2352];
+    CHECK_EQ(disc->Seek(kSplitSessionFile2Base), kSplitSessionFile2Base);
+    CHECK_EQ(disc->Read(expected, sizeof(expected)), (int)sizeof(expected));
+    CHECK_BYTES(r.data(), r.size(), expected, sizeof(expected));
+    CHECK_EQ(r[1], 0xFF); // a real Mode 2 sync, so these are stored bytes
+
+    // The last hole frame does not alias it.
+    std::vector<u8> before = ReadCdAnyType(bench, kSplitSessionDataLBA - 1, 1);
+    CHECK_EQ(before.size(), (size_t)2352);
+    if (before.size() >= 2352) {
+        CHECK(memcmp(before.data(), expected, 2352) != 0);
+    }
+}
+
+// A read that ends exactly on the image's last stored byte must not run on,
+// and one that starts there must report the end rather than loop.
+TEST(real_split_session_reads_at_the_image_boundary_stop_cleanly)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    const u64 end = disc->GetSize();
+    CHECK_EQ(end, kSplitSessionFile2Base + (u64)40 * 2352);
+
+    u8 last[2352];
+    CHECK_EQ(disc->Seek(end - 2352), end - 2352);
+    CHECK_EQ(disc->Read(last, sizeof(last)), (int)sizeof(last));
+
+    // At the end there is nothing left, and past it there is no seek at all.
+    CHECK_EQ(disc->Seek(end), end);
+    CHECK_EQ(disc->Read(last, sizeof(last)), 0);
+    CHECK_EQ(disc->Seek(end + 1), (u64)-1);
+
+    // An over-read of the tail returns only what is stored.
+    CHECK_EQ(disc->Seek(end - 2352), end - 2352);
+    u8 over[3 * 2352];
+    CHECK_EQ(disc->Read(over, sizeof(over)), 2352);
+
+    // The first hole byte and the last byte before it are on opposite sides of
+    // the same boundary, and neither steals the other's bytes.
+    CHECK_EQ(disc->Seek((u64)150 * 2352 - 2352), (u64)149 * 2352);
+    u8 straddle[2 * 2352];
+    CHECK_EQ(disc->Read(straddle, sizeof(straddle)), (int)sizeof(straddle));
+    bool tailIsAudio = false;
+    for (size_t i = 0; i < 2352; i++) {
+        if (straddle[i] != 0) {
+            tailIsAudio = true;
+        }
+    }
+    CHECK(tailIsAudio);
+    for (size_t i = 2352; i < sizeof(straddle); i++) {
+        CHECK_EQ(straddle[i], 0);
+    }
+}
+
+// Abutting the files instead would be the original aliasing bug: LBA 151 is
+// unbacked, and contiguous bases would answer with file 2's sector 1.
+TEST(real_split_session_absurd_gap_refuses_to_mount_the_image)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsessionfar.cue");
+    CHECK(disc == nullptr);
+    delete disc;
+}
+
+// AddDataFile rejecting a file leaves the device on its previous layout, and
+// the rejected FIL still belongs to the caller.
+TEST(split_rejected_data_file_is_not_adopted_and_the_layout_is_unchanged)
+{
+    const std::string dir = TestDataDir();
+    const std::string cue =
+        "REM SESSION 01\nFILE \"splitaudio-t1.bin\" BINARY\n"
+        "  TRACK 01 AUDIO\n    INDEX 01 00:00:00\n"
+        "REM SESSION 02\nFILE \"splitsession-t2.bin\" BINARY\n"
+        "  TRACK 02 MODE2/2352\n    INDEX 01 99:00:00\n";
+
+    CCueBinFileDevice *dev = OpenReader(dir + "/splitaudio-t1.bin", cue);
+    CHECK(dev != nullptr);
+    if (!dev) {
+        return;
+    }
+
+    FIL *second = new FIL();
+    CHECK(f_open(second, (dir + "/splitsession-t2.bin").c_str(), FA_READ) == FR_OK);
+    CHECK(!dev->AddDataFile(second));
+
+    CHECK_EQ(dev->GetDataFileCount(), 1);
+    CHECK_EQ(dev->GetSize(), (u64)150 * 2352);
+    CHECK_EQ(dev->GetByteOffsetForLBA(0), (u64)0);
+
+    u8 buf[2352];
+    CHECK_EQ(dev->Seek(0), (u64)0);
+    CHECK_EQ(dev->Read(buf, sizeof(buf)), (int)sizeof(buf));
+
+    // The caller closes what was not adopted; deleting the device must not
+    // close it again, so this ordering is the double-close check.
+    CHECK(f_close(second) == FR_OK);
+    delete second;
+    delete dev;
+}
+
+// A translation that genuinely fails answers (u64)-1, which is a bad LBA and
+// not a media condition; it must also leave no read pending behind it.
+TEST(real_split_failed_lba_translation_is_lba_out_of_range_not_a_pending_read)
+{
+    const std::string dir = TestDataDir();
+    const std::string cue =
+        "FILE \"splitaudio-t1.bin\" BINARY\n  TRACK 01 AUDIO\n    INDEX 01 00:00:00\n"
+        "FILE \"splitaudio-t2.bin\" BINARY\n  TRACK 02 AUDIO\n    INDEX 01 00:00:00\n"
+        "FILE \"splitaudio-t3.bin\" BINARY\n  TRACK 03 AUDIO\n    INDEX 01 00:00:00\n";
+
+    CCueBinFileDevice *dev = OpenReader(dir + "/splitaudio-t1.bin", cue);
+    CHECK(dev != nullptr);
+    if (!dev) {
+        return;
+    }
+    FIL *second = new FIL();
+    CHECK(f_open(second, (dir + "/splitaudio-t2.bin").c_str(), FA_READ) == FR_OK);
+    CHECK(dev->AddDataFile(second));
+    CHECK_EQ(dev->GetByteOffsetForLBA(0), (u64)-1);
+
+    CGadgetTestBench bench(dev);
+    bench.Activate();
+    bench.RequestSense();
+
+    const u8 cdb[12] = {0xBE, 0x04, 0, 0, 0, 0, 0, 0, 1, 0xF0, 0x00, 0x00};
+    auto r = bench.SendCommand(cdb, sizeof(cdb), 2352);
+    CHECK_EQ(r.csw.bmCSWStatus, 1);
+    CHECK_EQ(r.csw.dCSWDataResidue, 2352u);
+
+    auto sense = bench.RequestSense();
+    CHECK_EQ(sense.data[2], 0x05); // ILLEGAL REQUEST, not NOT READY
+    CHECK_EQ(sense.data[12], 0x21);
+    CHECK_EQ(sense.data[13], 0x00);
+
+    const u8 tur[6] = {0x00, 0, 0, 0, 0, 0};
+    CHECK_EQ(bench.SendCommand(tur, sizeof(tur), 0).csw.bmCSWStatus, 0);
+
+    // The next data command returns exactly its own reply, so nothing resumed.
+    const u8 inq[6] = {0x12, 0, 0, 0, 36, 0};
+    auto after = bench.SendCommand(inq, sizeof(inq), 36);
+    CHECK_EQ(after.csw.bmCSWStatus, 0);
+    CHECK_EQ(after.data.size(), (size_t)36);
+    CHECK_EQ(after.csw.dCSWDataResidue, 0u);
+}
+
+// GetSize() bounds the addressable space, holes included, and the comparison
+// must not wrap on a byte count a host is free to ask for.
+TEST(real_split_session_readcd_range_is_bounded_at_the_addressable_end)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Ending exactly on the last stored byte is in range.
+    const u32 lastLBA = kSplitSessionDataLBA + 39;
+    std::vector<u8> r = ReadCdAnyType(bench, lastLBA, 1);
+    CHECK_EQ(r.size(), (size_t)2352);
+
+    auto pastEnd = [&](u32 lba, u32 sectors) {
+        const u8 cdb[12] = {0xBE, 0x00, (u8)(lba >> 24), (u8)(lba >> 16), (u8)(lba >> 8),
+                            (u8)lba, (u8)(sectors >> 16), (u8)(sectors >> 8), (u8)sectors,
+                            0xF8, 0x00, 0x00};
+        auto res = bench.SendCommand(cdb, sizeof(cdb), 2352);
+        CHECK_EQ(res.csw.bmCSWStatus, 1);
+        auto s = bench.RequestSense();
+        CHECK_EQ(s.data[2], 0x05);
+        CHECK_EQ(s.data[12], 0x21);
+    };
+
+    pastEnd(lastLBA, 2);          // one sector too many
+    pastEnd(lastLBA, 0xFFFFFF);   // a byte count that overflows a 32-bit sum
+}
+
+TEST(real_split_session_read_crossing_into_the_gap_keeps_its_audio_prefix)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitsession.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Session 1 holds 150 sectors: 4 real, then 4 past the end of its .bin.
+    std::vector<u8> r = ReadCdAudio(bench, 146, 8);
+    CHECK_EQ(r.size(), (size_t)8 * 2352);
+    if (r.size() < (size_t)8 * 2352) {
+        return;
+    }
+
+    u8 expected[4 * 2352];
+    CHECK_EQ(disc->Seek((u64)146 * 2352), (u64)146 * 2352);
+    CHECK_EQ(disc->Read(expected, sizeof(expected)), (int)sizeof(expected));
+    CHECK_BYTES(r.data(), 4 * 2352, expected, sizeof(expected));
+
+    for (size_t i = 4 * 2352; i < r.size(); i++) {
+        CHECK_EQ(r[i], 0);
+    }
+}
+
+// Silence must not swallow a real track boundary: an ordinary split rip's
+// files abut in LBA space, so a read across one still returns the next file.
+TEST(real_split_audio_boundary_still_crosses_into_the_next_bin)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitaudio.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Track 1 ends at LBA 149, track 2's file begins at 150.
+    std::vector<u8> r = ReadCdAudio(bench, 146, 8);
+    CHECK_EQ(r.size(), (size_t)8 * 2352);
+
+    u8 expected[8 * 2352];
+    CHECK_EQ(disc->Seek((u64)146 * 2352), (u64)146 * 2352);
+    CHECK_EQ(disc->Read(expected, sizeof(expected)), (int)sizeof(expected));
+    CHECK_BYTES(r.data(), r.size(), expected, sizeof(expected));
+
+    bool anyNonZero = false;
+    for (size_t i = 4 * 2352; i < r.size(); i++) {
+        if (r[i] != 0) {
+            anyNonZero = true;
+        }
+    }
+    CHECK(anyNonZero); // real audio, not silence
+}
+
+// A stored INDEX 00 pregap has real bytes at the head of its own file.
+TEST(real_split_stored_pregap_still_reads_its_stored_bytes)
+{
+    IImageDevice *disc = LoadThroughProductionLoader(TestDataDir() + "/splitmixed.cue");
+    CHECK(disc != nullptr);
+    if (!disc) {
+        return;
+    }
+
+    CGadgetTestBench bench(disc);
+    bench.Activate();
+    bench.RequestSense();
+
+    // Track 2's pregap starts at LBA 150 and is the first 150 sectors of its
+    // file, so its bytes are the file's, not zeros.
+    std::vector<u8> r = ReadCdAudio(bench, 150, 4);
+    CHECK_EQ(r.size(), (size_t)4 * 2352);
+
+    u8 expected[4 * 2352];
+    const u64 off = disc->GetByteOffsetForLBA(150);
+    CHECK(off != (u64)-1);
+    CHECK_EQ(disc->Seek(off), off);
+    CHECK_EQ(disc->Read(expected, sizeof(expected)), (int)sizeof(expected));
+    CHECK_BYTES(r.data(), r.size(), expected, sizeof(expected));
+
+    bool anyNonZero = false;
+    for (size_t i = 0; i < r.size(); i++) {
+        if (r[i] != 0) {
+            anyNonZero = true;
+        }
+    }
+    CHECK(anyNonZero); // stored bytes, not silence
+}
+
 // ---------------------------------------------------------------------------
 // Real CHD image (tracked sdcard/usbode-audio-test.chd) through libchdr
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #242. Ordinary multi-BIN cues worked, but an Enhanced CD split into one BIN per track exposed two related gaps in the model: session 2 was placed too early, and the unbacked space between sessions could alias bytes from the next BIN.

## Root cause

Each BIN restarts its CUE `INDEX` times at `00:00:00`. When `REM SESSION 02` is also a `FILE` boundary, the sheet omits the physical distance between sessions: 6750 lead-out frames, 4500 lead-in frames, and—when the cue does not state one—the next track's 150-frame pregap.

For Akumajou Dracula - MIDI Collection (Japan), track 21 was reported at LBA 267988 instead of INDEX 01 at LBA 279388. Once that layout was corrected, a hardware trace exposed the backing problem: the host requested CD-DA at LBA 268045, 57 frames into the valid session gap, but physically concatenated BINs turned that into MODE2 sector 57 of track 21 and produced modem-like noise.

The 57 is not a missing constant. It is simply where the host read inside the 11250-frame gap. Combined images work because those gap frames physically exist in the single BIN.

## Fix

- At a session change that is also a `FILE` change, add the 11250-frame lead-out/lead-in distance to disc addresses.
- Add a 150-frame unstored pregap only when the cue does not state its own pregap.
- Keep `file_start` and `file_offset` unchanged, so session 2 INDEX 01 still maps to byte 0 of its BIN.
- Build a sparse virtual seek layout once when the CUE files are opened.
- Represent unbacked inter-file frames as holes that `CCueBinFileDevice::Read()` serves as digital zeros.
- Preserve backed prefixes and resume at the correct later file when a read crosses a hole.
- Fail malformed or unrepresentable layouts closed rather than abutting their files.

Per-file physical sizes remain available for parsing, lead-out, and validation. `GetSize()` now describes the addressable virtual seek space for split CUE images. Ordinary contiguous multi-BIN files retain adjacent bases and the existing cache/fast-seek path.

No disc-format logic or per-batch track scan is added to `tcdstate_update.cpp`; that generic transfer hot path is byte-identical to `main`.

## Verification

Twenty new tests cover session layout, stored and unstored pregaps, zero-length `INDEX 00`, TOC and both lead-outs, `READ(10)` of `CD001`, sparse gap silence, audio/gap/data spanning reads, exact INDEX 01 mapping, ordinary split-audio boundaries, image limits, malformed-layout rejection, failed-file ownership rollback, invalid LBA sense data, and overflow-safe READ CD bounds.

- Host regression suite: **204 passed, 0 failed**
- Host regression suite with CHD: **207 passed, 0 failed**
- CodeRabbit completed review: zero findings after minor test-guard corrections
- Sparse implementation hardware-tested by iTechMedic on the original Akumajou reproduction: Song 20 ends cleanly and session-2 data remains accessible
- Polynectar independently exercised the earlier gap-silence behavior across numerous images; the sparse refactor preserves that behavior without modifying the generic transfer loop

One unrelated pre-existing issue remains out of scope: READ SUB-CHANNEL relative addressing around unstored pregaps is tracked separately in #245.
